### PR TITLE
fixes #449 Bar chart view renders cropped y-axis labels

### DIFF
--- a/app/post/directives/views/post-view-chart-directive.js
+++ b/app/post/directives/views/post-view-chart-directive.js
@@ -19,10 +19,10 @@ function (
                 type: 'multiBarHorizontalChart',
                 height: 450,
                 margin: {
-                    top: 20,
+                    top: 0,
                     right: 40,
                     bottom: 40,
-                    left: 65
+                    left: 5
                 },
                 x: function (d) {
                     return d.label;
@@ -30,12 +30,14 @@ function (
                 y: function (d) {
                     return d.total;
                 },
-                showValues: true,
+                showValues: false,
                 showControls: false,
                 valueFormat: d3.format('d'),
                 transitionDuration: 500,
                 xAxis: {
-                    axisLabel: $filter('translate')('post.categories')
+                    axisLabel: $filter('translate')('post.categories'),
+                    tickPadding: -10,
+                    axisLabelDistance: 0
                 },
                 yAxis: {
                     axisLabel: $filter('translate')('graph.post_count'),

--- a/app/post/directives/views/post-view-timeline-directive.js
+++ b/app/post/directives/views/post-view-timeline-directive.js
@@ -39,8 +39,8 @@ function (
                 type: 'lineChart',
                 height: 450,
                 margin: {
-                    top: 20,
-                    right: 40,
+                    top: 0,
+                    right: 65,
                     bottom: 40,
                     left: 65
                 },

--- a/sass/overrides/_nvd3.scss
+++ b/sass/overrides/_nvd3.scss
@@ -12,3 +12,19 @@
 .nvd3.nv-line .nvd3.nv-scatter .nv-groups .nv-point.hover {
     stroke-width:8px;
 }
+.nv-x .tick text {
+    text-anchor: start !important;
+}
+.nvd3 .nv-multibar .nv-groups rect:hover, .nvd3 .nv-multibarHorizontal .nv-groups rect:hover, .nvd3 .nv-discretebar .nv-groups rect:hover {
+    opacity: 0.8;
+}
+.nvd3 text, .nvd3 .title, .nvtooltip {
+    font-family: inherit;
+    font-size: 14px;
+}
+.nvtooltip {
+    font-size: 12px;
+}
+.nv-multibarHorizontal .nv-group {
+    opacity: 0.6;
+}


### PR DESCRIPTION
Made fixes to post view bar chart having its labels cropped reported in this issue- 
https://github.com/ushahidi/platform/issues/449

<img width="1018" alt="screen shot 2015-09-24 at 7 42 04 pm" src="https://cloud.githubusercontent.com/assets/863674/10075751/2b1546b2-62f5-11e5-8ff4-9953f9d89593.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/17)
<!-- Reviewable:end -->
