### PR TITLE
Clearing sets correctly on reload sets

### DIFF
--- a/app/set/directives/sets-menu-directive.js
+++ b/app/set/directives/sets-menu-directive.js
@@ -20,6 +20,7 @@ function (
 
             // Load sets + users
             var reloadSets = function () {
+                $scope.sets = [];
                 endpoint.query().$promise.then(function (sets) {
                     $scope.sets = sets;
 


### PR DESCRIPTION
This pull request makes the following changes:
- Fix clearing of sets on private deployment logout

Test these changes by:
- Ensure your deployment has at least 1 savedsearch and 1 collection
- Setting a deployment to private in the general settings menu, and logging out.
- Neither savedsearches nor collections should be visible

Fixes ushahidi/platform# 97

Ping @ushahidi/platform

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/118)
<!-- Reviewable:end -->
