### PR TITLE
762 language settings

### DIFF
--- a/app/setting/directives/setting-editor-directive.js
+++ b/app/setting/directives/setting-editor-directive.js
@@ -57,6 +57,18 @@ function (
                 $scope.languages = languages;
             });
 
+            $scope.changeLanguage = function (code) {
+                $translate.use(code).then(function (code) {
+                    Languages.then(function (languages) {
+                        angular.forEach(languages, function (language) {
+                            if (language.code === code) {
+                                $rootScope.rtlEnabled = language.rtl;
+                            }
+                        });
+                    });
+                });
+            };
+
             $scope.clearHeader = function () {
                 $scope.site.image_header = null;
             };

--- a/server/www/templates/settings/settings-editor.html
+++ b/server/www/templates/settings/settings-editor.html
@@ -27,7 +27,7 @@
 
     <label class="input-label" for="site-settings-language" translate>settings.site_language</label>
     <div class="custom-select">
-        <select id="site-settings-language" ng-model="site.language" ng-options="lang.code as 'languages.' + lang.code  | translate for lang in languages"></select>
+        <select id="site-settings-language" ng-model="site.language" ng-options="lang.code as 'languages.' + lang.code  | translate for lang in languages" ng-change="changeLanguage(site.language)"></select>
     </div>
 
     <div ng-show="isPrivateEnabled()" class="form-field checkbox">


### PR DESCRIPTION
This pull request makes the following changes:
- Switches site language when the user changes the language using the language settings drop-down

Test these changes by:
- Run `gulp transifex-download` to download translated languages. Afterwards, go to General settings and switch languages using the drop down.

Fixes ushahidi/platform#762.

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/122)
<!-- Reviewable:end -->
