### PR TITLE
Point documentation at support pages

### DIFF
--- a/server/www/index.html
+++ b/server/www/index.html
@@ -102,7 +102,7 @@
                             <li><a ng-href="/" translate>nav.home</a></li>
                             <!-- <li><a ng-href="/about" translate>nav.about</a></li> -->
                             <li><a ng-href="/activity" translate>nav.activity</a></li>
-                            <li><a href="http://docs.ushahidi.com" translate>app.documentation</a></li>
+                            <li><a href="https://ushahidi.com/support" translate>app.documentation</a></li>
                             <li><a href="https://github.com/ushahidi/platform/issues/new" translate>app.report_a_bug</a></li>
                             <li><a ng-href="/tools/settings" ng-show="hasManageSettingsPermission()" translate>nav.settings</a></li>
                         </ul>


### PR DESCRIPTION
This pull request makes the following changes:
- Point documentation link in app at support pages

Test these changes by:
- Load UI and check 'Documentation' points to ushahidi.comsupport

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/145)
<!-- Reviewable:end -->