### PR TITLE
Strip trailing slash from backendUrl

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -36,7 +36,7 @@ require('./user-profile/user-profile-module.js');
 window.ushahidi = window.ushahidi || {};
 
 // this 'environment variable' will be set within the gulpfile
-var backendUrl = window.ushahidi.backendUrl = window.ushahidi.backendUrl || process.env.BACKEND_URL || 'http://ushahidi-backend',
+var backendUrl = window.ushahidi.backendUrl = (window.ushahidi.backendUrl || process.env.BACKEND_URL || 'http://ushahidi-backend').replace(/\/$/, ''),
     intercomAppId = window.ushahidi.intercomAppId = window.ushahidi.intercomAppId || process.env.INTERCOM_APP_ID || '',
     apiUrl = window.ushahidi.apiUrl = backendUrl + '/api/v3',
     claimedAnonymousScopes = [


### PR DESCRIPTION
This pull request makes the following changes:
- Strip a trailing slash from backendUrl

Test these changes by:
- Add a trailing slash to your backend url. Rebuild and check things work

Fixes ushahidi/platform#705

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/156)
<!-- Reviewable:end -->