### PR TITLE
Generate post title from content when post is title-less

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -36,7 +36,7 @@ require('./user-profile/user-profile-module.js');
 window.ushahidi = window.ushahidi || {};
 
 // this 'environment variable' will be set within the gulpfile
-var backendUrl = window.ushahidi.backendUrl = window.ushahidi.backendUrl || process.env.BACKEND_URL || 'http://ushahidi-backend',
+var backendUrl = window.ushahidi.backendUrl = (window.ushahidi.backendUrl || process.env.BACKEND_URL || 'http://ushahidi-backend').replace(/\/$/, ''),
     intercomAppId = window.ushahidi.intercomAppId = window.ushahidi.intercomAppId || process.env.INTERCOM_APP_ID || '',
     apiUrl = window.ushahidi.apiUrl = backendUrl + '/api/v3',
     claimedAnonymousScopes = [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,6 +306,11 @@ gulp.task('jscs', function () {
         .pipe(jscs());
 });
 
+gulp.task('jscs-fix', function () {
+    return gulp.src(['app/**/*.js', 'test/**/*.js'])
+        .pipe(jscs({ fix : true }));
+});
+
 /**
  * Task `bump` - bump version in package.json
  * Options

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "pre-commit": [
       "jshint",
-      "jscs" 
+      "jscs"
   ],
   "devDependencies": {
     "body-parser": "^1.9.2",
@@ -100,7 +100,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "novus/nvd3#v1.7.1",
     "selection-model": "jtrussell/angular-selection-model.git",
-    "platform-pattern-library": "ushahidi/platform-pattern-library#gh-pages",
+    "platform-pattern-library": "ushahidi/platform-pattern-library#v3.2.1",
     "transifex": "^1.4.3",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "pre-commit": [
       "jshint",
-      "jscs"
+      "jscs" 
   ],
   "devDependencies": {
     "body-parser": "^1.9.2",
@@ -100,7 +100,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "novus/nvd3#v1.7.1",
     "selection-model": "jtrussell/angular-selection-model.git",
-    "platform-pattern-library": "ushahidi/platform-pattern-library#v3.2.1",
+    "platform-pattern-library": "ushahidi/platform-pattern-library#gh-pages",
     "transifex": "^1.4.3",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ushahidi-platform-client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Ushahidi Platform Official Web Client",
   "main": "gulpfile.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor test/protractor-conf.js",
     "jshint": "jshint .",
-    "jscs": "jscs ./app/* ./test/*",
-    "jscs-fix": "jscs -x ./app/* ./test/*"
+    "jscs": "gulp jscs",
+    "jscs-fix": "gulp jscs-fix"
   },
   "pre-commit": [
       "jshint",
-      "jscs" 
+      "jscs"
   ],
   "devDependencies": {
     "body-parser": "^1.9.2",

--- a/server/www/index.html
+++ b/server/www/index.html
@@ -102,7 +102,7 @@
                             <li><a ng-href="/" translate>nav.home</a></li>
                             <!-- <li><a ng-href="/about" translate>nav.about</a></li> -->
                             <li><a ng-href="/activity" translate>nav.activity</a></li>
-                            <li><a href="http://docs.ushahidi.com" translate>app.documentation</a></li>
+                            <li><a href="https://ushahidi.com/support" translate>app.documentation</a></li>
                             <li><a href="https://github.com/ushahidi/platform/issues/new" translate>app.report_a_bug</a></li>
                             <li><a ng-href="/tools/settings" ng-show="hasManageSettingsPermission()" translate>nav.settings</a></li>
                         </ul>

--- a/server/www/templates/posts/preview.html
+++ b/server/www/templates/posts/preview.html
@@ -18,7 +18,7 @@
         </div>
         <div class="post-text">
             <a href="/posts/{{post.id}}">
-                <h3>{{ post.title || post.content | limitTo:50 }} ...</h3>
+                <h3>{{ post.title || post.content | limitTo:50 }}{{ post.content.length > 50 ? ' ...' : ''}}</h3>
             </a>
             <p>
                 {{post.content}}

--- a/server/www/templates/posts/preview.html
+++ b/server/www/templates/posts/preview.html
@@ -18,7 +18,7 @@
         </div>
         <div class="post-text">
             <a href="/posts/{{post.id}}">
-                <h3>{{post.title}}</h3>
+                <h3>{{ post.title || post.content | limitTo:50 }} ...</h3>
             </a>
             <p>
                 {{post.content}}
@@ -61,7 +61,7 @@
 -->
                 <collection-selector
                     post="post"
-                    ng-if="post.allowed_privileges.indexOf('update') !== -1" 
+                    ng-if="post.allowed_privileges.indexOf('update') !== -1"
                     ng-show="editableCollections.length > 0 || post.allowed_privilleges.indexOf('update') != 1"
                     >
                 </collection-selector>
@@ -77,5 +77,3 @@
         </span>
 -->
 </div>
-
-


### PR DESCRIPTION
This pull request makes the following changes:
- `<h3>{{post.title}}</h3>`

to 

- `<h3>{{ post.title || post.content | limitTo:50 }}{{ post.content.length > 50 ? ' ...' : ''}}</h3>`

Test these changes by:
- Add a new post without a title
- Post description is required
- Post title should default to post content and should link to post detail

Fixes ushahidi/platform-pattern-library#23

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/158)
<!-- Reviewable:end -->
