### PR TITLE
Fixed user account settings cache between users

### DIFF
--- a/app/common/services/authentication.js
+++ b/app/common/services/authentication.js
@@ -6,6 +6,7 @@ module.exports = [
     'CONST',
     'Session',
     'RoleEndpoint',
+    'UserEndpoint',
     '_',
 function (
     $rootScope,
@@ -15,6 +16,7 @@ function (
     CONST,
     Session,
     RoleEndpoint,
+    UserEndpoint,
     _
 ) {
 
@@ -37,6 +39,7 @@ function (
 
     setToLogoutState = function () {
         Session.clearSessionData();
+        UserEndpoint.invalidateCache();
         loginStatus = false;
     };
 


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes persistence of Account Settings between after user logout

Test these changes by:
- Login as user, view Account Settings logout
- Login as different user, view Account Settings -> Account settings should display for current not previous user.

Fixes ushahidi/platform-client#161

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/162)
<!-- Reviewable:end -->