### PR TITLE
Make site image open in a different tab

### DIFF
--- a/server/www/templates/settings/settings-editor.html
+++ b/server/www/templates/settings/settings-editor.html
@@ -14,7 +14,7 @@
         <p class="small" translate>settings.appearance_header_image_instructions</p>
         <file-upload file-container="fileContainer">
         </file-upload>
-    <p class="small" ng-show="site.image_header"><a href="{{ site.image_header }}" translate>settings.current_header</a> <button type="button" ng-click="clearHeader()" class="button button-secondary icon-only trash"></button></p>
+    <p class="small" ng-show="site.image_header"><a target="_blank" href="{{ site.image_header }}" translate>settings.current_header</a> <button type="button" ng-click="clearHeader()" class="button button-secondary icon-only trash"></button></p>
 
     <label class="input-label" for="site-settings-email" translate>settings.site_email</label>
     <p class="small" translate>settings.site_email_note</p>


### PR DESCRIPTION
This pull request makes the following changes:
- Makes the *Current background image* link in /settings/general to open in a new tab. It's the path of least friction now, but maybe can also be improved upon [in the future](https://github.com/ushahidi/platform-client/issues/152#issuecomment-203309670).

Test these changes by:
- Going to /settings/general in your deployment and clicking the *Current background image* link

Fixes ushahidi/platform-client#152 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/163)
<!-- Reviewable:end -->