### PR TITLE
Fixed post status filter not appearing despite user having permissions

### DIFF
--- a/app/post/directives/post-choose-form-directive.js
+++ b/app/post/directives/post-choose-form-directive.js
@@ -15,7 +15,7 @@ function (
         },
         templateUrl: 'templates/posts/choose-form.html',
         link: function ($scope) {
-            $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
+            $scope.hasPermission = $rootScope.hasPermission;
 
             $scope.chooseForm = function (form) {
                 angular.copy(form, $scope.activeForm);

--- a/app/post/directives/post-view-filters-directive.js
+++ b/app/post/directives/post-view-filters-directive.js
@@ -17,7 +17,7 @@ function (
         },
         templateUrl: 'templates/posts/post-view-filters.html',
         link: function ($scope, $element, $attrs) {
-            $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
+            $scope.hasPermission = $rootScope.hasPermission;
             $scope.filter = {};
             $scope.globalFilter = GlobalFilter;
             $scope.globalFilter.loadInitialData();

--- a/app/post/directives/post-view-filters-directive.js
+++ b/app/post/directives/post-view-filters-directive.js
@@ -17,6 +17,7 @@ function (
         },
         templateUrl: 'templates/posts/post-view-filters.html',
         link: function ($scope, $element, $attrs) {
+            $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
             $scope.filter = {};
             $scope.globalFilter = GlobalFilter;
             $scope.globalFilter.loadInitialData();

--- a/server/www/templates/posts/choose-form.html
+++ b/server/www/templates/posts/choose-form.html
@@ -3,7 +3,7 @@
         <div class="page-header-body">
             <h1 class="page-title" translate translate-values="{ type: activeForm.name }" ng-if="! post.id">post.modify.add_a_post</h1>
             <h1 class="page-title" translate translate-values="{ title: post.title }" ng-if="!! post.id">post.modify.edit_post</h1>
-            <a ng-href="/settings/forms" class="cta edit" ng-if="hasPermission">Edit Post Types</a>
+            <a ng-href="/settings/forms" class="cta edit" ng-if="hasPermission('Manage Posts')">Edit Post Types</a>
         </div>
     </div>
 

--- a/server/www/templates/posts/post-view-filters.html
+++ b/server/www/templates/posts/post-view-filters.html
@@ -99,7 +99,7 @@
                         </ul>
                     </li>
 
-                    <li class="accordion-menu-list__item" accordion-group ng-if="hasPermission('Manage Posts')">
+                    <li class="accordion-menu-list__item" accordion-group ng-if="hasPermission">
                         <div class="accordion-menu-header">
                             <a class="accordion-menu-trigger delta" accordion-trigger translate>global_filter.post_statuses.post_statuses</a>
                         </div>

--- a/server/www/templates/posts/post-view-filters.html
+++ b/server/www/templates/posts/post-view-filters.html
@@ -99,7 +99,7 @@
                         </ul>
                     </li>
 
-                    <li class="accordion-menu-list__item" accordion-group ng-if="hasPermission">
+                    <li class="accordion-menu-list__item" accordion-group ng-if="hasPermission('Manage Posts')">
                         <div class="accordion-menu-header">
                             <a class="accordion-menu-trigger delta" accordion-trigger translate>global_filter.post_statuses.post_statuses</a>
                         </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes post status filter which was not enabled even when user had correct permissions

Test these changes by:
- On the post views screen, it should be possible to select status as a filter option, when a user either is an admin or has the manage Posts permission.


Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/170)
<!-- Reviewable:end -->
