### PR TITLE
1005 csv export

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -272,7 +272,8 @@
         "source" : "via {{source}}",
         "post_actions" : {
             "edit" : "Edit",
-            "delete" : "Delete"
+            "delete" : "Delete",
+            "export" : "Export"
         },
         "modify" : {
             "intro" : "Select post type:",
@@ -633,7 +634,8 @@
             "destroy_success" : "Post deleted",
             "destroy_error" : "Unable to delete post, please try again",
             "bulk_destroy_confirm" : "Are you sure you want to delete {{count}} posts?",
-            "stage_save_success" : "Updated {{stage}}"
+            "stage_save_success" : "Updated {{stage}}",
+            "export" : "This will export filtered posts. Are you sure you want to continue?"
         },
         "tag" : {
             "save_success" : "Saved category {{name}}",

--- a/app/post/directives/views/post-view-list-directive.js
+++ b/app/post/directives/views/post-view-list-directive.js
@@ -10,6 +10,7 @@ function (
         'Session',
         'Notify',
         '_',
+        'ConfigEndpoint',
         function (
             $scope,
             $q,
@@ -18,7 +19,8 @@ function (
             CollectionEndpoint,
             Session,
             Notify,
-            _
+            _,
+            ConfigEndpoint
         ) {
             var getPostsForPagination = function (query) {
                 query = query || $scope.filters;
@@ -108,6 +110,47 @@ function (
 
             $scope.allSelectedOnCurrentPage = function ($event) {
                 return $scope.selectedItems === $scope.posts.length;
+            };
+
+            $scope.exportPosts = function () {
+                // prepare filters for export
+                var filters = {};
+
+                angular.extend(filters, $scope.filters, {format: 'csv'});
+
+                $translate('notify.post.export').then(function (message) {
+                    Notify.showConfirm(message).then(function (message) {
+
+                        var site = ConfigEndpoint.get({ id: 'site' }).$promise,
+                            postExport = PostEndpoint.export(filters),
+                            format = 'csv'; // @todo handle more formats
+
+                        $q.all([site, postExport]).then(function (response) {
+                            var siteName = response[0].name;
+
+                            // Save export to file
+
+                            // Create anchor link
+                            var anchor = angular.element('<a/>');
+
+                            // Attach it to the document
+                            angular.element(document.body).append(anchor);
+
+                            // Set attributes
+                            anchor.attr({
+                                href: 'data:attachment/' + format + ';charset=utf-8,' + encodeURIComponent(response[1].data),
+                                target: '_self',
+                                download: siteName + '.csv'
+                            });
+
+                            // Save to file
+                            anchor[0].click();
+
+                            // ... and finally remove the link
+                            anchor.remove();
+                        });
+                    });
+                });
             };
 
             $scope.hasFilters = function () {

--- a/app/post/directives/views/post-view-list-directive.js
+++ b/app/post/directives/views/post-view-list-directive.js
@@ -113,37 +113,35 @@ function (
             };
 
             $scope.exportPosts = function () {
-                // prepare filters for export
-                var filters = {};
-
-                angular.extend(filters, $scope.filters, {format: 'csv'});
-
                 $translate('notify.post.export').then(function (message) {
                     Notify.showConfirm(message).then(function (message) {
+                        var filters = {},
+                            format = 'csv'; //@todo handle more formats
+
+                        // Prepare filters for export
+                        angular.extend(filters, $scope.filters, {format: format});
 
                         var site = ConfigEndpoint.get({ id: 'site' }).$promise,
-                            postExport = PostEndpoint.export(filters),
-                            format = 'csv'; // @todo handle more formats
+                            postExport = PostEndpoint.export(filters);
 
+                        // Save export data to file
                         $q.all([site, postExport]).then(function (response) {
-                            var siteName = response[0].name;
-
-                            // Save export to file
+                            var filename = response[0].name + '.' + format,
+                                data = response[1].data;
 
                             // Create anchor link
                             var anchor = angular.element('<a/>');
 
-                            // Attach it to the document
+                            // ...and attach it.
                             angular.element(document.body).append(anchor);
 
                             // Set attributes
                             anchor.attr({
-                                href: 'data:attachment/' + format + ';charset=utf-8,' + encodeURIComponent(response[1].data),
-                                target: '_self',
-                                download: siteName + '.csv'
+                                href: 'data:attachment/' + format + ';charset=utf-8,' + encodeURIComponent(data),
+                                download: filename
                             });
 
-                            // Save to file
+                            // Show file download dialog
                             anchor[0].click();
 
                             // ... and finally remove the link

--- a/app/post/services/endpoints/post-endpoint.js
+++ b/app/post/services/endpoints/post-endpoint.js
@@ -3,11 +3,13 @@ module.exports = [
     '$rootScope',
     'Util',
     '_',
+    '$http',
 function (
     $resource,
     $rootScope,
     Util,
-    _
+    _,
+    $http
 ) {
 
     var PostEndpoint = $resource(Util.apiUrl('/posts/:id/:extra'), {
@@ -54,8 +56,12 @@ function (
             url: Util.apiUrl('/posts/:id/collections'),
             isArray: true
         }
-
     });
+
+    PostEndpoint.export = function (filters) {
+        var config =  {params: filters};
+        return $http.get(Util.apiUrl('/posts/export'), config);
+    };
 
     $rootScope.$on('event:authentication:logout:succeeded', function () {
         PostEndpoint.query();

--- a/server/www/templates/views/list.html
+++ b/server/www/templates/views/list.html
@@ -1,8 +1,10 @@
 <div>
 
-    <div class="list-actions" ng-if="userHasBulkActionPermissions()">
+  <div class="list-actions">
+    <span ng-if="userHasBulkActionPermissions()">
         <a ng-if="!allSelectedOnCurrentPage()" ng-click="selectAllPosts($event)" class="cta" translate>post.select_all</a>
         <a ng-if="allSelectedOnCurrentPage()" ng-click="unselectAllPosts($event)" class="cta" translate>post.unselect_all</a>
+    </span>
 
         <div class="bulk-actions">
             <!-- <div class="dropdown-group dropdown" dropdown>
@@ -18,12 +20,12 @@
                 </div>
             </div> -->
 
-            <button type="button" class="button-secondary alt icon-only-when-small export" ng-click="exportPosts()">
+            <button type="button" class="button-secondary alt icon-only-when-small export" ng-if="posts.length > 0" ng-click="exportPosts()">
                 <span translate>post.post_actions.export</span>
             </button>
 
 
-            <button type="button" class="button-secondary icon-only-when-small alt trash" ng-disabled="selectedItems <= 0" ng-click="deleteSelectedPosts()">
+            <button type="button" class="button-secondary icon-only-when-small alt trash" ng-if="userHasBulkActionPermissions()" ng-disabled="selectedItems <= 0" ng-click="deleteSelectedPosts()">
                 <span translate>post.post_actions.delete</span>
             </button>
 

--- a/server/www/templates/views/list.html
+++ b/server/www/templates/views/list.html
@@ -18,9 +18,9 @@
                 </div>
             </div> -->
 
-            <!-- <button type="button" class="button-secondary alt icon-only-when-small export">
-                <span>Export</span>
-            </button> -->
+            <button type="button" class="button-secondary alt icon-only-when-small export" ng-click="exportPosts()">
+                <span translate>post.post_actions.export</span>
+            </button>
 
 
             <button type="button" class="button-secondary icon-only-when-small alt trash" ng-disabled="selectedItems <= 0" ng-click="deleteSelectedPosts()">

--- a/test/e2e/post/views/post-list-e2e-spec.js
+++ b/test/e2e/post/views/post-list-e2e-spec.js
@@ -50,7 +50,7 @@ describe('post detail interaction', function () {
 
         describe('checking bulk edit actions', function () {
             it('the delete button should initially be disabled', function () {
-                var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
+                var deleteButton = element.all(by.css(bulkActionButtonSelector)).get(1);
                 expect(deleteButton.isEnabled()).toEqual(false);
             });
 
@@ -61,13 +61,13 @@ describe('post detail interaction', function () {
                 });
 
                 it('should enable the delete button', function () {
-                    var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
+                    var deleteButton = element.all(by.css(bulkActionButtonSelector)).get(1);
                     expect(deleteButton.isEnabled()).toEqual(true);
                 });
 
                 describe('when clicking the delete button', function () {
                     beforeEach(function () {
-                        var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
+                        var deleteButton = element.all(by.css(bulkActionButtonSelector)).get(1);
                         deleteButton.click();
                         browser.sleep(200);
                     });
@@ -114,13 +114,13 @@ describe('post detail interaction', function () {
                 });
 
                 it('should enable the delete button', function () {
-                    var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
+                    var deleteButton = element.all(by.css(bulkActionButtonSelector)).get(1);
                     expect(deleteButton.isEnabled()).toEqual(true);
                 });
 
                 describe('when clicking delete', function () {
                     beforeEach(function () {
-                        var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
+                        var deleteButton = element.all(by.css(bulkActionButtonSelector)).get(1);
                         deleteButton.click();
                         browser.sleep(200);
                     });

--- a/test/e2e/post/views/post-list-e2e-spec.js
+++ b/test/e2e/post/views/post-list-e2e-spec.js
@@ -4,7 +4,7 @@ describe('post detail interaction', function () {
         postLink = '.post-text a',
         postSelectSelector = '.select-post input',
         postCheckedSelectSelector = '.select-post input:checked',
-        deleteButtonSelector = '.bulk-actions button',
+        bulkActionButtonSelector = '.bulk-actions button',
         openCreateCollectionButton = '.form-field.bar a',
         createCollectionButton = '.form-field.bar button',
         postCollectionsButtonSelector = '.actions-content .dropdown-trigger.init.dropdown-toggle',
@@ -50,7 +50,7 @@ describe('post detail interaction', function () {
 
         describe('checking bulk edit actions', function () {
             it('the delete button should initially be disabled', function () {
-                var deleteButton = element(by.css(deleteButtonSelector));
+                var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                 expect(deleteButton.isEnabled()).toEqual(false);
             });
 
@@ -61,13 +61,13 @@ describe('post detail interaction', function () {
                 });
 
                 it('should enable the delete button', function () {
-                    var deleteButton = element(by.css(deleteButtonSelector));
+                    var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                     expect(deleteButton.isEnabled()).toEqual(true);
                 });
 
                 describe('when clicking the delete button', function () {
                     beforeEach(function () {
-                        var deleteButton = element(by.css(deleteButtonSelector));
+                        var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                         deleteButton.click();
                         browser.sleep(200);
                     });
@@ -114,13 +114,13 @@ describe('post detail interaction', function () {
                 });
 
                 it('should enable the delete button', function () {
-                    var deleteButton = element(by.css(deleteButtonSelector));
+                    var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                     expect(deleteButton.isEnabled()).toEqual(true);
                 });
 
                 describe('when clicking delete', function () {
                     beforeEach(function () {
-                        var deleteButton = element(by.css(deleteButtonSelector));
+                        var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                         deleteButton.click();
                         browser.sleep(200);
                     });
@@ -253,7 +253,7 @@ describe('post detail interaction', function () {
                 });
 
                 it('should not be possible to see the delete button', function () {
-                    var deleteButton = element(by.css(deleteButtonSelector));
+                    var deleteButton = element(by.css(bulkActionButtonSelector)).get(1);
                     expect(deleteButton.toEqual(null));
                 });
             });


### PR DESCRIPTION
This pull request makes the following changes:
- Adds an export button to export filtered posts. Currently, only CSV is supported.

Test these changes by:
- Navigating to the post list view and clicking export. Posts should be exported with the current filters.

Fixes ushahidi/platform#1005 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/174)
<!-- Reviewable:end -->
