### PR TITLE
New modal directive and service

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -39,6 +39,7 @@ angular.module('ushahidi.common', [
 .service('PasswordReset', require('./services/password-reset.js'))
 .service('IconManager', require('./services/icon-manager.js'))
 .service('FontAwesomeIcons', require('./services/endpoints/FontAwesomeIcons.js'))
+.service('ModalService', require('./services/modal.service.js'))
 
 .controller('navigation', require('./controllers/navigation.js'))
 .controller('PageMetadata', require('./controllers/page-metadata.js'))
@@ -50,6 +51,7 @@ angular.module('ushahidi.common', [
 .directive('iconPicker', require('./directives/iconpicker.js'))
 .directive('colorPicker', require('./directives/color-picker.js'))
 .directive('firstTimeConfig', require('./directives/first-time-config.js'))
+.directive('ushModalContainer', require('./directives/modal-container.directive.js'))
 
 // Event actions
 .constant('EVENT', {

--- a/app/common/directives/modal-container.directive.js
+++ b/app/common/directives/modal-container.directive.js
@@ -1,0 +1,104 @@
+/**
+ * Ushahidi Angular Modal directive
+ * Based on the Angular Bootstrap Modal directive
+ */
+module.exports = ModalContainer;
+
+ModalContainer.$inject = ['$timeout', '$rootScope', '$templateRequest', '$compile', 'ModalService'];
+function ModalContainer($timeout, $rootScope, $templateRequest, $compile, ModalService) {
+    return {
+        restrict: 'E',
+        transclude: true,
+        templateUrl: 'templates/modal/modal-container.html',
+
+        scope: true,
+
+        link: ModalContainerLink
+    };
+
+    function ModalContainerLink($scope, $element) {
+        $scope.classVisible = false;
+        $scope.modalOffset = 0;
+        $scope.title = '';
+        $scope.closeOnOverlayClick = true; // Could move out of scope
+        $scope.showCloseButton = true;
+        // Callbacks
+        $scope.closeButtonClicked = closeButtonClicked;
+
+        // Modal content element
+        var modalContent = $element.find('modal-content');
+
+        // Bind to modal service open/close events
+        ModalService.onOpen(openModal, $scope);
+        ModalService.onClose(closeModal, $scope);
+
+        //var classChangePromise = null;
+
+        function openModal(ev, templateUrl, title, closeOnOverlayClick, showCloseButton) {
+            // Load template markup
+            $templateRequest(templateUrl).then(function (template) {
+                modalContent.html(template);
+                $compile(modalContent)($scope);
+
+                $scope.title = title;
+
+                // If closeOnOverlayClick isn't passed, default to true
+                if (typeof closeOnOverlayClick === 'undefined') {
+                    $scope.closeOnOverlayClick = true;
+                }
+
+                // If showCloseButton isn't passed, default to true
+                if (typeof showCloseButton === 'undefined') {
+                    $scope.showCloseButton = true;
+                }
+
+                // @todo fade in
+                modalYPos();
+                $scope.classVisible = true;
+                $rootScope.toggleModalVisible();
+
+                // if (classChangePromise) {
+                //     $timeout.cancel(classChangePromise);
+                // }
+            });
+        }
+
+        function closeModal() {
+            // @todo fade out
+            $scope.classVisible = false;
+            $rootScope.toggleModalVisible();
+
+            // if (classChangePromise) {
+            //     $timeout.cancel(classChangePromise);
+            // }
+
+            // classChangePromise = $timeout(function () {
+            //     $scope.classDetached = true;
+            // }, 400);
+        }
+
+        function closeButtonClicked(context) {
+            if (context === 'overlay' && $scope.closeOnOverlayClick !== true) {
+                return;
+            }
+
+            closeModal();
+        }
+
+        function modalYPos() {
+            // Set offset based on window position
+            // @todo move offset to a config param
+            var windowYpos = window.scrollY || document.documentElement.scrollTop || document.body.scrollTop;
+            $scope.modalOffset = (windowYpos + 40) + 'px';
+
+            // @todo set max height
+            // $('.modal-body').css('max-height', $(window).height() * 0.66);
+        }
+
+        // $scope.$on('$destroy', function (event) {
+        //     if (classChangePromise) {
+        //         $timeout.cancel(classChangePromise);
+        //     }
+        // });
+    }
+}

--- a/app/common/services/modal.service.js
+++ b/app/common/services/modal.service.js
@@ -1,0 +1,42 @@
+module.exports = ModalService;
+
+ModalService.$inject = ['$rootScope', '$q'];
+function ModalService($rootScope, $q) {
+    var deferredOpen = $q.defer(),
+        deferredClose = $q.defer();
+
+    return {
+        open: open,
+        close: close,
+        onOpen: onOpen,
+        onClose: onClose
+    };
+
+    function open(templateUrl, title, closeOnOverlayClick, showCloseButton) {
+        deferredOpen.promise.then(function () {
+            $rootScope.$emit('modal:open', templateUrl, title, closeOnOverlayClick, showCloseButton);
+        });
+    }
+
+    function close() {
+        deferredClose.promise.then(function () {
+            $rootScope.$emit('modal:close');
+        });
+    }
+
+    function onOpen(callback, scope) {
+        var handler = $rootScope.$on('modal:open', callback);
+        if (scope) {
+            scope.$on('$destroy', handler);
+        }
+        deferredOpen.resolve();
+    }
+
+    function onClose(callback, scope) {
+        var handler = $rootScope.$on('modal:close', callback);
+        if (scope) {
+            scope.$on('$destroy', handler);
+        }
+        deferredClose.resolve();
+    }
+}

--- a/server/www/index.html
+++ b/server/www/index.html
@@ -53,7 +53,7 @@
             <!-- TODO: fix and uncomment
             <first-time-config></first-time-config>
             -->
-
+            <ush-modal-container></ush-modal-container>
         </div>
 
         <script src="/js/bundle.js"></script>

--- a/server/www/templates/modal/modal-container.html
+++ b/server/www/templates/modal/modal-container.html
@@ -1,0 +1,14 @@
+<div ng-show="classVisible" class="modal" style="display: block;">
+    <div class="modal-window" ng-style="{ top : modalOffset }">
+        <button class="button-beta button-flat modal-trigger modal-trigger-close" ng-show="showCloseButton" ng-click="closeButtonClicked()">
+            <svg class="iconic">
+                <!-- TODO: fix icon to be settable -->
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#x"></use>
+            </svg>
+            <span class="hidden" translate>modal.button.close</span>
+        </button>
+        <h3 class="modal-title" ng-if="title">{{ title | translate }}</h3>
+        <modal-content></modal-content>
+    </div>
+    <div class="modal-overlay"></div>
+</div>

--- a/server/www/templates/modal/modal.html
+++ b/server/www/templates/modal/modal.html
@@ -1,6 +1,6 @@
 <div ng-show="classVisible" class="modal" style="display: block;">
     <div class="modal-window" ng-style="{ top : modalOffset }">
-        <button class="button-beta button-flat" ng-show="showCloseButton" ng-click="closeModal()">
+        <button class="button-beta button-flat modal-trigger modal-trigger-close" ng-show="showCloseButton" ng-click="closeModal()">
             <svg class="iconic">
                 <!-- TODO: fix icon to be settable -->
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#x"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- Add `ush-modal-container` directive
- Add `ModalService`
  - Modals can be triggered by `ModalService.open(templateUrl, title ...)`

Todo: 
- [ ] slider service
- [ ] Split notification system templates and use modal/slider services
- [ ] Modify existing `<modal>` to delegate to ModalService

Test these changes by:
- N/A yet..

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/198)
<!-- Reviewable:end -->
