### PR TITLE
Fix for mysql datetime issue when mysql server using strict date time

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -114,6 +114,9 @@ angular.module('app',
     .factory('Leaflet', function () {
         return window.L;
     })
+    .factory('moment', function () {
+        return require('moment');
+    })
     .factory('BootstrapConfig', ['_', function (_) {
         return window.ushahidi.bootstrapConfig ?
             _.indexBy(window.ushahidi.bootstrapConfig, 'id') :

--- a/app/post/directives/post-editor-directive.js
+++ b/app/post/directives/post-editor-directive.js
@@ -6,6 +6,7 @@ function (
         '$filter',
         '$location',
         '$translate',
+        'moment',
         'PostEntity',
         'PostEndpoint',
         'TagEndpoint',
@@ -19,6 +20,7 @@ function (
             $filter,
             $location,
             $translate,
+            moment,
             postEntity,
             PostEndpoint,
             TagEndpoint,
@@ -182,6 +184,13 @@ function (
                 return valid;
             };
 
+            $scope.correctlyFormateDates = function (post) {
+                _.each(post.values, function (value) {
+                    value[0] = value[0] instanceof Date ? moment(value[0]).format('YYYY-MM-DD HH:mm:ss') : value[0];
+                });
+                return post;
+            };
+
             $scope.savePost = function () {
                 if (!$scope.canSavePost()) {
                     return;
@@ -201,6 +210,7 @@ function (
                         delete post.values[key];
                     }
                 });
+                post = $scope.correctlyFormateDates(post);
 
                 var request;
                 if (post.id) {

--- a/app/post/directives/post-editor-directive.js
+++ b/app/post/directives/post-editor-directive.js
@@ -184,7 +184,7 @@ function (
                 return valid;
             };
 
-            $scope.correctlyFormateDates = function (post) {
+            $scope.correctlyFormatDates = function (post) {
                 _.each(post.values, function (value) {
                     value[0] = value[0] instanceof Date ? moment(value[0]).format('YYYY-MM-DD HH:mm:ss') : value[0];
                 });
@@ -210,7 +210,7 @@ function (
                         delete post.values[key];
                     }
                 });
-                post = $scope.correctlyFormateDates(post);
+                post = $scope.correctlyFormatDates(post);
 
                 var request;
                 if (post.id) {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "leaflet-draw": "~0.2.1",
     "leaflet.locatecontrol": "^0.40.0",
     "leaflet.markercluster": "0.4.0",
+    "moment": "^2.13.0",
     "moment-timezone": "^0.3.1",
     "ng-showdown": "rjmackay/ng-showdown#patch-1",
     "ngGeolocation": "rjmackay/ngGeolocation",


### PR DESCRIPTION
This pull request makes the following changes:
- MySQL 5.6 enforces strict dates
- ngResource use JSON stringify, the dates output are not in a MySQL acceptable date format
- Platform treats all values agnostically
- This fix converts dates set on Post date fields to the MySQL date format prior to save/update
- This is intended as a hot fix for the current version of platform, I will investigate a better fix at the ngResource point or on the platform side.

Test these changes by:
- Save a post with a date field and ensure it is sent in the format 'YYYY-MM-DD HH:mm:ss'

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/215)
<!-- Reviewable:end -->
