### PR TITLE
Fix endpoint get fresh to properly remove cache key

### DIFF
--- a/app/common/services/endpoints/config.js
+++ b/app/common/services/endpoints/config.js
@@ -15,11 +15,6 @@ function (
         cache = new CacheFactory('configCache');
     }
 
-    cache.setOnExpire(function (key, value) {
-        ConfigEndpoint.get(value.id);
-    });
-
-
     var ConfigEndpoint = $resource(Util.apiUrl('/config/:id'), {
         'id': '@id'
     }, {
@@ -42,9 +37,9 @@ function (
         return cache.removeAll();
     };
 
-    ConfigEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return ConfigEndpoint.get(id);
+    ConfigEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/config/' + params.id));
+        return ConfigEndpoint.get(params);
     };
 
     /**

--- a/app/common/services/endpoints/data-providers.js
+++ b/app/common/services/endpoints/data-providers.js
@@ -42,9 +42,9 @@ function (
         }
     });
 
-    DataProviderEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return DataProviderEndpoint.get(id);
+    DataProviderEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/dataproviders/' + params.id));
+        return DataProviderEndpoint.get(params);
     };
 
     DataProviderEndpoint.queryFresh = function () {

--- a/app/common/services/endpoints/form-attributes.js
+++ b/app/common/services/endpoints/form-attributes.js
@@ -39,9 +39,9 @@ function (
         }
     });
 
-    FormAttributeEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return FormAttributeEndpoint.get(id);
+    FormAttributeEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/forms/' + params.formId + '/attributes/' + params.id));
+        return FormAttributeEndpoint.get(params);
     };
 
     FormAttributeEndpoint.queryFresh = function (params) {

--- a/app/common/services/endpoints/form-stages.js
+++ b/app/common/services/endpoints/form-stages.js
@@ -39,9 +39,9 @@ function (
         }
     });
 
-    FormStageEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return FormStageEndpoint.get(id);
+    FormStageEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/forms/' + params.formId + '/stages/' + params.id));
+        return FormStageEndpoint.get(params);
     };
 
     FormStageEndpoint.invalidateCache = function () {

--- a/app/common/services/endpoints/form.js
+++ b/app/common/services/endpoints/form.js
@@ -36,9 +36,9 @@ function (
         }
     });
 
-    FormEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return FormEndpoint.get(id);
+    FormEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/forms/' + params.id));
+        return FormEndpoint.get(params);
     };
 
     FormEndpoint.invalidateCache = function () {

--- a/app/common/services/endpoints/permission.js
+++ b/app/common/services/endpoints/permission.js
@@ -32,9 +32,9 @@ function (
         }
     });
 
-    PermissionEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return PermissionEndpoint.get(id);
+    PermissionEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/permissions/' + params.id));
+        return PermissionEndpoint.get(params);
     };
 
     PermissionEndpoint.invalidateCache = function () {

--- a/app/common/services/endpoints/permission.js
+++ b/app/common/services/endpoints/permission.js
@@ -13,10 +13,6 @@ function (
         cache = new CacheFactory('permissionCache');
     }
 
-    cache.setOnExpire(function (key, value) {
-        PermissionEndpoint.get(value.id);
-    });
-
     var PermissionEndpoint = $resource(Util.apiUrl('/permissions/:id'), {
             id: '@id'
         }, {

--- a/app/common/services/endpoints/role.js
+++ b/app/common/services/endpoints/role.js
@@ -39,9 +39,10 @@ function (
         }
     });
 
-    RoleEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return RoleEndpoint.get(id);
+    RoleEndpoint.getFresh = function (params) {
+        console.log(cache);
+        cache.remove(Util.apiUrl('/roles/' + params.id));
+        return RoleEndpoint.get(params);
     };
 
     RoleEndpoint.invalidateCache = function () {

--- a/app/common/services/endpoints/role.js
+++ b/app/common/services/endpoints/role.js
@@ -13,10 +13,6 @@ function (
         cache = new CacheFactory('roleCache');
     }
 
-    cache.setOnExpire(function (key, value) {
-        RoleEndpoint.get(value.id);
-    });
-
     var RoleEndpoint = $resource(Util.apiUrl('/roles/:id'), {
             id: '@id'
         }, {

--- a/app/common/services/endpoints/tag.js
+++ b/app/common/services/endpoints/tag.js
@@ -43,9 +43,9 @@ function (
         }
     });
 
-    TagEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return TagEndpoint.get(id);
+    TagEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/tags/' + params.id));
+        return TagEndpoint.get(params);
     };
 
     TagEndpoint.queryFresh = function () {

--- a/app/common/services/endpoints/tag.js
+++ b/app/common/services/endpoints/tag.js
@@ -15,10 +15,6 @@ function (
         cache = new CacheFactory('tagCache');
     }
 
-    cache.setOnExpire(function (key, value) {
-        TagEndpoint.get(value.id);
-    });
-
     var TagEndpoint = $resource(Util.apiUrl('/tags/:id'), {
         id: '@id'
     }, {

--- a/app/common/services/endpoints/user-endpoint.js
+++ b/app/common/services/endpoints/user-endpoint.js
@@ -15,10 +15,6 @@ function (
         cache = new CacheFactory('userCache');
     }
 
-    cache.setOnExpire(function (key, value) {
-        UserEndpoint.get(value.id);
-    });
-
     var UserEndpoint = $resource(Util.apiUrl('/users/:id'), {
         id: '@id'
     }, {

--- a/app/common/services/endpoints/user-endpoint.js
+++ b/app/common/services/endpoints/user-endpoint.js
@@ -43,9 +43,9 @@ function (
         }
     });
 
-    UserEndpoint.getFresh = function (id) {
-        cache.remove(Util.apiUrl(id));
-        return UserEndpoint.get(id);
+    UserEndpoint.getFresh = function (params) {
+        cache.remove(Util.apiUrl('/users/' + params.id));
+        return UserEndpoint.get(params);
     };
 
     UserEndpoint.invalidateCache = function () {

--- a/test/unit/common/services/endpoints/form-attributes.js
+++ b/test/unit/common/services/endpoints/form-attributes.js
@@ -172,7 +172,7 @@ describe('FormAttributeEndpoint', function () {
 
                 spyOn(FormAttributeEndpoint, 'get').and.callThrough();
 
-                FormAttributeEndpoint.getFresh({id: 1}).$promise.then(successCallback);
+                FormAttributeEndpoint.getFresh({id: 1, formId: 1}).$promise.then(successCallback);
                 expect(FormAttributeEndpoint.get).toHaveBeenCalled();
             });
 

--- a/test/unit/common/services/endpoints/form-stages.js
+++ b/test/unit/common/services/endpoints/form-stages.js
@@ -172,7 +172,7 @@ describe('FormStageEndpoint', function () {
 
                 spyOn(FormStageEndpoint, 'get').and.callThrough();
 
-                FormStageEndpoint.getFresh({id: 1}).$promise.then(successCallback);
+                FormStageEndpoint.getFresh({id: 1, formId: 1}).$promise.then(successCallback);
                 expect(FormStageEndpoint.get).toHaveBeenCalled();
             });
 


### PR DESCRIPTION
This pull request makes the following changes:
- Properly set params passed to getFresh
- Update tests for getFresh
- Fix removal of cache key based on url

Test these changes by:
- Ensure that cache keys are removed on getFresh for Tags, Roles, Permissions, Forms, Form Attributes, Form Stages and Data provider

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/218)
<!-- Reviewable:end -->
