### PR TITLE
Used has hasManageSettingsPermission to check if Settings menu icon s…

### DIFF
--- a/app/frame/directives/mode-bar.js
+++ b/app/frame/directives/mode-bar.js
@@ -21,6 +21,7 @@ function (
             $scope.baseUrl = 'views/';
             $scope.activeMode = 'map';
             $scope.isActivityAvailable = ViewHelper.isViewAvailable('activity');
+            $scope.hasManageSettingsPermission = $rootScope.hasManageSettingsPermission;
 
             // Show account settings
             $scope.viewAccountSettings = function () {

--- a/server/www/templates/frame/mode-bar.html
+++ b/server/www/templates/frame/mode-bar.html
@@ -31,7 +31,7 @@
                 </a>
             </li>
 
-            <li ng-class="{ active: activeMode === 'settings' }" class="tuck" data-message="customize">
+            <li ng-class="{ active: activeMode === 'settings' }" class="tuck" data-message="customize" ng-show="hasManageSettingsPermission()">
                 <a href="/settings">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#cog"></use>


### PR DESCRIPTION
This pull request makes the following changes:
-
Adds the hasManageSettingsPermission to the mode-bar directive and template.

Test these changes by:
-
User with role==admin will see the Settings icon in the mode-bar. Other users, including non-logged in users, will not

Fixes ushahidi/platform# 1090.

Ping @ushahidi/platform

…hould be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/220)
<!-- Reviewable:end -->
