### PR TITLE
Limit length of post description on map

### DIFF
--- a/app/common/services/maps.js
+++ b/app/common/services/maps.js
@@ -5,13 +5,15 @@ module.exports = [
     'Leaflet',
     'leafletData',
     '_',
+    '$filter',
 function (
     $q,
     ConfigEndpoint,
     Util,
     L,
     LData,
-    _
+    _,
+    $filter
 ) {
 
     var layers = {
@@ -54,13 +56,14 @@ function (
         onEachFeature: function (feature, layer) {
             var description = feature.properties.description || '',
                 title = feature.properties.title || feature.properties.id;
+
             layer.bindPopup(
                 '<article class="postcard">' +
                     '<div class="post-band" style="background-color: #A51A1A;"></div>' +
                     '<div class="postcard-body">' +
                         '<h1 class="postcard-title"><a href="/posts/' + feature.properties.id + '">' + title + '</a></h1>' +
                         '<div class="postcard-field">' +
-                        '<p>' + description + '</p>' +
+                        '<p>' + $filter('truncate')(description, 150, '...', true) + '</p>' +
                         '</div>' +
                     '</div>' +
                 '</article>'


### PR DESCRIPTION
This pull request makes the following changes:
- Truncates post description on the map.

Test these changes by:
- Click on a marker of long post description. It should be truncated to the first 150 characters.

Fixes ushahidi/platform#1115 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/231)
<!-- Reviewable:end -->
