### PR TITLE
Addresses issues where the zoom control position default is enforced …

### DIFF
--- a/app/common/services/maps.js
+++ b/app/common/services/maps.js
@@ -83,7 +83,7 @@ function (
         getInitialScope: function () {
             return {
                 defaults: {
-	                zoomControlPosition: 'bottomright',
+                    zoomControlPosition: 'bottomright',
                     scrollWheelZoom: false
                 },
                 center: { // Default to centered on Nairobi

--- a/app/common/services/maps.js
+++ b/app/common/services/maps.js
@@ -83,6 +83,7 @@ function (
         getInitialScope: function () {
             return {
                 defaults: {
+	                zoomControlPosition: 'bottomright',
                     scrollWheelZoom: false
                 },
                 center: { // Default to centered on Nairobi
@@ -148,7 +149,6 @@ function (
             // Disable 'Leaflet prefix on attributions'
             this.map().then(function (map) {
                 map.attributionControl.setPrefix(false);
-                map.zoomControl.setPosition('bottomleft');
             });
 
             return this;

--- a/app/post/views/post-view-map.directive.js
+++ b/app/post/views/post-view-map.directive.js
@@ -20,7 +20,7 @@ function (
         Maps.getAngularScopeParams().then(function (params) {
             angular.extend($scope, params);
         });
-        
+
         Maps.getMap().init();
 
         // load geojson posts into the map obeying the global filter settings

--- a/app/post/views/post-view-map.directive.js
+++ b/app/post/views/post-view-map.directive.js
@@ -20,6 +20,8 @@ function (
         Maps.getAngularScopeParams().then(function (params) {
             angular.extend($scope, params);
         });
+        
+        Maps.getMap().init();
 
         // load geojson posts into the map obeying the global filter settings
         var map = Maps.getMap('map');


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes a bug where the zoom control position defaults to 'topleft' when navigating.
- Fixes bug where attribution prefix is restored when navigating back to /views/map

Test these changes by:
- navigate to /views/map, navigate to another page and then navigate back to /views/map

Fixes ushahidi/platform#1110 .

Ping @ushahidi/platform

…when navigating away from and then back to /views/map. While working on this I noticed that the attribution prefix was also being turned on when navigating away from and back to /views/map. Addressed that issue as well in this commit.

- sets zoomControlPosition to 'bottom right'
- runs map.init() in post-view-map.directive so the attributionPrefix is set to false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/240)
<!-- Reviewable:end -->
