### PR TITLE
Better handling of translations in Notify

### DIFF
--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -18,15 +18,19 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
     };
 
     function notify(message, translateValues) {
-        $translate(message, translateValues).then(function (message) {
+        function showSlider(message) {
             SliderService.openTemplate('<p>' + message + '</p>');
-        });
+        }
+
+        $translate(message, translateValues).then(showSlider, showSlider);
     }
 
     function error(errorText, translateValues) {
-        $translate(errorText, translateValues).then(function (errorText) {
+        function showSlider(errorText) {
             SliderService.openTemplate('<p>' + errorText + '</p>', 'warning', 'error');
-        });
+        }
+
+        $translate(errorText, translateValues).then(showSlider, showSlider);
     }
 
     function errorsPretranslated(errorTexts) {
@@ -35,10 +39,10 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         SliderService.openUrl('templates/common/notifications/api-errors.html', 'warning', 'error', scope);
     }
 
-    function errors(errorTexts) {
+    function errors(errorTexts, translateValues) {
         var scope = getScope();
 
-        $q.all(_.map(errorTexts, $translate)).then(function (errors) {
+        $translate(errorTexts, translateValues).then(function (errors) {
             scope.errors = errors;
             SliderService.openUrl('templates/common/notifications/api-errors.html', 'warning', 'error', scope);
         });
@@ -56,9 +60,11 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
     }
 
     function success(successText, translateValues) {
-        $translate(successText, translateValues).then(function (successText) {
+        function showSlider(successText) {
             SliderService.openTemplate('<p>' + successText + '</p>', 'thumb-up', 'confirmation');
-        });
+        }
+
+        $translate(successText, translateValues).then(showSlider, showSlider);
     }
 
     function confirm(confirmText, translateValues) {
@@ -74,7 +80,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
             ModalService.close();
         };
 
-        $translate(confirmText, translateValues).then(function (confirmText) {
+        function showSlider(confirmText) {
             scope.confirmText = confirmText;
             SliderService.openTemplate(
                 '<p>{{ confirmText }}</p>' +
@@ -83,7 +89,9 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 '    <button class="button-beta button-flat" ng-click="$parent.confirm()" translate="message.button.default">OK</button>' +
                 '</div>',
             false, false, scope, false, false);
-        });
+        }
+
+        $translate(confirmText, translateValues).then(showSlider, showSlider);
 
         return deferred.promise;
     }
@@ -101,14 +109,16 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
             ModalService.close();
         };
 
-        $translate(confirmText, translateValues).then(function (confirmText) {
+        function showSlider(confirmText) {
             scope.confirmText = confirmText;
             ModalService.openTemplate(
                 '<div class="form-field">' +
                 '    <button class="button-flat" ng-click="$parent.cancel()" translate="message.button.cancel">Cancel</button>' +
                 '    <button class="button-beta button-flat" ng-click="$parent.confirm()" translate="message.button.default">OK</button>' +
                 '</div>', confirmText, false, scope, false, false);
-        });
+        }
+
+        $translate(confirmText, translateValues).then(showSlider, showSlider);
 
         return deferred.promise;
     }
@@ -118,7 +128,9 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
 
         var scope = getScope();
 
-        $translate(confirmText, translateValues).then(function (confirmText) {
+        $translate(confirmText, translateValues).then(show, show);
+
+        function show(confirmText) {
             scope.confirmText = confirmText;
             // If modal is already open?
             if (ModalService.getState()) {
@@ -160,7 +172,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 '    </button>' +
                 '</div>', confirmText, false, scope, false, false);
             }
-        });
+        }
 
         return deferred.promise;
     }
@@ -168,10 +180,12 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
     function limit(message, translateValues) {
         var scope = getScope();
 
-        $translate(message, translateValues).then(function (message) {
+        $translate(message, translateValues).then(showSlider, showSlider);
+
+        function showSlider(message) {
             scope.message = message;
             SliderService.openUrl('templates/common/notifications/limit.html', 'warning', 'error', scope);
-        });
+        }
     }
 
     function getScope() {

--- a/test/unit/common/notifications/notify.service.spec.js
+++ b/test/unit/common/notifications/notify.service.spec.js
@@ -19,13 +19,23 @@ describe('Notify', function () {
     };
 
     beforeEach(function () {
-        var testApp = angular.module('testApp');
+        var testApp = angular.module('testApp', [
+            'pascalprecht.translate'
+        ]);
         testApp.service('Notify', require(rootPath + 'app/common/notifications/notify.service.js'))
         .service('SliderService', function () {
             return mockSliderService;
         })
         .service('ModalService', function () {
             return mockModalService;
+        })
+        // Inject some dummy translations
+        .config(function ($translateProvider) {
+            $translateProvider
+            .translations('en', {
+                'dummy_error': 'Some error'
+            })
+            .preferredLanguage('en');
         })
         ;
 
@@ -54,12 +64,19 @@ describe('Notify', function () {
     describe('errors', function () {
         beforeEach(function () {
             spyOn(mockSliderService, 'openUrl').and.callThrough();
-            Notify.errors(['Test message 1', 'Test message 2']);
-            $rootScope.$digest();
         });
 
         it('Calls SliderService.openUrl with error template + scope', function () {
-            expect(mockSliderService.openUrl).toHaveBeenCalledWith('templates/common/notifications/api-errors.html', 'warning', 'error', jasmine.objectContaining({ errors: ['Test message 1', 'Test message 2']}));
+            Notify.errors(['Test message 1', 'Test message 2']);
+            $rootScope.$digest();
+
+            expect(mockSliderService.openUrl).toHaveBeenCalledWith('templates/common/notifications/api-errors.html', 'warning', 'error', jasmine.objectContaining({ errors: {'Test message 1': 'Test message 1', 'Test message 2': 'Test message 2'}}));
+        });
+
+        it('To translate messages if possible', function () {
+            Notify.errors(['dummy_error', 'Test message 2']);
+            $rootScope.$digest();
+            expect(mockSliderService.openUrl).toHaveBeenCalledWith('templates/common/notifications/api-errors.html', 'warning', 'error', jasmine.objectContaining({ errors: {'dummy_error': 'Some error', 'Test message 2': 'Test message 2'}}));
         });
     });
 


### PR DESCRIPTION
This pull request makes the following changes:
- Just use raw string if translation fails
- Don't bother mapping errors to $translate - it already takes an array

Test these changes by:
- gulp test

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/247)
<!-- Reviewable:end -->
