### PR TITLE
Adding no post message when there are no posts for the map and timeli…

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -384,6 +384,8 @@
     "post": {
         "add_to_form" : "Add to {{form}}",
         "posts" : "Posts",
+        "there_are_no_posts" : "There are no posts",
+        "in_this_deployment" : " in this deployment, yet.",
         "by" : "by",
         "everyone" : "Everyone",
         "just_you" : "Just you",

--- a/app/common/notifications/slider.directive.js
+++ b/app/common/notifications/slider.directive.js
@@ -7,6 +7,7 @@ Slider.$inject = ['$timeout', '$compile', 'SliderService', 'ModalService'];
 function Slider($timeout, $compile, SliderService, ModalService) {
     return {
         restrict: 'E',
+        replace: 'true',
         templateUrl: 'templates/common/notifications/slider.html',
         scope: {
             insideModal: '@?'
@@ -104,4 +105,3 @@ function Slider($timeout, $compile, SliderService, ModalService) {
     }
 
 }
-

--- a/app/post/post-module.js
+++ b/app/post/post-module.js
@@ -22,6 +22,7 @@ angular.module('ushahidi.posts', [])
 .directive('postViewList', require('./views/post-view-list.directive.js'))
 .directive('postViewMap', require('./views/post-view-map.directive.js'))
 .directive('addPostButton', require('./views/add-post-button.directive.js'))
+.directive('addPostTextButton', require('./views/add-post-text-button.directive.js'))
 .directive('filterPosts', require('./views/filters/filter-posts.directive.js'))
 .directive('modeContextFormFilter', require('./views/mode-context-form-filter.directive.js'))
 .directive('postToolbar', require('./views/post-toolbar.directive.js'))
@@ -43,6 +44,7 @@ angular.module('ushahidi.posts', [])
 
 .service('PostEditService', require('./services/post-edit-service.js'))
 .service('PostActionsService', require('./services/post-actions-service.js'))
+.service('PostViewService', require('./services/post-view.service.js'))
 
 .config(require('./post-routes.js'))
 

--- a/app/post/services/post-view.service.js
+++ b/app/post/services/post-view.service.js
@@ -1,0 +1,38 @@
+module.exports = [
+    '_',
+    'Util',
+    '$translate',
+    '$rootScope',
+    'SliderService',
+function (
+    _,
+    Util,
+    $translate,
+    $rootScope,
+    SliderService
+) {
+    var scope;
+
+    var PostViewService = {
+        showNoPostsSlider: function () {
+            var scope = getScope();
+            // TODO review translation sanitization
+            $translate(['post.there_are_no_posts', 'post.in_this_deployment']).then(function (noPostText) {
+                scope.noPostText = noPostText;
+                SliderService.openTemplate('<p><strong>{{noPostText["post.there_are_no_posts"]}}</strong>{{noPostText["post.in_this_deployment"]}}</p><add-post-text-button></add-post-text-button>',
+                'file', false, scope, false, true);
+            });
+
+        }
+    };
+
+    function getScope() {
+        if (scope) {
+            scope.$destroy();
+        }
+        scope = $rootScope.$new();
+        return scope;
+    }
+
+    return Util.bindAllFunctionsToSelf(PostViewService);
+}];

--- a/app/post/views/add-post-text-button.directive.js
+++ b/app/post/views/add-post-text-button.directive.js
@@ -1,0 +1,59 @@
+module.exports = AddPostButtonDirective;
+
+AddPostButtonDirective.$inject = [];
+function AddPostButtonDirective() {
+    return {
+        restrict: 'E',
+        scope: true,
+        replace: true,
+        controller: AddPostButtonController,
+        templateUrl: 'templates/posts/views/add-post-text-button.html'
+    };
+}
+
+AddPostButtonController.$inject = [
+    '$scope',
+    '$rootScope',
+    'FormEndpoint',
+    'SliderService',
+    '$location'
+];
+function AddPostButtonController(
+    $scope,
+    $rootScope,
+    FormEndpoint,
+    SliderService,
+    $location
+) {
+    $scope.forms = [];
+    $scope.buttonToggle = false;
+    $scope.buttonOptionsStyle = { opacity: 0, display: 'none' };
+    $scope.toggleButton = toggleButton;
+    $scope.createPost = createPost;
+    $scope.disabled = false;
+
+    activate();
+
+    function activate() {
+        // Load forms
+        $scope.forms = FormEndpoint.query();
+    }
+
+    function createPost(path) {
+        SliderService.close();
+        $location.path('/posts/create/' + path);
+    }
+
+    function toggleButton() {
+        if ($scope.forms.length === 1) {
+            createPost($scope.forms[0].id);
+        } else {
+            $scope.buttonToggle = !$scope.buttonToggle;
+            if ($scope.buttonToggle) {
+                $scope.buttonOptionsStyle = { opacity: 1, display: 'flex' };
+            } else {
+                $scope.buttonOptionsStyle = { opacity: 0, display: 'none' };
+            }
+        }
+    }
+}

--- a/app/post/views/post-view-list.directive.js
+++ b/app/post/views/post-view-list.directive.js
@@ -20,6 +20,7 @@ PostListController.$inject = [
     '$translate',
     'PostEndpoint',
     'Notify',
+    'PostViewService',
     '_',
     'ConfigEndpoint',
     'moment',
@@ -31,6 +32,7 @@ function PostListController(
     $translate,
     PostEndpoint,
     Notify,
+    PostViewService,
     _,
     ConfigEndpoint,
     moment,
@@ -78,6 +80,10 @@ function PostListController(
 
         $scope.isLoading = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
+            if (postsResponse.count === 0) {
+                PostViewService.showNoPostsSlider();
+                return;
+            }
             $scope.posts = postsResponse.results;
             var now = moment(),
                 yesterday = moment().subtract(1, 'days');

--- a/app/post/views/post-view-map.directive.js
+++ b/app/post/views/post-view-map.directive.js
@@ -7,12 +7,14 @@ function (
         'Maps',
         '_',
         'PostFilters',
+        'PostViewService',
     function (
         $scope,
         PostEndpoint,
         Maps,
         _,
-        PostFilters
+        PostFilters,
+        PostViewService
     ) {
         // Set initial map params
         angular.extend($scope, Maps.getInitialScope());
@@ -30,6 +32,10 @@ function (
 
             $scope.isLoading = true;
             return PostEndpoint.geojson(query).$promise.then(function (posts) {
+                if (posts.features.length === 0) {
+                    PostViewService.showNoPostsSlider();
+                    return;
+                }
                 map.reloadPosts(posts);
                 $scope.isLoading = false;
             });

--- a/server/www/templates/posts/views/add-post-text-button.html
+++ b/server/www/templates/posts/views/add-post-text-button.html
@@ -1,0 +1,21 @@
+<div class="form-button">
+    <button type="button" class="button-alpha button-dropdown init" ng-click="toggleButton()"  ng-class="{ 'active': buttonToggle }">
+        <svg class="iconic">
+            <use xlink:href="../../img/iconic-sprite.svg#plus"></use>
+            <foreignObject>
+                <img class="icon" src="../../img/icons/png/plus-2x.png">
+            </foreignObject>
+        </svg>
+        <span class="button-label" translate="nav.add_post">Add post</span>
+    </button>
+
+    <ul class="dropdown-menu init" ng-show="buttonToggle" ng-class="{ 'active': buttonToggle }">
+          <li ng-repeat="form in forms">
+              <a ng-click="createPost(form.id)">
+                  <span class="post-band">
+                  </span>
+                  {{form.name}}
+              </a>
+          </li>
+      </ul>
+</div>


### PR DESCRIPTION
This pull request makes the following changes:
- Added slider for handling empty post/map lists

Test these changes by:
- On a deployment with no posts on the map and timeline views you should see a slider which allows you to select a survey to create a new post from.
- you can reference http://mustang.robbiemackay.com/assets/html/5_layouts/timeline.html

Fixes ushahidi/platform#1160

Ping @ushahidi/platform

…ne views, allowing the user to create their first post

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/253)
<!-- Reviewable:end -->
