### PR TITLE
Clear filters when navigating to home

### DIFF
--- a/app/common/global/event-handlers.js
+++ b/app/common/global/event-handlers.js
@@ -1,9 +1,11 @@
 module.exports = [
     '$rootScope',
     '$location',
+    'PostFilters',
 function (
     $rootScope,
-    $location
+    $location,
+    PostFilters
 ) {
     $rootScope.switchRtl = function () {
         $rootScope.rtlEnabled = !$rootScope.rtlEnabled;
@@ -20,4 +22,11 @@ function (
     $rootScope.toggleModalVisible = function (state) {
         $rootScope.modalVisible = (typeof state !== 'undefined') ? state : !$rootScope.modalVisible;
     };
+
+    // Clear filters when navigating to home
+    $rootScope.$on('$locationChangeSuccess', function () {
+        if ($location.path() === '/') {
+            PostFilters.clearFilters();
+        }
+    });
 }];


### PR DESCRIPTION
This pull request makes the following changes:
- Clears filters when user navigates to home

Test these changes by:
- Start a search and navigate elsewhere. Going back to home should clear the search term in the search box and mode context bar.

Fixes ushahidi/platform#1200 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/269)
<!-- Reviewable:end -->
