### PR TITLE
Only display "DELETE THIS ROLE" sheet in role edit template for unpro…

### DIFF
--- a/server/www/templates/settings/roles/roles-edit.html
+++ b/server/www/templates/settings/roles/roles-edit.html
@@ -66,7 +66,7 @@
                    </fieldset>
                 </div>
 
-                <div class="form-sheet" ng-show="role.id">
+                <div ng-if="!role.protected" class="form-sheet" ng-show="role.id">
                    <div class="form-sheet-summary">
                        <h3 class="form-sheet-title" translate>role.delete_role</h3>
                    </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds an ng-if to the "DELETE THIS ROLE" sheet in the role edit template so that is is hidden if the role is protected (i.e. protected attribute is true)

Test these changes by:
- view a protected role (e.g. /settings/roles/1). There should be no DELETE THIS ROLE option
- view an unprotected role. There should be a DELETE THIS ROLE option

Fixes ushahidi/platform#1017 .

Ping @ushahidi/platform

…tected roles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/270)
<!-- Reviewable:end -->
