### PR TITLE
1241 Added navigate away feature to slider service

### DIFF
--- a/app/common/notifications/slider.directive.js
+++ b/app/common/notifications/slider.directive.js
@@ -19,6 +19,7 @@ function Slider($timeout, $compile, SliderService, ModalService) {
         $scope.icon = false;
         $scope.iconClass = {};
         $scope.showCloseButton = true;
+        $scope.closeOnNavigate = false;
         // Callbacks
         $scope.closeButtonClicked = closeButtonClicked;
 
@@ -31,11 +32,14 @@ function Slider($timeout, $compile, SliderService, ModalService) {
         // Run clean up on scope destroy (probably never happens)
         $scope.$on('$destroy', cleanUp);
 
+        // Close slider on navigation if feature enabled
+        $scope.$on('$locationChangeStart', navigateClose);
+
         // Bind to modal service open/close events
         SliderService.onOpen(open, $scope);
         SliderService.onClose(close, $scope);
 
-        function open(ev, template, icon, iconClass, scope, closeOnTimeout, showCloseButton) {
+        function open(ev, template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate) {
             // If we're inside a modal, modal must be open
             if ((typeof $scope.insideModal !== 'undefined') !== ModalService.getState()) {
                 // Ignore, the other slider can open
@@ -64,6 +68,13 @@ function Slider($timeout, $compile, SliderService, ModalService) {
                 $scope.showCloseButton = true;
             } else {
                 $scope.showCloseButton = showCloseButton;
+            }
+
+            // If closeOnNavigate isn't passed, default to false
+            if (typeof closeOnNavigate === 'undefined') {
+                $scope.closeOnNavigate = true;
+            } else {
+                $scope.closeOnNavigate = closeOnNavigate;
             }
 
             // Default closeOnTimeout to true
@@ -96,6 +107,12 @@ function Slider($timeout, $compile, SliderService, ModalService) {
                 $timeout.cancel(closeTimeout);
             }
             sliderContent.html('');
+        }
+
+        function navigateClose() {
+            if ($scope.closeOnNavigate) {
+                close();
+            }
         }
 
         function closeButtonClicked(context) {

--- a/app/common/notifications/slider.directive.js
+++ b/app/common/notifications/slider.directive.js
@@ -72,7 +72,7 @@ function Slider($timeout, $compile, SliderService, ModalService) {
 
             // If closeOnNavigate isn't passed, default to false
             if (typeof closeOnNavigate === 'undefined') {
-                $scope.closeOnNavigate = true;
+                $scope.closeOnNavigate = false;
             } else {
                 $scope.closeOnNavigate = closeOnNavigate;
             }

--- a/app/common/notifications/slider.service.js
+++ b/app/common/notifications/slider.service.js
@@ -14,18 +14,18 @@ function SliderService($rootScope, $q, $templateRequest) {
         onClose: onClose
     };
 
-    function openUrl(templateUrl, icon, iconClass, scope, closeOnTimeout, showCloseButton) {
+    function openUrl(templateUrl, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate) {
         deferredOpen.promise.then(function () {
             // Load template
             $templateRequest(templateUrl).then(function (template) {
-                $rootScope.$emit('slider:open', template, icon, iconClass, scope, closeOnTimeout, showCloseButton);
+                $rootScope.$emit('slider:open', template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate);
             });
         });
     }
 
-    function openTemplate(template, icon, iconClass, scope, closeOnTimeout, showCloseButton) {
+    function openTemplate(template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate) {
         deferredOpen.promise.then(function () {
-            $rootScope.$emit('slider:open', template, icon, iconClass, scope, closeOnTimeout, showCloseButton);
+            $rootScope.$emit('slider:open', template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate);
         });
     }
 

--- a/app/post/views/post-view.service.js
+++ b/app/post/views/post-view.service.js
@@ -23,7 +23,7 @@ function (
                     '<p><strong>{{noPostText["post.there_are_no_posts"]}}</strong>{{noPostText["post.in_this_deployment"]}}</p>' +
                     '<add-post-text-button></add-post-text-button>' +
                     '<button class="button-flat message-trigger" ng-click="close()">Dismiss</button>',
-                'file', false, scope, false, false);
+                'file', false, scope, false, false, true);
             });
 
         }


### PR DESCRIPTION
This pull request makes the following changes:
- Adding closeOnNavigate feature to slider service

Test these changes by:
- With no posts in system visit the Timeline view, you should see a notification telling you that there are no posts and you can add one
- Without dismissing the notification, visit a different view, the slider should close
- On viewing timeline again the slider should reappear

Fixes ushahidi/platform#1241

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/275)
<!-- Reviewable:end -->
