### PR TITLE
Do not redirect after creating a collection

### DIFF
--- a/app/set/directives/collections/editor.directive.js
+++ b/app/set/directives/collections/editor.directive.js
@@ -36,13 +36,11 @@ function CollectionEditorController(
     RoleEndpoint
 ) {
     $scope.collectioneditorVisible = false;
-    $scope.redirectToCollectionListing = false;
     $scope.isAdmin = $rootScope.isAdmin;
     $scope.views = ViewHelper.views();
 
     $scope.setBasicCollection = setBasicCollection;
     $scope.featuredEnabled = featuredEnabled;
-    $scope.continueFlow = continueFlow;
     $scope.cancel = cancel;
     $scope.saveCollection = saveCollection;
     $scope.deleteCollection = deleteCollection;
@@ -77,7 +75,6 @@ function CollectionEditorController(
             // This is a stop-gap until we have a data layer to maintain
             // state
             $scope.posts = posts;
-            $scope.redirectToCollectionListing = true;
         }
         $scope.collectionEditorVisible = true;
     });
@@ -92,10 +89,6 @@ function CollectionEditorController(
 
     function featuredEnabled() {
         return $rootScope.hasPermission('Manage Posts');
-    }
-
-    function continueFlow(collection) {
-        $scope.redirectToCollectionListing ? $rootScope.$emit('collectionToggle:show:afterCreate', $scope.posts, collection) : $location.path('/collections/' + collection.id);
     }
 
     function cancel() {
@@ -120,9 +113,7 @@ function CollectionEditorController(
             $scope.collection = _.clone(collection);
             $scope.collectionEditorVisible = false;
             $rootScope.$broadcast('collection:update');
-            $scope.setBasicCollection();
-            $scope.continueFlow(collection);
-
+            Notify.notify('notify.collection.created_collection', {collection: collection.name});
         }, function (errorResponse) {
             Notify.apiErrors(errorResponse);
         });

--- a/app/set/directives/collections/listing.directive.js
+++ b/app/set/directives/collections/listing.directive.js
@@ -187,21 +187,4 @@ function CollectionListingController(
         $scope.isToggleMode = true;
         $scope.loadCollections();
     });
-
-    // Show listing modal Collection Toggle mode
-    // This occurs post creation of a new collection
-    // The event expects the post(s) which should be added to the collection
-    // and the newly created collection
-    $rootScope.$on('collectionToggle:show:afterCreate', function (event, posts, collection) {
-        // Get posts back so that collection listing modal does not have to maintain state
-        $scope.posts = posts;
-        // Add posts to the newly created collection
-        $scope.addToCollection(collection);
-        // Show the modal
-        $scope.collectionListingVisible = true;
-        // Set the modal to toggle modal
-        $scope.isToggleMode = true;
-        // Refresh the collections to ensure the list is up todate
-        $scope.loadCollections();
-    });
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Creating a new collection closes the modal without redirecting to collection's landing page.

Test these changes by:
- Create a new collection and save it. The modal should close with a success message after the collection is created.

Fixes ushahidi/platform#1138 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/276)
<!-- Reviewable:end -->
