### PR TITLE
Updated fab button to hide correctly on listing toolbar active

### DIFF
--- a/app/mock-backend-config.js
+++ b/app/mock-backend-config.js
@@ -18,7 +18,8 @@ angular.module('e2e-mocks', ['ngMockE2E'])
             'config/site': require('../mocked_backend/api/v3/config/site.json'),
             'config/map': require('../mocked_backend/api/v3/config/map.json'),
             'config/features': require('../mocked_backend/api/v3/config/features.json'),
-            'config': require('../mocked_backend/api/v3/config.json')
+            'config': require('../mocked_backend/api/v3/config.json'),
+            'tags': require('../mocked_backend/api/v3/tags.json')
         },
 
         getResultForResource = function (resourceName, offset, limit) {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ng-showdown": "rjmackay/ng-showdown#patch-1",
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.3",
-    "platform-pattern-library": "ushahidi/platform-pattern-library#v3.4.1",
+    "platform-pattern-library": "ushahidi/platform-pattern-library#gh-pages",
     "selection-model": "jtrussell/angular-selection-model.git",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ng-showdown": "rjmackay/ng-showdown#patch-1",
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.3",
-    "platform-pattern-library": "ushahidi/platform-pattern-library#gh-pages",
+    "platform-pattern-library": "ushahidi/platform-pattern-library#v3.4.5",
     "selection-model": "jtrussell/angular-selection-model.git",
     "underscore": "^1.7.0"
   },

--- a/server/www/templates/settings/categories/categories.html
+++ b/server/www/templates/settings/categories/categories.html
@@ -21,7 +21,7 @@
         <!-- toolbar -->
         <div class="toolbar">
             <div class="fab">
-                <a ng-href="/settings/categories/create" type="button" class="button button-alpha button-fab">
+                <a ng-href="/settings/categories/create" type="button" class="button button-alpha button-fab" ng-class="{'disabled': selectedCategories.length}">
                     <svg class="iconic">
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#plus"></use>
                     </svg>

--- a/server/www/templates/settings/users/users.html
+++ b/server/www/templates/settings/users/users.html
@@ -21,7 +21,7 @@
         <!-- toolbar -->
         <div class="toolbar">
             <div class="fab">
-                <a ng-href="/settings/users/create" type="button" class="button button-alpha button-fab">
+                <a ng-href="/settings/users/create" type="button" class="button button-alpha button-fab" ng-class="{'disabled': selectedUsers.length}">
                     <svg class="iconic">
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#plus"></use>
                     </svg>


### PR DESCRIPTION
This pull request makes the following changes:
- Added disable class to fab button on listing-toolbar active
- Pinned develop to gh-pages version of PL

Test these changes by:
- On User and Category page, select one of the elements, the fab button (yellow plus button for adding new entity) should hide and the listing toolbar should display
- On deselect the fab should reappear and listing toolbar should hide

Fixes ushahidi/platform#1248

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/277)
<!-- Reviewable:end -->
