### PR TITLE
Category label should be hidden when there are no actegories to selec…

### DIFF
--- a/server/www/templates/posts/modify/post-tabs.html
+++ b/server/www/templates/posts/modify/post-tabs.html
@@ -55,7 +55,7 @@
             </div>
         </div>
 
-        <fieldset id="categories" ng-show="isFirstStage(visibleStage)">
+        <fieldset id="categories" ng-show="isFirstStage(visibleStage) && categories.length">
             <legend translate="post.modify.form.categories">Categories</legend>
             <div class="form-field checkbox" ng-repeat="category in categories">
                 <label for="cat1">


### PR DESCRIPTION
This pull request makes the following changes:
- Updated category fieldset to display only when categories available

Test these changes by:
- When adding/editing a post with categories in the system then you should see categories appear on the post add/edit view
- When adding a post with no cateogries in the system then you should see no category label on the view

Fixes ushahidi/platform#1155

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/282)
<!-- Reviewable:end -->
