### PR TITLE
Hide nested options in until parent is selected

### DIFF
--- a/app/common/directives/publish-selector.js
+++ b/app/common/directives/publish-selector.js
@@ -26,7 +26,9 @@ function (
 
             $scope.canSeeThis = function () {
                 if ($scope.post.published_to && $scope.post.published_to.length) {
-                    return $scope.post.published_to.join(', ');
+                    return _.map($scope.post.published_to, function (role) {
+                        return $scope.roles[role].display_name;
+                    }).join(', ');
                 } else if ($scope.post.status === 'draft') {
                     return $translate.instant('post.just_you');
                 } else {
@@ -35,7 +37,7 @@ function (
             };
 
             RoleEndpoint.query().$promise.then(function (roles) {
-                $scope.roles = roles;
+                $scope.roles = _.indexBy(roles, 'name');
             });
 
             $scope.checkIfAllSelected = function () {

--- a/app/common/directives/publish-selector.js
+++ b/app/common/directives/publish-selector.js
@@ -22,6 +22,7 @@ function (
             RoleEndpoint,
             _
         ) {
+            $scope.showRoles = !!$scope.post.published_to.length;
 
             $scope.canSeeThis = function () {
                 if ($scope.post.published_to && $scope.post.published_to.length) {
@@ -44,13 +45,14 @@ function (
             $scope.toggleRole = function (role) {
                 if (role === 'draft' || role === '') {
                     $scope.post.published_to = [];
+                    $scope.showRoles = false;
                 } else if ($scope.checkIfAllSelected()) {
                     // All check boxes selected, therefore publish to everyone
                     $scope.post.published_to = [];
+                    $scope.showRoles = false;
                 }
 
                 $scope.post.status = role === 'draft' ? role : 'published';
-
             };
 
             $scope.toggleRolesView = function () {

--- a/app/common/directives/publish-selector.js
+++ b/app/common/directives/publish-selector.js
@@ -53,6 +53,9 @@ function (
 
             };
 
+            $scope.toggleRolesView = function () {
+                $scope.showRoles = true;
+            };
         }];
     return {
         restrict: 'E',

--- a/server/www/templates/common/publish-selector/publish-selector.html
+++ b/server/www/templates/common/publish-selector/publish-selector.html
@@ -16,7 +16,7 @@
         <div class="form-fieldgroup" dropdown>
             <div class="form-field radio">
                 <input
-                    name="{{post.id}}_draft"
+                    name="{{post.id}}"
                     id="{{post.id}}_draft"
                     value="draft"
                     type="radio"
@@ -27,7 +27,7 @@
 
             <div class="form-field radio">
                 <input
-                    name="{{post.id}}_everyone"
+                    name="{{post.id}}"
                     id="{{post.id}}_everyone"
                     value=""
                     type="radio"
@@ -36,11 +36,14 @@
                 <label for="{{post.id}}_everyone" translate="post.everyone">Everyone</label>
             </div>
             <div class="form-field radio">
-                <input
-                    auto-close="disabled"
-                    ng-checked="post.published_to.length"
-                    type="radio" ng-click="toggleRolesView()">
-                <label for="{{post.id}}_everyone" translate="post.specific_roles">Specific roles...</label>
+              <input
+                  name="{{post.id}}"
+                  id="{{post.id}}_roles"
+                  auto-close="disabled"
+                  ng-checked="post.published_to.length"
+                  value="roles"
+                  type="radio" ng-click="toggleRolesView()">
+                <label for="{{post.id}}_roles" translate="post.specific_roles">Specific roles...</label>
                 <div class="form-fieldgroup" dropdown-menu ng-show="showRoles">
                     <div class="form-field checkbox" ng-repeat="role in roles">
                         <input

--- a/server/www/templates/common/publish-selector/publish-selector.html
+++ b/server/www/templates/common/publish-selector/publish-selector.html
@@ -13,7 +13,7 @@
       </svg>
     </legend>
     <div class="dropdown-menu init" dropdown-menu>
-        <div class="form-fieldgroup">
+        <div class="form-fieldgroup" dropdown>
             <div class="form-field radio">
                 <input
                     name="{{post.id}}_draft"
@@ -35,14 +35,13 @@
                     ng-click="toggleRole('')">
                 <label for="{{post.id}}_everyone" translate="post.everyone">Everyone</label>
             </div>
-            <div class="form-field radio" dropdown>
+            <div class="form-field radio">
                 <input
-                    dropdown-toggle
                     auto-close="disabled"
                     ng-checked="post.published_to.length"
-                    type="radio">
+                    type="radio" ng-click="toggleRolesView()">
                 <label for="{{post.id}}_everyone" translate="post.specific_roles">Specific roles...</label>
-                <div class="form-fieldgroup" dropdown-menu>
+                <div class="form-fieldgroup" dropdown-menu ng-show="showRoles">
                     <div class="form-field checkbox" ng-repeat="role in roles">
                         <input
                             id="{{role.id}}"


### PR DESCRIPTION
This pull request makes the following changes:
- Hides nested options for fieldset until parent is selected.

Test these changes by:
- Edit a post and select "Who can see this" from the dropdown.
- Select "Specific roles" to see nested options.

Fixes ushahidi/platform#1131 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/283)
<!-- Reviewable:end -->
