### PR TITLE
1101 fix edit/add keywords depending on presence of id

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -33,6 +33,7 @@
         "share": "Share",
         "general" : "General",
         "surveys" : "Surveys",
+        "add_survey" : "Add Survey",
         "edit_survey" : "Edit Survey",
         "data_sources" : "Data Sources",
         "import" : "Import",

--- a/app/setting/directives/setting-survey-editor.directive.js
+++ b/app/setting/directives/setting-survey-editor.directive.js
@@ -288,7 +288,8 @@ function SurveyEditorController(
             ModalService.close();
         }
         $scope.editAttribute = attribute;
-        ModalService.openTemplate('<survey-attribute-editor></survey-attribute-editor>', 'survey.edit_field', '', $scope, true, true);
+        var title = attribute.id ? 'survey.edit_field' : 'survey.add_field';
+        ModalService.openTemplate('<survey-attribute-editor></survey-attribute-editor>', title, '', $scope, true, true);
     }
 
     function addNewAttribute(attribute) {

--- a/server/www/templates/settings/surveys/modify/editor.html
+++ b/server/www/templates/settings/surveys/modify/editor.html
@@ -7,7 +7,8 @@
                 <li><a href="/settings" translate>app.settings</a></li>
                 <li><a href="/settings/surveys" translate>app.surveys</a></li>
             </ol>
-            <h1 class="mode-context-title" translate>app.edit_survey</h1>
+            <h1 ng-show="survey.id" class="mode-context-title" translate>app.edit_survey</h1>
+            <h1 ng-show="!survey.id" class="mode-context-title" translate>app.add_survey</h1>
         </header>
 
         <span class="mode-context-trigger" dropdown-toggle>
@@ -47,7 +48,7 @@
                 <div class="form-field form-field-adapt">
                     <label translate>app.description</label>
                     <textarea name="description" data-min-rows='1' rows='1' ng-model="survey.description"></textarea>
-                </div>                
+                </div>
                 <color-picker color-container="survey"></color-picker>
                 <fieldset class="custom-fieldset init" dropdown auto-close="outsideClick">
                     <legend class="dropdown-trigger init" data-toggle="dropdown-menu" dropdown-toggle>


### PR DESCRIPTION
This pull request makes the following changes:
- Chnges Add/Edit keywords for survey interface to appropriate based on whether an entity, attribute/survey has yet gotten an id

Test these changes by:
- Create new survey you should see Add Survey in breadcrumb
- Edit existing survey you should see Edit Survey in breadcrumb
- Create new attribute for task you should see title as Add Field
- Create new attribute for task you should see action button as Add & Close
- Edit existing saved attribute for task you should see title as Edit Field
- Edit existing saved attribute for task you should see action button as Update & Close


Fixes ushahidi/platform#1101

Ping @ushahidi/platform

… for entity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/284)
<!-- Reviewable:end -->
