### PR TITLE
Changed gravatar links to use https to resolve mied content warning

### DIFF
--- a/server/www/templates/frame/mode-bar.html
+++ b/server/www/templates/frame/mode-bar.html
@@ -72,7 +72,7 @@
 
             <li ng-show="currentUser">
                 <a ng-click="viewAccountSettings()">
-                    <img class="avatar" src="http://www.gravatar.com/avatar/{{ currentUser.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ currentUser.realname }}"/>
+                    <img class="avatar" src="https://www.gravatar.com/avatar/{{ currentUser.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ currentUser.realname }}"/>
                     <span class="label">{{currentUser.realname || currentUser.email}}</span>
                 </a>
             </li>

--- a/server/www/templates/posts/post-metadata.html
+++ b/server/www/templates/posts/post-metadata.html
@@ -1,6 +1,6 @@
 <div class="metadata">
     <!-- todo: cleanup / combine this line into a single translation string -->
-    <span ng-show="post.user" class="metadata-author"><img src="http://www.gravatar.com/avatar/{{ post.user.gravatar || '00000000000000000000000000000000' }}?d=retro&s=40" class="avatar">{{ post.user.realname }}</span>
+    <span ng-show="post.user" class="metadata-author"><img src="https://www.gravatar.com/avatar/{{ post.user.gravatar || '00000000000000000000000000000000' }}?d=retro&s=40" class="avatar">{{ post.user.realname }}</span>
     <span ng-show="post.contact" class="metadata-author">{{ post.contact.contact }}</span>
 
     <span title="{{ displayTimeFull }}">{{ displayTime }}</span>

--- a/server/www/templates/settings/users/users.html
+++ b/server/www/templates/settings/users/users.html
@@ -56,7 +56,7 @@
 
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
-                            <img class="avatar" src="http://www.gravatar.com/avatar/{{ user.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ user.realname }}">
+                            <img class="avatar" src="https://www.gravatar.com/avatar/{{ user.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ user.realname }}">
                         </div>
 
                         <h2 class="listing-item-title"><a ng-href="/settings/users/{{user.id}}">{{user.realname}}</a></h2>


### PR DESCRIPTION
This pull request makes the following changes:
- Switches to using https for gravatar img request to resolve warning for mixed content

Test these changes by:
- To be decdided

Fixes ushahidi/platform#1300

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/294)
<!-- Reviewable:end -->
