### PR TITLE
ushahidi/platform#1320 add 'deploy' task to gulp with cachebusting of css and js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vault.txt
 *.swp
 *.svg
 server/www/img/icons/
+server/deploy

--- a/docker/build.run.sh
+++ b/docker/build.run.sh
@@ -36,7 +36,7 @@ build() {
   npm install
   gulp transifex-download
   gulp build
-  cp ./server/rewrite.htaccess ./server/www/
+  cp ./server/rewrite.htaccess ./server/deploy/
 }
 
 # Bundle the build into a tarball

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jscs"
   ],
   "devDependencies": {
+    "async": "^2.0.1",
     "body-parser": "^1.15.1",
     "brfs": "^1.2.0",
     "browserify": "^13.0.1",
@@ -36,6 +37,7 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-bump": "^2.1.0",
+    "gulp-cachebust": "^0.0.6",
     "gulp-coveralls": "^0.1.3",
     "gulp-gzip": "1.4.0",
     "gulp-jscs": "^3.0.2",


### PR DESCRIPTION
This pull request makes the following changes:
-
Adds a 'deploy' gulp task that makes a copy of the build, cachebusting some of the resulting assets, specifically: css and js files (tried to do images too, but references are too spread around).

Fixed the 'transifex-download' task to provide feedback of when it's complete (so it can be used as a dependency in other tasks).

The 'release' task is now based on this 'deploy' task so we distribute bundles with cachebusted filenames.

Test these changes by:
-
Run gulp deploy

Fixes ushahidi/platform#1320 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/304)
<!-- Reviewable:end -->
