### PR TITLE
add transifex credential inputs to heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,14 @@
       "description" : "A deployment of ushahidi/platform to use",
       "value" : "https://ushahidi-platform-api-master.herokuapp.com",
       "required" : true
+    },
+    "TX_USERNAME": {
+      "description" : "Your username in transifex in order to download translation files (optional)",
+      "required": false
+    },
+    "TX_PASSWORD": {
+      "description": "Your password in transifex (optional)",
+      "required": false
     }
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,8 @@ var gulp         = require('gulp'),
     gzip         = require('gulp-gzip'),
     jscs         = require('gulp-jscs'),
     dotenv       = require('dotenv'),
-    Transifex    = require('transifex');
+    Transifex    = require('transifex'),
+    runSeq       = require('run-sequence');
 
 // Grab env vars from .env file
 dotenv.load({silent: true});
@@ -392,7 +393,13 @@ gulp.task('release', ['transifex-download'], function () {
 /**
  * Task `heroku:dev` - builds app for heroku
  */
-gulp.task('heroku:dev', ['build'], function () {});
+gulp.task('heroku:dev', ['build'], function (done) {
+    if (process.env.TX_USERNAME && process.env.TX_PASSWORD) {
+        runSeq('transifex-download', done);
+    } else {
+        done();
+    }
+});
 
 /**
  * Task: `transifex-download`

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "phantomjs-prebuilt": "^2.1.7",
     "pre-commit": "^1.1.2",
     "protractor": "^4.0.0",
+    "run-sequence": "^1.2.2",
     "serve-static": "^1.10.0",
     "transifex": "^1.4.3",
     "underscore.string": "^3.3.4",


### PR DESCRIPTION
This pull request makes the following changes:
-
Enables heroku deployers to pull the transifex translations when deploying the client.

Test these changes by:
-

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/316)
<!-- Reviewable:end -->
