### PR TITLE
Changed task display to show alert message when empty

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -479,6 +479,7 @@
         "status_archived" : "This post is archived",
         "modify" : {
             "intro" : "Select survey:",
+            "no_task_values": "There are currently no saved values for this task.",
             "create_type" : "Create {{type}}",
             "edit_type" : "Edit {{type}}: {{title}}",
             "add_a_post" : "Add a post",

--- a/app/post/detail/post-detail.controller.js
+++ b/app/post/detail/post-detail.controller.js
@@ -120,9 +120,8 @@ function (
             }
 
             _.each(tasks, function (task) {
-
                 // Set post task id
-                // NOTE: This assumes that there is only one Post task per Post
+                // NOTE: This assumes that there is only one Post Task per Post
                 if (task.type === 'post') {
                     $scope.post_task = task;
                 } else {
@@ -139,22 +138,21 @@ function (
             });
 
             $scope.tasks = tasks;
-            $scope.removeEmptyTasks();
+
+            // Figure out which tasks have values
+            $scope.tasks_with_attributes = [];
+            _.each($scope.post.values, function (value, key) {
+                if ($scope.form_attributes[key]) {
+                    $scope.tasks_with_attributes.push($scope.form_attributes[key].form_stage_id);
+                }
+            });
+            $scope.tasks_with_attributes = _.uniq($scope.tasks_with_attributes);
+
         });
     }
 
-    $scope.removeEmptyTasks = function () {
-        var tasks_with_attributes = [];
-        _.each($scope.post.values, function (value, key) {
-            if ($scope.form_attributes[key]) {
-                tasks_with_attributes.push($scope.form_attributes[key].form_stage_id);
-            }
-        });
-        tasks_with_attributes = _.uniq(tasks_with_attributes);
-
-        $scope.tasks = _.filter($scope.tasks, function (task) {
-            return _.contains(tasks_with_attributes, task.id);
-        });
+    $scope.taskHasValues = function (task) {
+        return _.contains($scope.tasks_with_attributes, task.id);
     };
 
     $scope.showTasks = function () {

--- a/app/post/detail/post-detail.controller.js
+++ b/app/post/detail/post-detail.controller.js
@@ -234,23 +234,6 @@ function (
         }
     });
 
-    $scope.toggleCompletedTask = function (task) {
-        // @todo how to validate this before saving
-        if (_.includes($scope.post.completed_stages, task.id)) {
-            $scope.post.completed_stages = _.without($scope.post.completed_stages, task.id);
-        } else {
-            $scope.post.completed_stages.push(task.id);
-        }
-
-        PostEndpoint.update($scope.post).$promise
-            .then(function () {
-                Notify.notify('notify.post.stage_save_success', {stage: task.label});
-                task.completed = !task.completed;
-            }, function (errorResponse) {
-                Notify.apiErrors(errorResponse);
-            });
-    };
-
     $scope.publishPostTo = function (updatedPost) {
         // first check if tasks required have been marked complete
         var requiredTasks = _.where($scope.tasks, {required: true}),

--- a/server/www/templates/posts/detail.html
+++ b/server/www/templates/posts/detail.html
@@ -121,6 +121,12 @@
           </ul>
         </nav>
         <div class="listing-item tasks-tabs tabs-target active">
+          <div class="alert"
+              ng-repeat="task in tasks"
+              ng-if="!taskHasValues(task)"
+              ng-show="task.id === visibleTask">
+                <p translate="post.modify.no_task_values">There are currently no saved values for this task.</p>
+          </div>
           <div
             ng-repeat="(key,value) in post.values"
             ng-if="form_attributes[key].type === 'media' && !isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)"


### PR DESCRIPTION
This pull request makes the following changes:
- Changed tasks on post detail to display irrespective of whether they contain value or not
- Add message stating tasks that are empty currently have no values
- Removed unneeded toggleCompletionTask code as post detail no longer has that functionality

Test these changes by:
- Using a post that has tasks, fill in the post values but leave the task values empty, save and view the detail page, the task should appear at the bottom but it should contain only a message stating there are currently no saved values for this task.

Fixes ushahidi/platform# .

Ping @ushahidi/platform

…ther than not displaying task at all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/327)
<!-- Reviewable:end -->
