### PR TITLE
approach to building the pattern library that is friendlier to custom…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ vault.txt
 *.swp
 *.svg
 server/www/img/icons/
+vendor/*
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "AGPL-3.0",
   "homepage": "https://github.com/ushahidi/platform-client",
   "scripts": {
+    "postinstall": "gulp build-pl",
     "build": "gulp build",
     "watch": "gulp",
     "start": "gulp node-server",


### PR DESCRIPTION
This pull request makes the following changes:
-
Allows the pattern library to be overridden by contents in vendor/platform-pattern-library . I've been struggling in custom deployments with this, and the latest changes have made it nearly impossible (for whatever obscure reason only npm knows)

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/328)
<!-- Reviewable:end -->
