### PR TITLE
Update ng-showdown and allow markdown in site description

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -15,7 +15,7 @@ require('angular-filter');
 require('angular-local-storage');
 require('checklist-model');
 require('ngGeolocation/ngGeolocation');
-require('ng-showdown/src/ng-showdown');
+require('ng-showdown');
 window.d3 = require('d3'); // Required for nvd3
 require('./common/wrapper/nvd3-wrapper');
 require('angular-nvd3/src/angular-nvd3');
@@ -68,7 +68,7 @@ angular.module('app',
         'angular-datepicker',
         'leaflet-directive',
         'angular.filter',
-        'showdown',
+        'ng-showdown',
         'ngGeolocation',
         'nvd3',
         'angular-cache',

--- a/app/main/activity/activity.html
+++ b/app/main/activity/activity.html
@@ -14,7 +14,7 @@
         </span>
 
         <div class="mode-context-body">
-            <p ng-bind="nav.site.description"></p>
+            <p markdown-to-html="nav.site.description"></p>
         </div>
     </div>
 

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -69,7 +69,7 @@
         <div
           ng-if="post.content"
           class="postcard-field">
-          <p sd-model-to-html="post.content"></p>
+          <p markdown-to-html="post.content"></p>
         </div>
 
         <div

--- a/app/main/posts/views/main.html
+++ b/app/main/posts/views/main.html
@@ -14,7 +14,7 @@
         </span>
 
         <div class="mode-context-body">
-            <p ng-bind="nav.site.description"></p>
+            <p markdown-to-html="nav.site.description"></p>
 
             <mode-context-form-filter></mode-context-form-filter>
 

--- a/app/settings/settings-list.html
+++ b/app/settings/settings-list.html
@@ -14,7 +14,7 @@
         </span>
 
         <div class="mode-context-body">
-            <p ng-bind="nav.site.description"></p>
+            <p markdown-to-html="nav.site.description"></p>
         </div>
     </div>
     <main role="main">

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "leaflet.markercluster": "0.5.0",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
-    "ng-showdown": "rjmackay/ng-showdown#patch-1",
+    "ng-showdown": "^1.1.0",
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "ushahidi-platform-pattern-library": "3.5.0",


### PR DESCRIPTION
This pull request makes the following changes:
- Update ng-showdown 
- Allow markdown in site description
- Use markdown-to-html directive in post detail (old directive was deprecated)

Test these changes by:
- Add markdown to posts and site description
- View the timeline

Refs ushahidi/platform#1403

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/345)
<!-- Reviewable:end -->
