### PR TITLE
Editable post date follow up changes

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -248,6 +248,8 @@
             "q": "Keyword",
             "created_after": "Start date",
             "created_before": "End date",
+            "date_after": "Start date",
+            "date_before": "End date",
             "center_point": "Location",
             "tags": "Category",
             "form": "Survey",

--- a/app/main/posts/common/post-metadata.directive.js
+++ b/app/main/posts/common/post-metadata.directive.js
@@ -39,17 +39,17 @@ function PostMetadataDirective(
             }
 
             function formatDates() {
-                var created = moment($scope.post.created),
+                var postDate = moment($scope.post.post_date),
                     now = moment();
 
-                if (now.isSame(created, 'day')) {
-                    $scope.displayTime = created.fromNow();
-                } else if (now.isSame(created, 'week') && $scope.hideDateThisWeek) {
-                    $scope.displayTime = created.format('LT');
+                if (now.isSame(postDate, 'day')) {
+                    $scope.displayTime = postDate.fromNow();
+                } else if (now.isSame(postDate, 'week') && $scope.hideDateThisWeek) {
+                    $scope.displayTime = postDate.format('LT');
                 } else {
-                    $scope.displayTime = created.format('LL');
+                    $scope.displayTime = postDate.format('LL');
                 }
-                $scope.displayTimeFull = created.format('LLL');
+                $scope.displayTimeFull = postDate.format('LLL');
             }
 
             function visibleTo(post) {

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -268,17 +268,4 @@ function (
             Notify.apiErrors(errorResponse);
         });
     };
-
-    function formatDate() {
-        var created = moment($scope.post.update || $scope.post.created),
-            now = moment();
-
-        if (now.isSame(created, 'day')) {
-            $scope.displayTime = created.fromNow();
-        } else {
-            $scope.displayTime = created.format('LLL');
-        }
-    }
-
-    formatDate();
 }];

--- a/app/main/posts/modify/post-entity.service.js
+++ b/app/main/posts/modify/post-entity.service.js
@@ -11,7 +11,8 @@ function (
             locale: CONST.DEFAULT_LOCALE,
             values: {},
             completed_stages: [],
-            published_to: []
+            published_to: [],
+            post_date: new Date()
         }, data);
     };
 }];

--- a/app/main/posts/modify/post-toolbox.directive.js
+++ b/app/main/posts/modify/post-toolbox.directive.js
@@ -77,10 +77,10 @@ function PostToolboxDirective(
         }
 
         function formatDates() {
-            $scope.displayCreated = moment($scope.post.created).format('LT MMMM D, YYYY');
+            $scope.displayCreated = moment($scope.post.created).format('LLL');
 
             if ($scope.post.updated) {
-                $scope.displayUpdated = moment($scope.post.updated).format('LT MMMM D, YYYY');
+                $scope.displayUpdated = moment($scope.post.updated).format('LLL');
             }
         }
     }

--- a/app/main/posts/modify/post-toolbox.html
+++ b/app/main/posts/modify/post-toolbox.html
@@ -89,23 +89,13 @@
 
     <div class="toggle-content init" dropdown-menu>
       <fieldset>
-            <post-datetime ng-model="post.post_date"></post-datetime>
-            <div class="metadata">
-              <ul>
+        <post-datetime ng-model="post.post_date"></post-datetime>
+        <ul class="metadata">
             <li><span translate="post.created_at"></span> {{displayCreated}} <span translate-values="{ source : source }" translate="post.source"></span></li>
             <li ng-if="post.updated"><span translate="post.updated_at"></span> {{displayUpdated}}</li>
-          </ul>
-        </div>
+        </ul>
       </fieldset>
     </div>
-
-  </div>
-  <!-- FIXME: Remove after post timestamp dropdown is enabled -->
-  <div class="metadata">
-      <ul>
-          <li><span translate="post.created_at"></span> {{displayCreated}} <span translate-values="{ source : source }" translate="post.source"></span></li>
-          <li ng-if="post.updated"><span translate="post.updated_at"></span> {{displayUpdated}}</li>
-      </ul>
   </div>
 
   <!-- END: IF -->

--- a/app/main/posts/views/filters/active-filters.directive.js
+++ b/app/main/posts/views/filters/active-filters.directive.js
@@ -98,6 +98,12 @@ function ActiveFilters($translate, $filter, PostFilters, _, TagEndpoint, RoleEnd
             created_after : function (value) {
                 return $filter('date', 'longdate')(value);
             },
+            date_before : function (value) {
+                return $filter('date', 'longdate')(value);
+            },
+            date_after : function (value) {
+                return $filter('date', 'longdate')(value);
+            },
             status : function (value) {
                 return $translate.instant('post.' + value);
             }

--- a/app/main/posts/views/filters/filter-date.directive.js
+++ b/app/main/posts/views/filters/filter-date.directive.js
@@ -5,8 +5,8 @@ function DateSelectDirective() {
     return {
         restrict: 'E',
         scope: {
-            createdBeforeModel: '=',
-            createdAfterModel: '='
+            dateBeforeModel: '=',
+            dateAfterModel: '='
         },
         controller: DateSelectController,
         templateUrl: 'templates/main/posts/views/filters/filter-date.html'

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -7,7 +7,7 @@
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <input type="date" pick-a-date="createdAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="createdAfterModel" />
+            <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
         </div>
         <span class="date-joiner">to</span>
     </div>
@@ -19,7 +19,7 @@
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#calendar"></use>
             </svg>
         </div>
-        <input type="date" pick-a-date="createdBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="createdBeforeModel">
+        <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
     </div>
 
 </fieldset>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -29,7 +29,7 @@
             <filter-category ng-model="filters.tags"></filter-category>
             <filter-status ng-model="filters.status"></filter-status>
 
-            <filter-date created-after-model="filters.created_after" created-before-model="filters.created_before"></filter-date>
+            <filter-date date-after-model="filters.date_after" date-before-model="filters.date_before"></filter-date>
 
             <filter-location center-point-model="filters.center_point" within-km-model="filters.within_km"></filter-location>
         </div>

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -57,8 +57,8 @@ function PostFiltersService(_, FormEndpoint) {
     function getDefaults() {
         return {
             q: '',
-            created_after: '',
-            created_before: '',
+            date_after: '',
+            date_before: '',
             status: ['published', 'draft'],
             published_to: '',
             center_point: '',

--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -92,13 +92,13 @@ function PostListController(
                 yesterday = moment().subtract(1, 'days');
 
             $scope.groupedPosts = _.groupBy(postsResponse.results, function (post) {
-                var created = moment(post.created);
-                if (now.isSame(created, 'd')) {
+                var postDate = moment(post.post_date);
+                if (now.isSame(postDate, 'd')) {
                     return $translate.instant('nav.today');
-                } else if (yesterday.isSame(created, 'd')) {
+                } else if (yesterday.isSame(postDate, 'd')) {
                     return $translate.instant('nav.yesterday');
                 } else {
-                    return created.fromNow();
+                    return postDate.fromNow();
                 }
             });
             $scope.totalItems = postsResponse.total_count;


### PR DESCRIPTION
This pull request makes the following changes:
- Use post_date for default post display
- Fix markup on post toolbox
- Set default post_date value
- Use correct i18n date format
- Filter based on post_date

Test these changes by:
- Editing a post date
- Check the edited date is used on list/detail/map views
- Search and check the post_date is used

Fixes ushahidi/platform#1362

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/371)
<!-- Reviewable:end -->
