### PR TITLE
Adding v7 and allowing failure, as gulp: 3.9.1 currently has an issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ notifications:
 #  sauce_connect: true
 language: node_js
 matrix:
+  allow_failures:
+  - node_js: stable
   include:
   # Run everything with v5 (match production)
   # Skip e2e test during mustang build
@@ -22,6 +24,8 @@ matrix:
   - node_js: 5
     env: TEST_SUITE=lint
   - node_js: 5
+    env: TEST_SUITE=unit
+  - node_js: 6
     env: TEST_SUITE=unit
   - node_js: stable
     env: TEST_SUITE=unit


### PR DESCRIPTION
This pull request makes the following changes:
- Update travis config to cover v6 and v7 while allowing v7 to fail for the moment

Ping @ushahidi/platform

… with a dependency fail for graceful-fs which is unlikely to be fixed quickly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/382)
<!-- Reviewable:end -->
