### PR TITLE
Changing collection behaviour to include source field which determine…

### DIFF
--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -40,6 +40,10 @@ module.exports = [
         // Extend filters, always adding the current collection id
         var extendFilters = function (filters) {
             filters = angular.copy(filters, { set : [] });
+
+            // If collection was imported we want to show archived posts by default
+            collection.source === 'import' ? filters.status.push('archived') : null;
+
             filters.set.push(collection.id);
             return filters;
         };

--- a/app/settings/data-import/data-import.directive.js
+++ b/app/settings/data-import/data-import.directive.js
@@ -272,6 +272,7 @@ function (
                 collection.name = 'Imported ' + now;
                 collection.view = 'list';
                 collection.visible_to = ['admin'];
+                collection.source = 'import';
                 var calls = [];
                 CollectionEndpoint.save(collection).$promise.then(function (collection) {
                     _.each(post_ids, function (id) {


### PR DESCRIPTION
This pull request makes the following changes:
- Changes import collection creation to set the collection source field to imported
- Changes collection display logic to always display archived posts if a collection was created by an import

Test these changes by:
- [ ] Import a new csv with archived posts
- [ ] When you click 'see imported posts' or when you navigate to the collection created by the import, you should see posts of all statuses, 'published', 'under review', 'archived'
- [ ] Create a collection manually and add archived posts to it
- [ ] When viewing this collection the archived posts should not be shown by default

Fixes ushahidi/platform#1462

Ping @ushahidi/platform

…s if a collection originates from import and if so always displays archived posts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/383)
<!-- Reviewable:end -->
