### PR TITLE
Adding share functionality for client

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -6,6 +6,7 @@
         "can_see_this" : "can see this",
         "collections" : "Collections",
         "create_collection" : "Create collection",
+        "export_to_csv" : "Export to CSV",
         "create_new" : "Create new",
         "created_by" : "Created by {{author}}",
         "documentation": {

--- a/app/common/services/util.js
+++ b/app/common/services/util.js
@@ -1,12 +1,17 @@
 module.exports = [
     '_',
     'CONST',
+    '$window',
 function (
     _,
-    CONST
+    CONST,
+    $window
 ) {
 
     var Util = {
+        currentUrl: function () {
+            return $window.location.href;
+        },
         url: function (relative_url) {
             return CONST.BACKEND_URL + relative_url;
         },

--- a/app/main/posts/posts-module.js
+++ b/app/main/posts/posts-module.js
@@ -50,8 +50,12 @@ angular.module('ushahidi.posts', [])
 .directive('filterStatus', require('./views/filters/filter-status.directive.js'))
 .directive('filterLocation', require('./views/filters/filter-location.directive.js'))
 .directive('postActiveFilters', require('./views/filters/active-filters.directive.js'))
-.directive('postExport', require('./views/post-export.directive.js'))
 .service('PostFilters', require('./views/post-filters.service.js'))
+
+// Share
+.directive('postShare', require('./views/share/post-share.directive.js'))
+.directive('shareMenu', require('./views/share/share-menu.directive.js'))
+.directive('postExport', require('./views/share/post-export.directive.js'))
 // @todo move elsewhere? Used in post-view and activity
 .directive('postViewUnavailable', require('./views/post-view-unavailable.directive.js'))
 

--- a/app/main/posts/views/post-export.html
+++ b/app/main/posts/views/post-export.html
@@ -1,7 +1,0 @@
-<button type="button" ng-click="exportPosts()">
-	<div class="loading" ng-if="loading"><div class="line"></div><div class="line"></div><div class="line"></div></div>
-    <svg class="iconic" ng-hide="loading">
-      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#external-link"></use>
-    </svg>
-	<span class="button-label">Export</span>
-</button>

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -17,7 +17,7 @@
         <span class="button-label">Share</span>
       </button>
       -->
-      <post-export filters="filters"></post-export>
+      <post-share filters="filters"></post-share>
     </div>
     <!-- toolbar -->
 </div>

--- a/app/main/posts/views/share/post-export.directive.js
+++ b/app/main/posts/views/share/post-export.directive.js
@@ -4,12 +4,11 @@ PostExportDirective.$inject = [];
 function PostExportDirective() {
     return {
         restrict: 'E',
-        replace: true,
         scope: {
             filters: '='
         },
         controller: PostExportController,
-        templateUrl: 'templates/main/posts/views/post-export.html'
+        templateUrl: 'templates/main/posts/views/share/post-export.html'
     };
 }
 

--- a/app/main/posts/views/share/post-export.html
+++ b/app/main/posts/views/share/post-export.html
@@ -1,0 +1,1 @@
+<a ng-click="exportPosts()" translate="app.export_to_csv">Export to CSV</a>

--- a/app/main/posts/views/share/post-share.directive.js
+++ b/app/main/posts/views/share/post-share.directive.js
@@ -1,0 +1,36 @@
+module.exports = PostShareDirective;
+
+PostShareDirective.$inject = [];
+function PostShareDirective() {
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+            filters: '='
+        },
+        controller: PostShareController,
+        templateUrl: 'templates/main/posts/views/share/post-share.html'
+    };
+}
+
+PostShareController.$inject = [
+    '$scope',
+    'ModalService'
+];
+function PostShareController(
+    $scope,
+    ModalService
+) {
+    $scope.loading = false;
+    $scope.openShareMenu = openShareMenu;
+
+    activate();
+
+    function activate() {
+
+    }
+
+    function openShareMenu() {
+        ModalService.openTemplate('<share-menu></share-menu>', 'app.share', 'share', $scope, true, true);
+    }
+}

--- a/app/main/posts/views/share/post-share.html
+++ b/app/main/posts/views/share/post-share.html
@@ -1,0 +1,7 @@
+<button type="button" ng-click="openShareMenu()">
+	<div class="loading" ng-if="loading"><div class="line"></div><div class="line"></div><div class="line"></div></div>
+    <svg class="iconic" ng-hide="loading">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#share"></use>
+    </svg>
+	<span class="button-label" translate="app.share">Share</span>
+</button>

--- a/app/main/posts/views/share/share-menu.directive.js
+++ b/app/main/posts/views/share/share-menu.directive.js
@@ -19,7 +19,7 @@ function ShareMenuController(
     Util
 ) {
     $scope.loading = false;
-    $scope.shareUrl = Util.deploymentUrl();
+    $scope.shareUrl = Util.currentUrl();
     $scope.shareUrlEncoded = encodeURIComponent($scope.shareUrl);
 
     activate();

--- a/app/main/posts/views/share/share-menu.directive.js
+++ b/app/main/posts/views/share/share-menu.directive.js
@@ -1,0 +1,30 @@
+module.exports = ShareMenuDirective;
+
+ShareMenuDirective.$inject = [];
+function ShareMenuDirective() {
+    return {
+        restrict: 'E',
+        replace: true,
+        controller: ShareMenuController,
+        templateUrl: 'templates/main/posts/views/share/share-menu.html'
+    };
+}
+
+ShareMenuController.$inject = [
+    '$scope',
+    'Util'
+];
+function ShareMenuController(
+    $scope,
+    Util
+) {
+    $scope.loading = false;
+    $scope.shareUrl = Util.deploymentUrl();
+    $scope.shareUrlEncoded = encodeURIComponent($scope.shareUrl);
+
+    activate();
+
+    function activate() {
+
+    }
+}

--- a/app/main/posts/views/share/share-menu.html
+++ b/app/main/posts/views/share/share-menu.html
@@ -28,7 +28,7 @@
 										<div class="listing-item-image">
 												<img class="icon" src="../../img/twitter.png" alt="">
 										</div>
-										<h2 class="listing-item-title"><a ng-href="https://twitter.com/home?status={{shareUrl}}">Twitter</a></h2>
+										<h2 class="listing-item-title"><a ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
 								</div>
 						</div>
 

--- a/app/main/posts/views/share/share-menu.html
+++ b/app/main/posts/views/share/share-menu.html
@@ -1,0 +1,78 @@
+<div class="modal-body">
+    <form class="panel-body" name="form" ng-submit="submit()">
+				<div class="listing init">
+
+						<div class="listing-item">
+								<div class="listing-item-primary">
+										<div class="listing-item-image">
+												<img class="icon" src="../../img/facebook.png" alt="">
+										</div>
+										<h2 class="listing-item-title">
+											<div class="fb-share-button"
+												data-href="{{shareUrl}}"
+												data-layout="button_count"
+												data-size="large"
+												data-mobile-iframe="true">
+													<a class="fb-xfbml-parse-ignore"
+														target="_blank"
+														ng-href="https://www.facebook.com/sharer/sharer.php?u={{shareUrlEncoded}}&amp;src=sdkpreparse">
+															Facebook
+													</a>
+											</div>
+										</h2>
+								</div>
+						</div>
+
+						<div class="listing-item">
+								<div class="listing-item-primary">
+										<div class="listing-item-image">
+												<img class="icon" src="../../img/twitter.png" alt="">
+										</div>
+										<h2 class="listing-item-title"><a ng-href="https://twitter.com/home?status={{shareUrl}}">Twitter</a></h2>
+								</div>
+						</div>
+
+						<div class="listing-item" dropdown>
+							<div dropdown-toggle>
+								<div class="listing-item-secondary">
+										<button type="button" class="button-link listing-item-toggle">
+												<svg class="iconic">
+														<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#chevron-bottom"></use>
+												</svg>
+												<span class="button-label">Configure</span>
+										</button>
+								</div>
+
+								<div class="listing-item-primary">
+										<div class="listing-item-image">
+											<svg class="iconic">
+													<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#code"></use>
+											</svg>
+										</div>
+										<h2 class="listing-item-title listing-item-toggle">Embed</h2>
+								</div>
+							</div>
+
+								<div class="listing-item-body" dropdown-menu>
+									<div class="form-field">
+											<label>HTML</label>
+											<textarea>&lt;iframe width="560" height="315" src="{{shareUrl}}" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;</textarea>
+									</div>
+							</div>
+					</div>
+
+					<div class="listing-item">
+							<div class="listing-item-primary">
+									<div class="listing-item-image">
+										<svg class="iconic">
+												<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../../img/iconic-sprite.svg#external-link"></use>
+										</svg>
+									</div>
+									<h2 class="listing-item-title">
+										<post-export filters="filters"></post-export>
+									</h2>
+							</div>
+					</div>
+			</div>
+    </form>
+</div>

--- a/app/settings/site/editor.directive.js
+++ b/app/settings/site/editor.directive.js
@@ -34,7 +34,6 @@ function (
         },
         templateUrl: 'templates/settings/site/settings-editor.html',
         link: function ($scope, $element, $attrs) {
-            $scope.embedUrl = Util.deploymentUrl();
             $scope.saving_config = false;
             $scope.map = {};
 

--- a/app/settings/site/settings-editor.html
+++ b/app/settings/site/settings-editor.html
@@ -94,15 +94,6 @@
                          <label for="private" translate>settings.site_private</label>
                     </div>
 
-                    <div class="form-field">
-                         <label translate>settings.embed</label>
-                         <p class="small" translate>settings.embed_info</p>
-                         <div class="alert">
-                             <p translate-values="{url: embedUrl}" translate>settings.embed_code</p>
-                        </div>
-
-                    </div>
-
                     <settings-map map="map"></settings-map>
                 </div>
 

--- a/server/www/index.html
+++ b/server/www/index.html
@@ -137,5 +137,17 @@
                 }));
             }
         </script>
+
+        <!--
+          Facebook sharing code
+        -->
+          <div id="fb-root"></div>
+        	<script>(function(d, s, id) {
+        	  var js, fjs = d.getElementsByTagName(s)[0];
+        	  if (d.getElementById(id)) return;
+        	  js = d.createElement(s); js.id = id;
+        	  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1";
+        	  fjs.parentNode.insertBefore(js, fjs);
+        	}(document, 'script', 'facebook-jssdk'));</script>
     </body>
 </html>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds share menu for client, which includes, twitter facebook, embed, and export

Test these changes by:
- [ ] On the map or timeline views, click Share, the menu should open with 4 options
- [ ] Click share on Facebook, should allow you to share a link to the deployment on facebook
- [ ] Click share on Twitter, should allow you to share a link to the deployment on twitter
- [ ] Click share on embed, should show you the html code need for sharing
- [ ] Paste the above code into a html file on your local machine and test that the embed works
- [ ] Click share on Export, should allow you to export the current posts
- [ ] Set different filters then click on export the correct posts based on the filters should be exported only

Fixes ushahidi/platform#1465

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/384)
<!-- Reviewable:end -->
