### PR TITLE
1462-collection and active filter fix

### DIFF
--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -39,11 +39,11 @@ module.exports = [
 
         // Extend filters, always adding the current collection id
         var extendFilters = function (filters) {
-            filters = angular.copy(filters, { set : [] });
+            filters = angular.copy(filters, { set : []});
             filters.set.push(collection.id);
-
             //Ensure that ALL posts are visible under collections
-            filters.status.push('archived');
+            // Set default collection status filters
+            filters.status = ['published', 'draft', 'archived'];
             return filters;
         };
 

--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -39,12 +39,13 @@ module.exports = [
 
         // Extend filters, always adding the current collection id
         var extendFilters = function (filters) {
-            filters = angular.copy(filters, { set : []});
+            //filters = angular.copy(filters, { set : []});
+            filters.set = [];
             filters.set.push(collection.id);
             //Ensure that ALL posts are visible under collections
             // Set default collection status filters
             if (_.has(filters, 'status')) {
-                filters.status.push('archived');
+                !_.contains(filters.status, 'archived') ? filters.status.push('archived') : null;
             } else {
                 filters.status = ['archived'];
             }

--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -41,6 +41,9 @@ module.exports = [
         var extendFilters = function (filters) {
             filters = angular.copy(filters, { set : [] });
             filters.set.push(collection.id);
+
+            //Ensure that ALL posts are visible under collections
+            filters.status.push('archived');
             return filters;
         };
 

--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -43,7 +43,12 @@ module.exports = [
             filters.set.push(collection.id);
             //Ensure that ALL posts are visible under collections
             // Set default collection status filters
-            filters.status = ['published', 'draft', 'archived'];
+            if (_.has(filters, 'status')) {
+                filters.status.push('archived');
+            } else {
+                filters.status = ['archived'];
+            }
+
             return filters;
         };
 

--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -42,13 +42,6 @@ module.exports = [
             //filters = angular.copy(filters, { set : []});
             filters.set = [];
             filters.set.push(collection.id);
-            //Ensure that ALL posts are visible under collections
-            // Set default collection status filters
-            if (_.has(filters, 'status')) {
-                !_.contains(filters.status, 'archived') ? filters.status.push('archived') : null;
-            } else {
-                filters.status = ['archived'];
-            }
 
             return filters;
         };
@@ -62,7 +55,11 @@ module.exports = [
         }, true);
 
         // Reset GlobalFilter + add set filter
+        // Ensure that ALL posts are visible under collections
+        // Set default collection status filters
         PostFilters.clearFilters();
+        PostFilters.setFilters({ status: ['archived', 'draft', 'published'] });
         $scope.filters = extendFilters(PostFilters.getFilters());
+
     }
 ];

--- a/app/main/posts/collections/mode-context.html
+++ b/app/main/posts/collections/mode-context.html
@@ -108,6 +108,8 @@
             </a>
         </div>
 
+        <mode-context-form-filter></mode-context-form-filter>
+        
         <post-active-filters></post-active-filters>
 
     </div>

--- a/app/main/posts/views/filters/active-filters.directive.js
+++ b/app/main/posts/views/filters/active-filters.directive.js
@@ -48,6 +48,8 @@ function ActiveFilters($translate, $filter, PostFilters, _, TagEndpoint, RoleEnd
             var activeFilters = angular.copy(filters);
             rawFilters = angular.copy(filters);
 
+            // Remove set filter as it is only relevant to collections and should be immutable in that view
+            delete activeFilters.set;
             // Remove form filter as its shown by the mode-context-form-filter already
             delete activeFilters.form;
             // Remove within_km as its shown with the center_point value

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -113,7 +113,7 @@ function PostFiltersService(_, FormEndpoint) {
                     return true;
                 }
                 // Is an array with all the same elements? (order doesn't matter)
-                if (_.isArray(defaults[key]) && _.difference(defaults[key], value).length === 0) {
+                if (_.isArray(defaults[key]) && _.difference(value, defaults[key]).length === 0) {
                     return true;
                 }
                 // Is value empty? ..and not a date object

--- a/test/unit/main/post/collections/collections-controller-spec.js
+++ b/test/unit/main/post/collections/collections-controller-spec.js
@@ -32,7 +32,6 @@ describe('set collections controller', function () {
         $rootScope.goBack = function () {};
     }));
 
-
     beforeEach(function () {
         spyOn($rootScope, '$emit').and.callThrough();
 

--- a/test/unit/main/post/views/filters/active-filters.directive.spec.js
+++ b/test/unit/main/post/views/filters/active-filters.directive.spec.js
@@ -84,5 +84,6 @@ describe('post active filters directive', function () {
 
             expect(PostFilters.clearFilter).toHaveBeenCalled();
         });
+
     });
 });

--- a/test/unit/main/post/views/filters/post-filters.service.spec.js
+++ b/test/unit/main/post/views/filters/post-filters.service.spec.js
@@ -1,0 +1,49 @@
+var ROOT_PATH = '../../../../../../';
+
+describe('Post Filters Service', function () {
+
+    var $rootScope,
+        $scope,
+        PostFilters,
+        Notify;
+
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+
+        require(ROOT_PATH + 'test/unit/mock/mock-modules.js');
+
+        var testApp = angular.module('testApp', [
+            'ushahidi.mock',
+            'pascalprecht.translate'
+        ]);
+
+        testApp.service('PostFiltersService', require(ROOT_PATH + 'app/main/posts/views/post-filters.service.js'))
+        .value('$filter', function () {
+            return function () {
+                return 'Feb 17, 2016';
+            };
+        });
+
+        require(ROOT_PATH + 'test/unit/simple-test-app-config')(testApp);
+
+        angular.mock.module('testApp');
+    });
+
+    beforeEach(inject(function (_$rootScope_, $compile, _Notify_, _PostFilters_) {
+        $rootScope = _$rootScope_;
+        $scope = _$rootScope_.$new();
+
+        PostFilters = _PostFilters_;
+        Notify = _Notify_;
+    }));
+
+    describe('test service functions', function () {
+
+        it('should return the active filters when an array filter differs from the default', function () {
+            PostFilters.filterState.tags.push('test');
+            var filters = PostFilters.getActiveFilters(PostFilters.getFilters());
+            expect(filters.tags.length).toEqual(1);
+        });
+
+    });
+});


### PR DESCRIPTION
This pull request makes the following changes:
- Changed active filter array comparison check
- Add archived filter to collection default filters

Test these changes by:
- [ ] Create or import a set of posts with archived posts
- [ ] On viewing collection archived posts should be visible
- [ ] On all map or timeline views, when you click on a filter it should appear in the active filters on the left hand side in the mode context

Fixes ushahidi/platform#1462

Ping @ushahidi/platform

…r not appearing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/385)
<!-- Reviewable:end -->
