### PR TITLE
Separate /release directory from /last_build directory

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -11,7 +11,7 @@ release:
     image: release
     dockerfile_path: docker/release.Dockerfile
   volumes:
-    - ./tmp/out:/release
+    - ./tmp/out/release:/release
   encrypted_env_file: deployment.env.encrypted
 deploy:
   build:

--- a/docker/build.run.sh
+++ b/docker/build.run.sh
@@ -40,7 +40,7 @@ build() {
 
 # export the build files to a shared folder
 export_build() {
-  # copy the raw build as a deployable 
+  # copy the raw build as a deployable
   check_vols_out
   if [ ! -d /vols/out/last_build ]; then
     mkdir /vols/out/last_build
@@ -53,7 +53,7 @@ bundle() {
   check_vols_out
   local version=${GITHUB_VERSION:-${CI_BRANCH:-v0.0.0}}
   cp ./server/rewrite.htaccess ./server/www/
-  gulp release --version-suffix=${version} --dest-dir=/vols/out
+  gulp release --version-suffix=${version} --dest-dir=/vols/out/release
 }
 
 watch() {


### PR DESCRIPTION
Separate release and build dirs, otherwise we get build files
uploaded to github releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/400)
<!-- Reviewable:end -->
