### PR TITLE
ushahidi/platform-client#404 upgrade node to v6

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.1
+FROM node:6.9.1
 
 RUN apt-get update && apt-get install -y rsync && \
     apt-get clean && \

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.1
+FROM node:6.9.1
 
 RUN apt-get update && apt-get install -y rsync && \
     apt-get clean && \


### PR DESCRIPTION
This pull request makes the following changes:
-
Changes the node.js version that we use for testing and deployment from v5 to the latest v6 as of today.

Fixes ushahidi/platform-client#404

Ping @ushahidi/platform

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/405)
<!-- Reviewable:end -->
