### PR TITLE
Handle filtering posts to 'all' statuses better

### DIFF
--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -37,6 +37,12 @@ function PostFiltersService(_, FormEndpoint) {
     }
 
     function setFilters(newState) {
+        // Replace 'all' with full list of statuses
+        // Gives less confusing active display, and works around API bug
+        if (newState.status === 'all') {
+            newState.status = ['published', 'draft', 'archived'];
+        }
+
         // Replace filterState with defaults + newState
         // Including defaults ensures all values are always defined
         return angular.merge(filterState, getDefaults(), newState);


### PR DESCRIPTION
Replace status=all in post filters with full set of possible statuses.
This display better in active filters and avoids weird bugs.

Refs ushahidi/platform#1484

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/409)
<!-- Reviewable:end -->
