### PR TITLE
Adding correct ui to roles dropdown in collections and saved searches #1486

### DIFF
--- a/app/main/posts/collections/editor.directive.js
+++ b/app/main/posts/collections/editor.directive.js
@@ -64,7 +64,7 @@ function CollectionEditorController(
     function setBasicCollection() {
         $scope.cpyCollection = {};
         $scope.cpyCollection.view = 'map';
-        $scope.cpyCollection.visible_to = [];
+        $scope.cpyCollection.role = [];
     }
 
     function featuredEnabled() {
@@ -78,9 +78,6 @@ function CollectionEditorController(
     function saveCollection(collection) {
         // Are we creating or updating?
         var persist = collection.id ? CollectionEndpoint.update : CollectionEndpoint.save;
-
-        // Strip out any null values from visible_to
-        collection.visible_to = _.without(_.values(collection.visible_to), null);
 
         // Collection endpoint uses collectionId so make sure thats set
         collection.collectionId = collection.id;

--- a/app/main/posts/collections/editor.html
+++ b/app/main/posts/collections/editor.html
@@ -36,17 +36,8 @@
             </select>
         </div>
     </div>
-
-    <div class="form-field select">
-        <label>
-            <div class="custom-select">
-                <select ng-options="role.name as role.display_name for role in roles" ng-model="cpyCollection.visible_to[0]">
-                    <option value="" translate>post.modify.everyone</option>
-                </select>
-            </div>
-            <span translate>app.can_see_this</span>
-        </label>
-    </div>
+    <!-- Who can see -->
+    <role-selector model="cpyCollection" title="'Who can see this?'"></role-selector>
 
     <div class="modal-actions">
         <div class="form-field">

--- a/app/main/posts/collections/mode-context.html
+++ b/app/main/posts/collections/mode-context.html
@@ -24,17 +24,17 @@
 
         <ul class="metadata">
             <li>
-                <span class="status-indicator public tooltip" ng-if="!collection.visible_to || collection.visible_to.length == 0">
+                <span class="status-indicator public tooltip" ng-if="!collection.role || collection.role.length == 0">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#globe"></use>
                     </svg>
                     <span class="bug" translate="collection.visible_to_public">This Collection is visible to the public</span>
                 </span>
-                <span class="status-indicator yellow tooltip" ng-if="collection.visible_to.length > 0">
+                <span class="status-indicator yellow tooltip" ng-if="collection.role.length > 0">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#globe"></use>
                     </svg>
-                    <span class="bug" translate="collection.visible_to_roles" translate-values="{ roles: collection.visible_to.join(', ') }">This Collection is visible to ...</span>
+                    <span class="bug" translate="collection.visible_to_roles" translate-values="{ roles: collection.role.join(', ') }">This Collection is visible to ...</span>
                 </span>
             </li>
             <li>

--- a/app/main/posts/savedsearches/create-directive.js
+++ b/app/main/posts/savedsearches/create-directive.js
@@ -15,7 +15,7 @@ function (
             // Init an empty saved search
             $scope.savedSearch = {
                 view : 'map',
-                visibile_to : []
+                role : []
             };
 
             // Compare current filters to default filters

--- a/app/main/posts/savedsearches/editor-directive.js
+++ b/app/main/posts/savedsearches/editor-directive.js
@@ -39,20 +39,12 @@ function (
 
             $scope.isAdmin = $rootScope.isAdmin;
 
-            RoleEndpoint.query().$promise.then(function (roles) {
-                $scope.roles = roles;
-            });
-
             $scope.views = ViewHelper.views();
 
             $scope.cpySavedSearch = _.clone($scope.savedSearch);
 
             $scope.save = function (savedSearch) {
                 var persist = savedSearch.id ? SavedSearchEndpoint.update : SavedSearchEndpoint.save;
-
-                // Strip out any null values from visible_to
-                savedSearch.visible_to = _.without(_.values(savedSearch.visible_to), null);
-
                 persist(savedSearch)
                 .$promise
                 .then(function (savedSearch) {

--- a/app/main/posts/savedsearches/mode-context.html
+++ b/app/main/posts/savedsearches/mode-context.html
@@ -24,17 +24,17 @@
 
         <ul class="metadata">
             <li>
-                <span class="status-indicator public tooltip" ng-if="!savedSearch.visible_to">
+                <span class="status-indicator public tooltip" ng-if="!savedSearch.role">
                     <svg class="iconic">
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#globe"></use>
                     </svg>
                     <span class="bug" translate="saved_search.visible_to_public">This saved search is visible to the public</span>
                 </span>
-                <span class="status-indicator yellow tooltip" ng-if="savedSearch.visible_to.length > 0">
+                <span class="status-indicator yellow tooltip" ng-if="savedSearch.role">
                     <svg class="iconic">
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#globe"></use>
                     </svg>
-                    <span class="bug" translate="saved_search.visible_to_roles" translate-values="{ roles: savedSearch.visible_to.join(', ') }">This saved search is visible to ...</span>
+                    <span class="bug" translate="saved_search.visible_to_roles" translate-values="{ roles: savedSearch.role.join(', ') }">This saved search is visible to ...</span>
                 </span>
             </li>
             <li>

--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -33,18 +33,8 @@
             </select>
         </div>
     </div>
-
-    <div class="form-field select">
-        <label class="input-label">
-            <div class="custom-select">
-                <select ng-options="role.name as role.display_name for role in roles" ng-model="cpySavedSearch.visible_to[0]">
-                    <option value="" translate>post.modify.everyone</option>
-                </select>
-            </div>
-            <span class="nodisplay">Who</span> <translate translate="app.can_see_this">can see this</translate>
-        </label>
-    </div>
-
+    <!-- Who can see? -->
+    <role-selector model="savedSearch" title="'Who can see this?'"></role-selector>
     <div class="modal-actions">
         <div class="form-field">
             <button type="button" class="button-link  modal-trigger" ng-click="cancel()" translate>app.cancel</button>

--- a/app/main/posts/savedsearches/update-directive.js
+++ b/app/main/posts/savedsearches/update-directive.js
@@ -32,9 +32,6 @@ function (
                 // Copy the current filters into our search..
                 $scope.savedSearch.filter = PostFilters.getQueryParams($scope.filters);
 
-                // Strip out any null values from visible_to
-                $scope.savedSearch.visible_to = _.without(_.values($scope.savedSearch.visible_to), null);
-
                 SavedSearchEndpoint.update($scope.savedSearch)
                 .$promise
                 .then(function (savedSearch) {


### PR DESCRIPTION
*This pr needs https://github.com/ushahidi/platform/pull/1526 to be merged first*

This pull request makes the following changes:
- Adds the role-selector directive to saved-searches and collections
- Renames the variable `visible_to` to `role`

Test these changes by:
_Saved_Searches_
1. Make a new search
2. Click 'save search'
3. Make sure the role-selector is the same as: http://preview.ushahidi.com/platform-pattern-library/develop/assets/html/5_layouts/settings-category-edit.html
4. Choose a role
5. Save
6. Try editing and saving with different roles to make sure they are saved properly

_Collections_
1. Click on 'collections' + choose 'Create New'
2. Make sure the role-selector is the same as: http://preview.ushahidi.com/platform-pattern-library/develop/assets/html/5_layouts/settings-category-edit.html
3. Choose a role
4. Save
5. Try editing and saving with different roles to make sure they are saved properly

Fixes ushahidi/platform#1486 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/444)
<!-- Reviewable:end -->