### PR TITLE
Webpack background-image: url()

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -583,9 +583,7 @@
             "upload" : "Upload"
         },
         "video" : {
-            "input_desc" : "<span>Enter a</span><span id=\"wordmark-youtube\" class=\"wordmark-replace\" style=\"background-image: url(/img/youtube.png);\"><span> Youtube</span></span><span> or </span><span id=\"wordmark-vimeo\" class=\"wordmark-replace\" style=\"background-image: url(/img/vimeo.png);\"><span> Vimeo</span></span><span> video URL</span>",
             "enter_a" : "Enter a",
-            "youtube" : " Youtube",
             "or" : " or ",
             "vimeo" : " Vimeo",
             "video_url" : " video URL"

--- a/app/main/posts/modify/video.html
+++ b/app/main/posts/modify/video.html
@@ -2,7 +2,14 @@
 <form>
   <div class="form-field video_embed">
     <label>{{label}}</label>
-    <p translate="post.video.input_desc"></p>
+    <p>
+      <span translate="post.video.enter_a">Enter a</span>
+
+      <img src="/img/youtube.png" class="wordmark-replace">
+      <span translate="post.video.or"> or </span>
+      <img src="/img/vimeo.png" class="wordmark-replace">
+      <span translate="post.video.video_url"> video URL</span>
+    </p>
     <input type="text" ng-model="videoUrl" ng-change="constructIframe(videoUrl)" placeholder="https://youtu.be/123456">
 
     <div id="{{previewId}}" class="form-field-preview" ng-show="videoUrl">


### PR DESCRIPTION
This pull request makes the following changes:
- Changes layout of video.html to include definition of video provider logo images
- This images were not served by webpack as they were not picked up because they were within the translation string for the video input desc
- This is a patch the background images should be moved to the css class and webpack config should be set to use resolve-url on the css/scss

Test these changes by:
- [ ] Add/Edit a Post with a Video field, confirm that Youtube and Vimeo logos appear

Fixes ushahidi/platform# .

Ping @ushahidi/platform

…style in en.json. This is less a bug and more a need of a redesign of the video provider logo layout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/449)
<!-- Reviewable:end -->
