### PR TITLE
Removing bug that duplicates locations from twitter-messages

### DIFF
--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -44,8 +44,9 @@ function (
     $scope.post_task = {};
     $scope.hasPermission = $rootScope.hasPermission;
     $scope.canCreatePostInSurvey = PostSurveyService.canCreatePostInSurvey;
-
     $scope.mapDataLoaded = false;
+    $scope.form_attributes = [];
+
     $scope.publishedFor = function () {
         if ($scope.post.status === 'draft') {
             return 'post.publish_for_you';
@@ -75,11 +76,8 @@ function (
     if ($scope.post.user && $scope.post.user.id) {
         $scope.post.user = UserEndpoint.get({id: $scope.post.user.id});
     }
-
     // Load the post form
     if ($scope.post.form && $scope.post.form.id) {
-        $scope.form_attributes = [];
-
         $q.all([
             FormEndpoint.get({id: $scope.post.form.id}),
             FormStageEndpoint.query({formId:  $scope.post.form.id}).$promise,

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -95,6 +95,7 @@ function PostEditorController(
                 Notify.error('post.valid.invalid_state');
             }
         });
+
         $scope.medias = {};
     }
 
@@ -144,7 +145,6 @@ function PostEditorController(
                         // Prepopulate location fields from message location
                         if ($scope.post.values.message_location) {
                             $scope.post.values[attr.key] = angular.copy($scope.post.values.message_location);
-                            delete $scope.post.values.message_location;
                         } else {
                             $scope.post.values[attr.key] = [null];
                         }
@@ -230,6 +230,9 @@ function PostEditorController(
 
             // Avoid messing with original object
             // Clean up post values object
+            if ('message_location' in $scope.post.values) {
+                $scope.post.values.message_location = [];
+            }
             var post = PostEditService.cleanPostValues(angular.copy($scope.post));
             var request;
             if (post.id) {

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -144,6 +144,7 @@ function PostEditorController(
                         // Prepopulate location fields from message location
                         if ($scope.post.values.message_location) {
                             $scope.post.values[attr.key] = angular.copy($scope.post.values.message_location);
+                            delete $scope.post.values.message_location;
                         } else {
                             $scope.post.values[attr.key] = [null];
                         }

--- a/test/unit/main/post/modify/post-editor.directive.spec.js
+++ b/test/unit/main/post/modify/post-editor.directive.spec.js
@@ -69,10 +69,6 @@ describe('post editor directive', function () {
         it('should load the associated form stages', function () {
             expect(isolateScope.tasks.length).toEqual(2);
         });
-        it('should load form-attributes', function () {
-            // number 9 below comes from the mockdata for post and form-attributes
-            expect(Object.keys($scope.post.values).length).toEqual(9);
-        });
     });
     describe('test directive functions', function () {
         it('should save a post', function () {
@@ -93,7 +89,6 @@ describe('post editor directive', function () {
             isolateScope.savePost();
 
             $rootScope.$apply();
-
             expect(Notify.errors).toHaveBeenCalled();
         });
     });

--- a/test/unit/main/post/modify/post-editor.directive.spec.js
+++ b/test/unit/main/post/modify/post-editor.directive.spec.js
@@ -69,8 +69,11 @@ describe('post editor directive', function () {
         it('should load the associated form stages', function () {
             expect(isolateScope.tasks.length).toEqual(2);
         });
+        it('should load form-attributes', function () {
+            // number 9 below comes from the mockdata for post and form-attributes
+            expect(Object.keys($scope.post.values).length).toEqual(9);
+        });
     });
-
     describe('test directive functions', function () {
         it('should save a post', function () {
             spyOn(Notify, 'notify');


### PR DESCRIPTION
This pull request makes the following changes:
- Removing message_location after those values are copied over to a post
- A minor change, I moved the assignment of a variable to the outer-scope to avoid an error-message caused by that the twitter-messages are not yet part of a survey but still uses a form_attribute (`message_location`).

Test these changes by:
_Duplicate twitter-locations_
1. Select a post originating from a twitter-message
2. Edit it with a new location
3. Make sure only the new location is connected to that twitter-message and that the old location no longer is marked on the map.

_Error-message_
- 1 Select and look at an unstructured posts from twitter on the map. 
- 2 This should not generate an error message in the console (previously it was: 

``` 
angular.js:14110 TypeError: Cannot read property 'message_location' of undefined
    at ChildScope.$scope.isPostValue (post-detail.controller.js:164)
    at fn (eval at compile (angular.js:15033), <anonymous>:4:685)
    at Scope.$digest (angular.js:17747)
    at Scope.$apply (angular.js:18021)
    at done (angular.js:12002)
    at completeRequest (angular.js:12211)
    at XMLHttpRequest.requestLoaded (angular.js:12139) 
```
)


Fixes ushahidi/platform#1503, #1508 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/461)
<!-- Reviewable:end -->
