### PR TITLE
Adding confirmation-dialogs before deleting stuff

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -923,7 +923,8 @@
             "duplicate_fields" : "Columns must be mapped to unique survey fields. The following columns have more than 1 mapping: {{duplicates}}",
             "required_fields" : "Required fields must be set to a value. The following fields have not been set: {{required}}",
             "no_mappings" : "No fields have been assigned mappings - at least one field must be mapped to continue",
-            "csv_import_cancel" : "CSV import cancelled"
+            "csv_import_cancel" : "CSV import cancelled",
+            "csv_import_cancel_confirm": "Are you sure you want to cancel importing?"
         },
         "general_settings" : {
             "save_success" : "General settings saved"

--- a/app/settings/data-import/data-import.directive.js
+++ b/app/settings/data-import/data-import.directive.js
@@ -90,10 +90,11 @@ function (
             }
 
             function cancelImport() {
-                Notify.notify('notify.data_import.csv_import_cancel');
-
-                deleteDataImport($scope.csv);
-                $location.url('/settings/data-import/');
+                Notify.confirm('notify.data_import.csv_import_cancel_confirm').then(function () {
+                    Notify.notify('notify.data_import.csv_import_cancel');
+                    deleteDataImport($scope.csv);
+                    $location.url('/settings/data-import/');
+                });
             }
 
             function deleteDataImport() {

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -397,19 +397,19 @@ function SurveyEditorController(
     }
 
     function deleteAttribute(attribute) {
-        // If we have not yet saved this attribute
-        // we can drop it immediately
-        if (!attribute.id) {
-            $scope.activeTask.attributes = _.filter($scope.activeTask.attributes, function (item) {
-                return item.label !== attribute.label;
-            });
-            // Attribute delete is currently only available in modal
-            // so close the modal
-            ModalService.close();
-            return;
-        }
-
         Notify.confirmDelete('notify.form.delete_attribute_confirm').then(function () {
+            // If we have not yet saved this attribute
+            // we can drop it immediately
+            if (!attribute.id) {
+                $scope.activeTask.attributes = _.filter($scope.activeTask.attributes, function (item) {
+                    return item.label !== attribute.label;
+                });
+                // Attribute delete is currently only available in modal
+                // so close the modal
+                ModalService.close();
+                return;
+            }
+
             FormAttributeEndpoint.delete({
                 formId: $scope.survey.id,
                 id: attribute.id
@@ -434,17 +434,16 @@ function SurveyEditorController(
 
     function deleteTask(task) {
 
+        Notify.confirmDelete('notify.form.delete_stage_confirm').then(function () {
+            // If we haven't saved the task yet then we can just drop it
+            if (!task.id || _.isString(task.id)) {
+                $scope.survey.tasks = _.filter($scope.survey.tasks, function (item) {
+                    return item.label !== task.label;
+                });
+                $scope.resetSelectedTask();
+                return;
+            }
 
-        // If we haven't saved the task yet then we can just drop it
-        if (!task.id || _.isString(task.id)) {
-            $scope.survey.tasks = _.filter($scope.survey.tasks, function (item) {
-                return item.label !== task.label;
-            });
-            $scope.resetSelectedTask();
-            return;
-        }
-
-        Notify.confirm('notify.form.delete_stage_confirm').then(function () {
             FormStageEndpoint.delete({
                 formId: $scope.survey.id,
                 id: task.id
@@ -465,14 +464,15 @@ function SurveyEditorController(
     //Start - modify Survey
 
     function deleteSurvey() {
-        // If we haven't saved the survey
-        // just go back to the surveys views
-        if (!$scope.survey.id) {
-            $location.url('/settings/surveys');
-            return;
-        }
-
         Notify.confirmDelete('notify.form.delete_form_confirm').then(function () {
+
+            // If we haven't saved the survey
+            // just go back to the surveys views
+            if (!$scope.survey.id) {
+                $location.url('/settings/surveys');
+                return;
+            }
+
             FormEndpoint.delete({
                 id: $scope.survey.id
             }).$promise.then(function () {


### PR DESCRIPTION
This pull request makes the following changes:
- Adds confirmation-dialog before deleting unsaved surveys and tasks+fields connected to unsaved surveys.
- Adds confirmation-dialog when cancelling a csv-import.

Test these changes by:

*Surveys*
- [ ] Start creating a survey without saving
- [ ] Click delete-button
- [ ] A confirmation-dialog should appear

*Tasks*
- [ ] Add a task to the unsaved survey
- [ ] Click on task and delete it
- [ ] A confirmation-dialog should appear

*Fields*
- [ ] Add a field to the unsaved survey
- [ ] Click on field and delete it
- [ ] A confirmation-dialog should appear

*Cancelling csv-file-import*
- [ ] Start importing a csv-file, choose file and survey and press continue
- [ ] Click on 'cancel' 
- [ ] A confirmation-dialog should appear

Fixes ushahidi/platform#1528 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/548)
<!-- Reviewable:end -->
