### PR TITLE
fixing language-string for no savedsearches

### DIFF
--- a/app/main/posts/savedsearches/saved-search-dropdown.html
+++ b/app/main/posts/savedsearches/saved-search-dropdown.html
@@ -10,7 +10,7 @@
         <dt class="list-item" ng-repeat-start="search in searches"><a ng-href="savedsearches/{{ search.id }}" ng-bind="search.name"></a></dt>
         <dd ng-repeat-end ng-show="search.user.id" translate="nav.author_tagline" translate-values="{ author: search.user.realname }"></dd>
 
-        <dt ng-show="! searches.length" translate="set.empty_list_savedsearch"></dt>
+        <dt ng-show="! searches.length" translate="set.empty_list_savedsearches"></dt>
     </dl>
     <div class="form-field" ng-show="todo">
         <button type="button" class="button-beta">


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes spelling-error to make message translate correctly

Test these changes by:
- Click on saved searches, while not logged in.
- If no saved searches are available, the text 'No saved searches' should appear.

Fixes ushahidi/platform#1561 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/551)
<!-- Reviewable:end -->
