### PR TITLE
adding reply-button to twitter-messages #1338

### DIFF
--- a/app/main/posts/detail/post-messages.html
+++ b/app/main/posts/detail/post-messages.html
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <div class="listing-item" ng-show="contact.type !== 'twitter'">
+  <div class="listing-item">
     <div class="listing-item-primary">
       <h2 class="listing-item-title">
         <a href="" class="button button-flat" ng-click="reply()">


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the 'send new message'-button if a post is imported from twitter

Test these changes by:
- Go to a post imported from twitter. 
- In the bottom of the post, a button 'send new message' should appear.

Fixes ushahidi/platform#1338 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/579)
<!-- Reviewable:end -->
