### PR TITLE
Location picker fixes

### DIFF
--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -117,15 +117,8 @@ function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
         }
 
         function searchLocation() {
-            $scope.processing = true;
             Geocoding.searchAllInfo($scope.searchLocationTerm).then(function (results) {
-                $scope.processing = false;
-                if (!results) {
-                    Notify.error('location.error');
-                    return;
-                }
                 $scope.searchResults = results;
-                $scope.searchLocationTerm = '';
             });
         }
 

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -123,6 +123,7 @@ function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
         }
 
         function chooseLocation(location) {
+            $scope.searchLocationTerm = '';
             updateModelLatLon(location.lat, location.lon);
             updateMarkerPosition(location.lat, location.lon);
             centerMapTo(location.lat, location.lon);

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -31,7 +31,7 @@ function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
         $scope.chooseLocation = chooseLocation;
         $scope.chooseCurrentLocation = chooseCurrentLocation;
         $scope.searchResults = [];
-
+        $scope.showCurrentPositionControl = false;
         activate();
 
         function activate() {
@@ -48,10 +48,11 @@ function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
                     centerMapTo($scope.model.lat, $scope.model.lon);
                 }
                 map.on('click', onMapClick);
-                // treate locationfound same as map click
+                // treat locationfound same as map click
                 map.on('locationfound', onMapClick);
                 // Add locate control, but only on https
                 if (window.location.protocol === 'https:' || window.location.hostname === 'localhost') {
+                    $scope.showCurrentPositionControl = true;
                     currentPositionControl = L.control.locate({
                         follow: true
                     }).addTo(map);

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -17,6 +17,7 @@
                     ng-disabled="processing" 
                     ng-focus="showSearchResults()" 
                     ng-keyup="showSearchResults()"
+                    ng-keydown="searchLocation()"
                 />
             </div>
             <div class="searchbar-results dropdown-menu" ng-class="{'active': showDropdown}">

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -30,7 +30,7 @@
                         </svg>
                         <span class="button-label" translate>location.search</span>
                     </button>
-                    <button class="button-beta button-plain" ng-click="chooseCurrentLocation()">
+                    <button class="button-beta button-plain" ng-click="chooseCurrentLocation()" ng-if="showCurrentPositionControl" >
                         <svg class="iconic">
                             <use 
                                 xmlns:xlink="http://www.w3.org/1999/xlink" 

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -43,9 +43,14 @@
                 </div>
              <div class="tool">
                     <h6 class="tool-heading" translate>location.search_results</h6>
-                    <dl class="dropdown-menu-body" ng-repeat="result in searchResults">
+                    <dl class="dropdown-menu-body" ng-repeat="result in searchResults" ng-if="searchResults.length > 0">
                         <dt class="list-item" ng-click="chooseLocation(result)">
                             <em>{{result.display_name}}</em>
+                        </dt>
+                    </dl>
+                    <dl class="dropdown-menu-body" ng-if="!searchResults">
+                        <dt class="list-item">
+                            No matching locations.
                         </dt>
                     </dl>
                 </div>

--- a/test/unit/main/post/modify/location.directive.spec.js
+++ b/test/unit/main/post/modify/location.directive.spec.js
@@ -75,23 +75,7 @@ describe('post location directive', function () {
             expect(L.marker).toHaveBeenCalled();
             expect(marker.addTo).toHaveBeenCalledWith(map);
         });
-        it('should not clear search location term for failed searches', function () {
-            isolateScope.$apply(function () {
-                isolateScope.searchLocationTerm = 'Lorem';
-            });
-
-            spyOn(Geocoding, 'searchAllInfo').and.callFake(function (kupi) {
-                return {
-                    then: function (callback) {
-                        callback(false);
-                    }
-                };
-            });
-
-            isolateScope.searchLocation();
-            expect(isolateScope.searchLocationTerm).toEqual('Lorem');
-        });
-        it('should clear search location term for successful searches', function () {
+        it('should clear search location term when choosing a location', function () {
             isolateScope.$apply(function () {
                 isolateScope.searchLocationTerm = 'Ipsum';
             });
@@ -104,7 +88,7 @@ describe('post location directive', function () {
                 };
             });
 
-            isolateScope.searchLocation();
+            isolateScope.chooseLocation({lat: 1,lon: 2});
             expect(isolateScope.searchLocationTerm).toEqual('');
         });
         it('should call update model, marker position and map center', function () {


### PR DESCRIPTION
This pull request makes the following changes:
- Tweaks location-picker according to QA:
-- Only showing 'show current location'-button if on https
-- Searching immediately when typing and displaying results

Test these changes by:
- If not on https, 'show current location' -button on dropdown should not visible
- Search-results should appear when typing

Fixes ushahidi/platform#1327 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/580)
<!-- Reviewable:end -->
