### PR TITLE
refresh posts after delete

### DIFF
--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -158,6 +158,10 @@ function PostListController(
                 $scope.posts = _.reject($scope.posts, function (post) {
                     return _.contains(deletedIds, post.id);
                 });
+
+                if (!$scope.posts.length) {
+                    getPosts();
+                }
             }
         });
     }


### PR DESCRIPTION
This pull request makes the following changes:
- Fix timeline refresh after delete of timeline items when all items have been removed

Test these changes by:
- On timeline, where there are more posts then displayed on one page(>20) select all, delete and the next set of posts should be displayed

Fixes ushahidi/platform#1698

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/627)
<!-- Reviewable:end -->
