### PR TITLE
only setting bounds if there are posts to begin with

### DIFF
--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -69,9 +69,11 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
             markers.addTo(map);
 
+            if (posts.features.length > 0) {
+                map.fitBounds(geojson.getBounds());
+            }
             // Focus map on data points but..
             // Avoid zooming further than 15 (particularly when we just have a single point)
-            map.fitBounds(geojson.getBounds());
             if (map.getZoom() > 15) {
                 map.setZoom(15);
             }


### PR DESCRIPTION
This pull request makes the following changes:
- checking if there are any latlngs to get bounds-from before setting the bounds

Test these changes by:
- go to map-view, no error ``` Bounds are not valid ``` should  be visible in the console

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/633)
<!-- Reviewable:end -->
