### PR TITLE
Fixing autoclosing dropdown for categories in mode-context-bar

### DIFF
--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -51,6 +51,7 @@
         <fieldset
             class="survey-filter-children"
             dropdown
+            auto-close="outsideClick"
             ng-if="form.tags.length > 0 && form.post_count > 0"
             >
             <legend class="init" data-toggle="form-fieldgroup" dropdown-toggle>{{form.tags.length}} categories


### PR DESCRIPTION
This pull request makes the following changes:
- Makes the category-dropdown stay open until the user actively close it or clicks outside.

Test these changes by:
- Click on text `{{nb}} categories` in the mode-context-bar
- Dropdown should stay open even when the user selects/unselects a category
- Dropdown should close if user clicks on the arrow or outside the dropdown

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/635)
<!-- Reviewable:end -->
