### PR TITLE
Ui fixes categories

### DIFF
--- a/app/settings/categories/categories.controller.js
+++ b/app/settings/categories/categories.controller.js
@@ -6,6 +6,7 @@ module.exports = [
     '$q',
     'TagEndpoint',
     'Notify',
+    '_',
 function (
     $scope,
     $translate,
@@ -13,7 +14,8 @@ function (
     $location,
     $q,
     TagEndpoint,
-    Notify
+    Notify,
+    _
 ) {
 
     // Redirect to home if not authorized
@@ -31,6 +33,13 @@ function (
 
     $scope.refreshView = function () {
         TagEndpoint.queryFresh().$promise.then(function (tags) {
+            _.each(tags, function (tag) {
+                if (tag && tag.children) {
+                    tag.children = _.map(tag.children, function (child) {
+                        return _.findWhere(tags, {id: parseInt(child.id)});
+                    });
+                }
+            });
             $scope.categories = tags;
         });
         $scope.selectedCategories = [];

--- a/app/settings/categories/categories.html
+++ b/app/settings/categories/categories.html
@@ -53,9 +53,29 @@
                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                             </svg>
                             <span class="hidden">Delete</span>
+                            </button>
+                    </div>
+
+                    <div id="category-{{category.id}}" class="  listing-item" ng-repeat="child in category.children | orderBy:'realname'" ng-class="{ 'warning': isToggled(category) }" ng-click="toggleCategory(category)" ng-style="{'marginLeft': '50px', 'border': 'none'}" ng-if="category.children">
+
+                        <div class="listing-item-select">
+                            <input type="checkbox" value="{{category.id}}" ng-checked="isToggled(category)">
                         </div>
 
+                        <div class="listing-item-primary">
+                            <h2 class="listing-item-title"><a ng-href="/settings/categories/{{child.id}}">{{child.tag}}</a></h2>
+                        </div>
+                        <div class="listing-item-secondary">
+                            <button class="button-beta button-flat" ng-click="deleteCategory(category)">
+                                <svg class="iconic">
+                                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
+                                </svg>
+                                <span class="hidden">Delete</span>
+                            </button>
+                        </div>
+                    </div>
                 </div>
+
                 <listing-toolbar entities="categories" selected-set="selectedCategories">
                     <button type="button" class="button-destructive" ng-disabled="!selectedCategories.length" ng-click="deleteCategories()">
                         <svg class="iconic">
@@ -64,11 +84,10 @@
                         <span class="button-label hidden">nav.delete</span>
                     </button>
                 </listing-toolbar>
-           </div>
+            </div>
 
-           <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
+            <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
 
         </div>
-
     </main>
 </div>

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -1,9 +1,11 @@
 module.exports = [
     '$rootScope',
     'ModalService',
+    '_',
 function (
     $rootScope,
-    ModalService
+    ModalService,
+    _
 ) {
     return {
         restrict: 'E',
@@ -11,7 +13,6 @@ function (
         link: function ($scope, $element, $attrs) {
             $scope.defaultValueToggle = false;
             $scope.descriptionToggle = false;
-
             $scope.editName = function () {
                 if (!$scope.editAttribute.id) {
                     $scope.editAttribute.label = '';
@@ -27,6 +28,11 @@ function (
 
             $scope.canDisplay = function () {
                 return $scope.editAttribute.input !== 'upload' && $scope.editAttribute.type !== 'title' && $scope.editAttribute.type !== 'description' && $scope.editAttribute.input !== 'tags';
+            };
+            $scope.selectChild = function (child) {
+                if (!_.contains($scope.editAttribute.options, child.parent.id) && _.contains($scope.editAttribute.options, child.id)) {
+                    $scope.editAttribute.options.push(child.parent.id);
+                }
             };
         }
     };

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -32,7 +32,11 @@
    <!-- editing/adding categories -->
     <div class="form-field" ng-if="editAttribute.input ==='tags'">
       <label translate>Which labels should be available</label>
-        <div ng-repeat="category in availableCategories">
+        <div 
+          class="form-field checkbox"
+          ng-repeat="category in availableCategories"
+          ng-if="category.parent_id === null"
+        >
             <label>
               <input 
                 type="checkbox"
@@ -41,6 +45,20 @@
               />
               {{category.tag}}
             </label>
+            <div
+              class="form-field checkbox"
+              ng-if="category.children"
+              ng-repeat="child in category.children">
+                <label>
+                <input 
+                  type="checkbox" 
+                  checklist-model="editAttribute.options"
+                  checklist-value="child.id"
+                  ng-click="selectChild(child)"
+                />
+                {{child.tag}}
+                </label>
+              </div>
         </div>
       </div>
     <!-- End of editing/adding categories -->

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -222,6 +222,14 @@ function SurveyEditorController(
             params.formId = $scope.surveyId;
         }
         TagEndpoint.queryFresh(params).$promise.then(function (tags) {
+            // adding children to parents
+            _.each(tags, function (tag) {
+                if (tag && tag.children) {
+                    tag.children = _.map(tag.children, function (child) {
+                        return _.findWhere(tags, {id: parseInt(child.id)});
+                    });
+                }
+            });
             $scope.availableCategories = tags;
         });
     }


### PR DESCRIPTION
This pull request makes the following changes:
- Adding parent-child-ui to category-settings-list
- Adding parent-child-ui to attribute-edit-modal

Test these changes by:
- Go to settings->categories. The ui distinguishes between parent/child
- Add a new attribute in the form of categories. The ui distinguishes parent/child 

Fixes ushahidi/platform#1397 (part of) .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/650)
<!-- Reviewable:end -->
