### PR TITLE
Add historyApiFallback for `gulp serve:static` as used by heroku

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -212,6 +212,10 @@ gulp.task('serve:static', function() {
         port: process.env.PORT || 3000,
         ui: false,
         codeSync: false,
+        open: false,
+        middleware: [
+          historyApiFallback()
+        ]
     });
 });
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/652)
<!-- Reviewable:end -->
