### PR TITLE
displaying categories in a post and adding new categories in a post

### DIFF
--- a/app/common/directives/add-category.html
+++ b/app/common/directives/add-category.html
@@ -7,6 +7,7 @@
             ng-model="categoryName"
         />
         <button
+            type="button"
             class="button-alpha button-flat"
             ng-disabled="categoryName.length === 0"
             ng-click="saveCategory($event);"
@@ -17,6 +18,7 @@
         <span class="hidden">Add</span>
         </button>
         <button
+            type="button"
             class="button-beta button-flat"
             ng-click="showInputToggle()"
         >
@@ -28,4 +30,4 @@
 </div>
 <div class="form-field init" ng-click="showInputToggle()" ng-if="userCanAddCategory">
     <a data-toggle="add-label">+ Add new category</a>
-</div> 
+</div>

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -142,9 +142,13 @@ function PostEditorController(
                 }
                 if (attr.input === 'tags') {
                     // adding category-objects attribute-options
-                    attr.options = _.map(attr.options, function (category) {
+                    attr.options = _.chain(attr.options)
+                        .map(function (category) {
                             return _.findWhere(categories, {id: category});
-                        });
+                        })
+                        .filter()
+                        .value();
+
                     // adding category-objects to children
                     _.each(attr.options, function (category) {
                         if (category.children.length > 0) {

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -114,7 +114,7 @@ function PostEditorController(
             var attrs = _.chain(results[1])
                 .sortBy('priority')
                 .value();
-            $scope.categories = results[2];
+            var categories = results[2];
             // If attributesToIgnore is set, remove those attributes from set of fields to display
             var attributes = [];
             _.each(attrs, function (attr) {
@@ -139,6 +139,25 @@ function PostEditorController(
                         media = $scope.post.values[attr.key][0];
                     }
                     $scope.medias[attr.key] = {};
+                }
+                if (attr.input === 'tags') {
+                    // adding category-objects attribute-options
+                    attr.options = _.map(attr.options, function (category) {
+                            return _.findWhere(categories, {id: category});
+                        });
+                    // adding category-objects to children
+                    _.each(attr.options, function (category) {
+                        if (category.children.length > 0) {
+                            category.children = _.chain(category.children)
+                                .map(function (child) {
+                                    return _.findWhere(attr.options, {id: child.id});
+                                })
+                                .filter(function (child) {
+                                    return child !== undefined;
+                                })
+                                .value();
+                        }
+                    });
                 }
                 // @todo don't assign default when editing? or do something more sane
                 if (!$scope.post.values[attr.key]) {

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -152,9 +152,7 @@ function PostEditorController(
                                 .map(function (child) {
                                     return _.findWhere(attr.options, {id: child.id});
                                 })
-                                .filter(function (child) {
-                                    return child !== undefined;
-                                })
+                                .filter()
                                 .value();
                         }
                     });

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -605,7 +605,7 @@ function SurveyEditorController(
         _.each($scope.survey.tasks, function (task) {
             _.each(task.attributes, function (attribute) {
                 // removing faulty category-ids
-                if (attribute.input === 'tags') {
+                if (attribute.type === 'tags') {
                     attribute.options = _.filter(attribute.options, function (option) {
                         return !isNaN(option);
                     });

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -551,11 +551,7 @@ function SurveyEditorController(
 
     function saveSurvey() {
         $scope.saving_survey = true;
-        if (!$scope.surveyId) {
-            $scope.survey.tags = extractTags();
-        }
         // Saving a survey is a 3 step process
-
         // First save the actual survey
         FormEndpoint
         .saveCache($scope.survey)
@@ -604,26 +600,16 @@ function SurveyEditorController(
         }, handleResponseErrors);
     }
 
-    function extractTags() {
-        var tags = [];
-        _.each($scope.survey.tasks, function (task) {
-            _.each(task.attributes, function (attribute) {
-                if (attribute.type === 'tags') {
-                    _.each(attribute.options, function (tag) {
-                        if (tags.indexOf(tag) < 0) {
-                            tags.push(parseInt(tag));
-                        }
-                    });
-                }
-            });
-        });
-        return tags;
-    }
-
     function saveAttributes() {
         var calls = [];
         _.each($scope.survey.tasks, function (task) {
             _.each(task.attributes, function (attribute) {
+                // removing faulty category-ids
+                if (attribute.input === 'tags') {
+                    attribute.options = _.filter(attribute.options, function (option) {
+                        return !isNaN(option);
+                    });
+                }
                 attribute.form_stage_id = task.id;
                 calls.push(
                     FormAttributeEndpoint


### PR DESCRIPTION
This pull request makes the following changes:
- Displays correct categories when adding / editing a post
- Makes it possible to add a category from a post

Testing checklist:
- [x] Add a new post to a field with categories
- [x] Make sure the categories connected to that form is displayed
- [x] Add a new category through clicking on 'Add category' under the category-list, make sure it saves and is displayed as an option.
- [x] The above should also work for editing a post. 

Link to QA-deployment: http://qa.category-add-and-filter.ushahidilab.com
Fixes ushahidi/platform#1397 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/654)
<!-- Reviewable:end -->