### PR TITLE
Removing default category field addition for imported data

### DIFF
--- a/app/settings/data-import/data-import.directive.js
+++ b/app/settings/data-import/data-import.directive.js
@@ -189,11 +189,6 @@ function (
                             'label': descLabel,
                             'priority': 1,
                             'required': true
-                        },
-                        {
-                            'key': 'tags',
-                            'label': $translate.instant('post.modify.form.categories'),
-                            'priority': 2
                         }
                     )
                     .sortBy('priority')


### PR DESCRIPTION
This pull request makes the following changes:
- Removes category field added by default, as category is now a survey field type

Testing checklist:
- [x] When importing data for a Survey that has a category field, category should appear as a mapping option only once
- [x] When importing data for a Survey that has no category field, category should not appear as a mapping option

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/655)
<!-- Reviewable:end -->
