### PR TITLE
Fixed bug that prevented delete all for selected categories

### DIFF
--- a/app/settings/categories/categories.controller.js
+++ b/app/settings/categories/categories.controller.js
@@ -33,6 +33,7 @@ function (
 
     $scope.refreshView = function () {
         TagEndpoint.queryFresh().$promise.then(function (tags) {
+            $scope.allCategories = tags;
             $scope.categories = _.map(_.where(tags, { parent_id: null }), function (tag) {
                 if (tag && tag.children) {
                     tag.children = _.map(tag.children, function (child) {

--- a/app/settings/categories/categories.controller.js
+++ b/app/settings/categories/categories.controller.js
@@ -72,7 +72,7 @@ function (
     };
 
     $scope.toggleCategory = function (tag) {
-        var idx = $scope.selectedCategories.indexOf(tag);
+        var idx = $scope.selectedCategories.indexOf(tag.id);
         if (idx > -1) {
             $scope.selectedCategories.splice(idx, 1);
         } else {

--- a/app/settings/categories/categories.controller.js
+++ b/app/settings/categories/categories.controller.js
@@ -57,8 +57,8 @@ function (
     $scope.deleteCategories = function () {
         Notify.confirm('notify.category.bulk_destroy_confirm', { count: $scope.selectedCategories.length }).then(function () {
             var calls = [];
-            angular.forEach($scope.selectedCategories, function (tag) {
-                calls.push(TagEndpoint.delete(tag).$promise);
+            angular.forEach($scope.selectedCategories, function (tagId) {
+                calls.push(TagEndpoint.delete({id: tagId }).$promise);
             });
             $q.all(calls).then(function () {
                 Notify.notify('notify.category.bulk_destroy_success', { count: $scope.selectedCategories.length });
@@ -76,7 +76,7 @@ function (
         if (idx > -1) {
             $scope.selectedCategories.splice(idx, 1);
         } else {
-            $scope.selectedCategories.push(tag);
+            $scope.selectedCategories.push(tag.id);
         }
     };
 

--- a/app/settings/categories/categories.html
+++ b/app/settings/categories/categories.html
@@ -42,7 +42,7 @@
                 <div id="category-{{category.id}}" class="listing-item" ng-repeat="category in categories" ng-class="{ 'warning': isToggled(category) }" ng-click="toggleCategory(category)">
 
                     <div class="listing-item-select">
-                        <input type="checkbox" value="{{category.id}}" ng-checked="isToggled(category)">
+                        <input type="checkbox" value="{{category.id}}" ng-checked="isToggled(category)"></input>
                     </div>
 
                     <div class="listing-item-primary">
@@ -57,17 +57,17 @@
                             </button>
                     </div>
 
-                    <div id="category-{{category.id}}" class="  listing-item" ng-repeat="child in category.children" ng-class="{ 'warning': isToggled(category) }" ng-click="toggleCategory(category)" ng-style="{'marginLeft': '50px', 'border': 'none'}" ng-if="category.children">
+                    <div id="category-{{category.id}}" class="  listing-item" ng-repeat="child in category.children" ng-class="{ 'warning': isToggled(child) }" ng-click="toggleCategory(child)" ng-style="{'marginLeft': '50px', 'border': 'none'}" ng-if="category.children">
 
                         <div class="listing-item-select">
-                            <input type="checkbox" value="{{category.id}}" ng-checked="isToggled(category)">
+                            <input type="checkbox" value="{{child.id}}" ng-checked="isToggled(child)">
                         </div>
 
                         <div class="listing-item-primary">
                             <h2 class="listing-item-title"><a ng-href="/settings/categories/{{child.id}}">{{child.tag}}</a></h2>
                         </div>
                         <div class="listing-item-secondary">
-                            <button class="button-beta button-flat" ng-click="deleteCategory(category)">
+                            <button class="button-beta button-flat" ng-click="deleteCategory(child)">
                                 <svg class="iconic">
                                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                                 </svg>

--- a/app/settings/categories/categories.html
+++ b/app/settings/categories/categories.html
@@ -77,7 +77,7 @@
                     </div>
                 </div>
 
-                <listing-toolbar entities="categories" selected-set="selectedCategories">
+                <listing-toolbar entities="allCategories" selected-set="selectedCategories">
                     <button type="button" class="button-destructive" ng-disabled="!selectedCategories.length" ng-click="deleteCategories()">
                         <svg class="iconic">
                             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>

--- a/app/settings/categories/categories.html
+++ b/app/settings/categories/categories.html
@@ -39,9 +39,9 @@
                     <p ng-hide="categories.length"><em translate>empty.category</em></p>
                 </div>
 
-                <div id="category-{{category.id}}" class="listing-item" ng-repeat="category in categories" ng-class="{ 'warning': isToggled(category) }" ng-click="toggleCategory(category)">
+                <div id="category-{{category.id}}" class="listing-item" ng-repeat="category in categories" ng-class="{ 'warning': isToggled(category) }">
 
-                    <div class="listing-item-select">
+                    <div class="listing-item-select" ng-click="toggleCategory(category)">
                         <input type="checkbox" value="{{category.id}}" ng-checked="isToggled(category)"></input>
                     </div>
 
@@ -54,10 +54,10 @@
                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                             </svg>
                             <span class="hidden">Delete</span>
-                            </button>
+                        </button>
                     </div>
 
-                    <div id="category-{{category.id}}" class="  listing-item" ng-repeat="child in category.children" ng-class="{ 'warning': isToggled(child) }" ng-click="toggleCategory(child)" ng-style="{'marginLeft': '50px', 'border': 'none'}" ng-if="category.children">
+                    <div id="category-{{child.id}}" class="listing-item" ng-repeat="child in category.children" ng-class="{ 'warning': isToggled(child) }" ng-click="toggleCategory(child)" ng-style="{'marginLeft': '50px', 'border': 'none'}" ng-if="category.children">
 
                         <div class="listing-item-select">
                             <input type="checkbox" value="{{child.id}}" ng-checked="isToggled(child)">


### PR DESCRIPTION
This pull request makes the following changes:
- Fixed bug where category was being added to select list rather than category id

Testing checklist:
- [ ] On Category list view, select a category, then when the toolbar actions appear, click Select All, then click delete, confirm deletion, all categories should be deleted
- [ ] Having created categories with parents, select the child category, only the child category should be selected
- [ ] Delete the child category only the child category should be deleted
- [ ] Having created categories with parents, select the parent category, only the parent category should be selected
- [ ] Select a category, then hit select all, then unselect one of the categories, the number of selected categories should decrease

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/656)
<!-- Reviewable:end -->
