### PR TITLE
Fix removing attributes from forms

### DIFF
--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -111,7 +111,7 @@
         </div>
    </div>
    <div class="form-field">
-      <button ng-show="!editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute)" translate="app.add_and_close">Add &amp; close</button>
-      <button ng-show="editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute)" translate="app.update_and_close">Update &amp; close</button>
+      <button ng-show="!editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask)" translate="app.add_and_close">Add &amp; close</button>
+      <button ng-show="editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask)" translate="app.update_and_close">Update &amp; close</button>
    </div>
 </div>

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -423,8 +423,8 @@ function SurveyEditorController(
         return $scope.survey.tasks.length ? _.last($scope.survey.tasks).priority + 1 : 0;
     }
 
-    function getNewAttributePriority() {
-        return $scope.activeTask.attributes.length ? _.last($scope.activeTask.attributes).priority + 1 : 0;
+    function getNewAttributePriority(task) {
+        return task.attributes.length ? _.last(task.attributes).priority + 1 : 0;
     }
 
     function addNewTask(task) {
@@ -454,7 +454,7 @@ function SurveyEditorController(
         ModalService.openTemplate('<survey-attribute-editor></survey-attribute-editor>', title, '', $scope, true, true);
     }
 
-    function addNewAttribute(attribute) {
+    function addNewAttribute(attribute, task) {
         ModalService.close();
         // Set active task as form_stage_id
         // If this task is new and has not been saved
@@ -463,18 +463,18 @@ function SurveyEditorController(
         // TODO refactor this
         if (!attribute.form_stage_id) {
             // Set attribute priority
-            attribute.priority = getNewAttributePriority();
-            attribute.form_stage_id = $scope.activeTask.id ? $scope.activeTask.id : $scope.activeTask.label;
-            $scope.activeTask.attributes.push(attribute);
+            attribute.priority = getNewAttributePriority(task);
+            attribute.form_stage_id = task.id ? task.id : task.label;
+            task.attributes.push(attribute);
         }
     }
 
-    function deleteAttribute(attribute) {
+    function deleteAttribute(attribute, task) {
         Notify.confirmDelete('notify.form.delete_attribute_confirm').then(function () {
             // If we have not yet saved this attribute
             // we can drop it immediately
             if (!attribute.id) {
-                $scope.activeTask.attributes = _.filter($scope.activeTask.attributes, function (item) {
+                task.attributes = _.filter(task.attributes, function (item) {
                     return item.label !== attribute.label;
                 });
                 // Attribute delete is currently only available in modal
@@ -488,11 +488,11 @@ function SurveyEditorController(
                 id: attribute.id
             }).$promise.then(function (attribute) {
                 // Remove attribute from scope, binding should take care of the rest
-                var index = _.findIndex($scope.activeTask.attributes, function (item) {
+                var index = _.findIndex(task.attributes, function (item) {
                     return item.id === attribute.id;
                 });
 
-                $scope.activeTask.attributes.splice(index, 1);
+                task.attributes.splice(index, 1);
 
                 FormStageEndpoint.invalidateCache();
 

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -91,7 +91,7 @@
                  </div>
               </div>
               <div class="listing-item-secondary" ng-show="onlyOptional(attribute)">
-                  <button class="button-beta button-flat" ng-click="deleteAttribute(editAttribute)">
+                  <button class="button-beta button-flat" ng-click="deleteAttribute(attribute, survey.tasks[0])">
                       <svg class="iconic">
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                       </svg>
@@ -285,8 +285,9 @@
                          </button>
                      </div>
                   </div>
+
                   <div class="listing-item-secondary" ng-show="onlyOptional(attribute)">
-                      <button class="button-beta button-flat" ng-click="deleteAttribute(editAttribute)">
+                      <button class="button-beta button-flat" ng-click="deleteAttribute(attribute, task)">
                           <svg class="iconic">
                               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                           </svg>


### PR DESCRIPTION
This pull request makes the following changes:
- Pass task into delete attribute callback
- Strip out defunct uses of activeTask in survey editor
- Fix typo in attribute param passed to deleteAttribute

Testing checklist:
- [x] Delete a field from a survey and save
- [x] Add a field to a survey and save

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/657)
<!-- Reviewable:end -->
