### PR TITLE
Add more explicit notifications when deleting a category

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -714,7 +714,7 @@
         "save_add_another" : "Save & Add Another",
         "delete_category" : "Delete category",
         "delete_this_category" : "Delete this category",
-        "delete_category_desc" : "<strong>If you delete this category</strong>, it will no longer be asociated with any posts. Proceed with caution.",
+        "delete_category_desc" : "<strong>If you delete this category</strong>, it will no longer be associated with any posts. Proceed with caution.",
         "select_all" : "Select All",
         "choose_roles" : "Choose Roles",
         "create_tag" : "Create Category",
@@ -1027,9 +1027,11 @@
         "category" : {
             "save_success" : "Saved category {{name}}",
             "destroy_confirm" : "Are you sure you want to delete this category?",
+            "destroy_confirm_desc": "Deleting this category will remove it from all existing posts. This action cannot be undone.",
             "destroy_success" : "Category deleted",
             "destroy_error" : "Unable to delete category, please try again",
             "bulk_destroy_confirm" : "Are you sure you want to delete {{count}} categories?",
+            "bulk_destroy_confirm_desc" : "Deleting these categories will remove them from all existing posts. This action cannot be undone.",
             "bulk_destroy_success" : "{{count}} categories deleted"
         },
         "role" : {

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -122,15 +122,20 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         return deferred.promise;
     }
 
-    function confirmDelete(confirmText, translateValues) {
+    function confirmDelete(confirmText, confirmWarningText, translateValues) {
         var deferred = $q.defer();
-
         var scope = getScope();
+
+        if (typeof confirmWarningText === 'object') {
+            translateValues = confirmWarningText;
+            confirmWarningText = false;
+        }
 
         $translate(confirmText, translateValues).then(show, show);
 
         function show(confirmText) {
             scope.confirmText = confirmText;
+            scope.confirmWarningText = confirmWarningText || 'notify.default.proceed_warning';
             // If modal is already open?
             if (ModalService.getState()) {
                 scope.cancel = function () {
@@ -144,7 +149,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 // Open in slider
                 SliderService.openTemplate(
                     '<p>{{ confirmText }}</p>' +
-                    '<p><i translate>notify.default.proceed_warning</i></p>' +
+                    '<p><i translate="{{confirmWarningText}}"></i></p>' +
                     '    <button class="button-flat" ng-click="$parent.cancel()" translate="message.button.cancel">Cancel</button>' +
                     '    <button class="button-destructive button-flat" ng-click="$parent.confirm()">' +
                     '    <svg class="iconic"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="' + iconicSprite + '#trash"></use></svg>' +
@@ -163,7 +168,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 // Otherwise confirm in modal
                 ModalService.openTemplate(
                 '<div class="form-field">' +
-                '<p><i translate>notify.default.proceed_warning</i></p>' +
+                '<p><i translate="{{confirmWarningText}}"></i></p>' +
                 '    <button class="button-beta button-flat" ng-click="$parent.cancel()">Cancel</button>' +
                 '    <button class="button-destructive button-flat" ng-click="$parent.confirm()">' +
                 '    <svg class="iconic"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="' + iconicSprite + '#trash"></use></svg>' +

--- a/app/settings/categories/categories.controller.js
+++ b/app/settings/categories/categories.controller.js
@@ -48,15 +48,16 @@ function (
     $scope.refreshView();
 
     $scope.deleteCategory = function (tag) {
-        Notify.confirm('notify.category.destroy_confirm').then(function () {
+        Notify.confirmDelete('notify.category.destroy_confirm', 'notify.category.destroy_confirm_desc').then(function () {
             TagEndpoint.delete(tag).$promise.then(function () {
-                Notify.notify('notify.category.destroy_success');
+                Notify.notify('notify.category.destroy_success', { name: tag.tag });
                 $scope.refreshView();
-            });
+            }, handleResponseErrors);
         });
     };
+
     $scope.deleteCategories = function () {
-        Notify.confirm('notify.category.bulk_destroy_confirm', { count: $scope.selectedCategories.length }).then(function () {
+        Notify.confirmDelete('notify.category.bulk_destroy_confirm', 'notify.category.bulk_destroy_confirm_desc', { count: $scope.selectedCategories.length }).then(function () {
             var calls = [];
             angular.forEach($scope.selectedCategories, function (tagId) {
                 calls.push(TagEndpoint.delete({id: tagId }).$promise);
@@ -64,7 +65,7 @@ function (
             $q.all(calls).then(function () {
                 Notify.notify('notify.category.bulk_destroy_success', { count: $scope.selectedCategories.length });
                 $scope.refreshView();
-            });
+            }, handleResponseErrors);
         });
     };
 
@@ -80,5 +81,9 @@ function (
             $scope.selectedCategories.push(tag.id);
         }
     };
+
+    function handleResponseErrors(errorResponse) {
+        Notify.apiErrors(errorResponse);
+    }
 
 }];

--- a/test/unit/common/notifications/notify.service.spec.js
+++ b/test/unit/common/notifications/notify.service.spec.js
@@ -163,6 +163,27 @@ describe('Notify', function () {
             expect(mockModalService.openTemplate).toHaveBeenCalled();
         });
 
+        it('Calls ModalService.openTemplate with error message + warning text', function () {
+            mockModalService.state = false;
+            Notify.confirmDelete('Test message', 'Warning message');
+            $rootScope.$digest();
+
+            expect(mockModalService.openTemplate).toHaveBeenCalledWith(jasmine.any(String), 'Test message', false, jasmine.objectContaining({
+                confirmText: 'Test message',
+                confirmWarningText: 'Warning message'
+            }), false, false);
+        });
+
+        it('Handles vars as second argument', function () {
+            mockModalService.state = false;
+            Notify.confirmDelete('Test message', {'var': 1});
+            $rootScope.$digest();
+
+            expect(mockModalService.openTemplate).toHaveBeenCalledWith(jasmine.any(String), 'Test message', false, jasmine.objectContaining({
+                confirmText: 'Test message'
+            }), false, false);
+        });
+
         it('If modal is open, Calls SliderService.openTemplate with error message', function () {
             mockModalService.state = true;
 


### PR DESCRIPTION
This pull request makes the following changes:
- Use notify.confirmDelete when deleting a category
- Allow customizing the messaging on the delete modal

Testing checklist:
- [x] Try to delete a single category and check error message
- [x] Delete many categories and check the error message

Refs ushahidi/platform#1397

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/658)
<!-- Reviewable:end -->
