### PR TITLE
Deselecting children when deselecting a parent

### DIFF
--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -90,7 +90,6 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
     function selectParent(parent, formId) {
         // If we've just selected the tag
         if (_.contains($scope.filters.tags, parent.id)) {
-            console.log('selected');
             // ... then select its children too
             _.each(parent.children, function (child) {
                 $scope.filters.tags.push(child.id);

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -90,6 +90,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
     function selectParent(parent, formId) {
         // If we've just selected the tag
         if (_.contains($scope.filters.tags, parent.id)) {
+            console.log('selected');
             // ... then select its children too
             _.each(parent.children, function (child) {
                 $scope.filters.tags.push(child.id);
@@ -102,7 +103,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
             // Deselect the children too
             _.each(parent.children, function (child) {
                 // Remove each child without replacing the tags array
-                var index = $scope.filters.tags.indexOf(child);
+                var index = $scope.filters.tags.indexOf(child.id);
                 if (index !== -1) {
                     $scope.filters.tags.splice(index, 1);
                 }


### PR DESCRIPTION
This pull request makes the following changes:
- When a parent is deselected in the mode-context-bar, the children is also deselected

Testing checklist:
- [x] Add a post which contains a child-tag (this is for testing-purposes)
- [x] Select the parent in mode-context-bar
  - [x] The post should be visible
- [x] Deselect the parent in the mode-context-bar
  - [x] The child tag should also be deselected and the post should not appear.

QA can be done here: http://qa.filtering-categories-fix.ushahidilab.com

Fixes ushahidi/platform#1397 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform-client/660)
<!-- Reviewable:end -->
