### PR TITLE
Changed labels to categories in surveys and categories settings

### DIFF
--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -63,7 +63,7 @@
                   data-toggle="dropdown-menu"
                   dropdown-toggle
                 >
-                  <span class="legend-label">This label is a child to
+                  <span class="legend-label">This category is a child to
                     <span class="custom-fieldset-value">{{getParentName()}}</span>
                   </span>
                   <svg class="iconic chevron">
@@ -101,7 +101,7 @@
                 </div>
               </fieldset>
               <!-- Who can see and add -->
-              <role-selector model="category" title="'Who can see this label'"></role-selector>
+              <role-selector model="category" title="'Who can see this category'"></role-selector>
             </div>
           </form>
           <div class="form-sheet" ng-show="category.id">

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -31,7 +31,7 @@
    </div>
    <!-- editing/adding categories -->
     <div class="form-field" ng-if="editAttribute.input ==='tags'">
-      <label translate>Which labels should be available</label>
+      <label translate>Which categories should be available</label>
         <div
           class="form-field checkbox"
           ng-repeat="category in availableCategories"


### PR DESCRIPTION
This pull request makes the following changes:
-removes references to "labels" and replaces them with "categories"

Testing checklist:
- [ ]

Fixes ushahidi/platform# 1763.

Ping @ushahidi/platform
