### PR TITLE
Added ability to select all categories and show/hide categories list

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -81,6 +81,7 @@ angular.module('ushahidi.common', [
 .directive('fileUpload', require('./directives/file-upload.directive.js'))
 .directive('roleSelector', require('./directives/role-selector.directive.js'))
 .directive('addCategory', require('./directives/add-category.directive.js'))
+.directive('categorySelector', require('./directives/category-selector.directive.js'))
 .directive('languageSwitch', require('./directives/language-switch.directive.js'))
 
 // Event actions

--- a/app/common/directives/add-category.html
+++ b/app/common/directives/add-category.html
@@ -28,6 +28,6 @@
             <span class="hidden">Delete</span>
         </button>
 </div>
-<div class="form-field init" ng-click="showInputToggle()" ng-if="userCanAddCategory">
+<div class="form-field init" ng-click="showInputToggle()" ng-if="userCanAddCategory && !showInput">
     <a data-toggle="add-label">+ Add new category</a>
 </div>

--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -1,0 +1,96 @@
+module.exports = CategorySelectorDirective;
+
+CategorySelectorDirective.$inject = [];
+
+function CategorySelectorDirective() {
+    return {
+        restrict: 'E',
+        scope: {
+            available: '=',
+            selected: '='
+        },
+        controller: CategorySelectorController,
+        template: require('./category-selector.html')
+    };
+}
+CategorySelectorController.$inject = ['$scope', '_'];
+
+function CategorySelectorController($scope, _) {
+
+    $scope.selectAll = selectAll;
+    $scope.selectChild = selectChild;
+    $scope.selectParent = selectParent;
+
+    activate();
+
+    function activate() {
+
+        // remove default null value when creating a new post
+        if ($scope.selected[0] === null) {
+            $scope.selected = [];
+        }
+
+        // filter out child categories posing as available parent
+        $scope.available = _.filter($scope.available, function (category) {
+            return category.parent_id === null;
+        });
+
+        flattenCategories();
+
+    }
+
+    function flattenCategories() {
+        $scope.flattened = [];
+        _.each($scope.available, function (category) {
+            $scope.flattened.push(category);
+            if (category.children && category.children.length) {
+                _.each(category.children, function (subcategory) {
+                    $scope.flattened.push(subcategory);
+                });
+            }
+        });
+    }
+
+    function selectAll() {
+        if ($scope.flattened.length === $scope.selected.length) {
+            $scope.selected.length = [];
+        } else {
+            _.each($scope.flattened, function (category) {
+                if (!_.contains($scope.selected, category.id)) {
+                    $scope.selected.push(category.id);
+                }
+            });
+        }
+    }
+
+    function selectChild(child) {
+        if ($scope.selected.includes(child.id)) {
+            $scope.selected = _.filter($scope.selected, function (id) {
+                return id !== child.id;
+            });
+        } else {
+            $scope.selected.push(child.id);
+            if (!$scope.selected.includes(child.parent.id)) {
+                $scope.selected.push(child.parent.id);
+            }
+        }
+    }
+
+    function selectParent(parent) {
+        if ($scope.selected.includes(parent.id)) {
+            $scope.selected = _.filter($scope.selected, function (id) {
+                return id !== parent.id;
+            });
+            if (parent.children && parent.children.length) {
+                _.each(parent.children, function (child) {
+                    $scope.selected = _.filter($scope.selected, function (id) {
+                        return id !== child.id;
+                    });
+                });
+            }
+        } else {
+            $scope.selected.push(parent.id);
+        }
+    }
+
+}

--- a/app/common/directives/category-selector.html
+++ b/app/common/directives/category-selector.html
@@ -1,0 +1,46 @@
+<div class="form-field switch">
+    <label translate="category.show_categories"></label>
+    <div class="toggle-switch">
+        <input
+            id="categories"
+            class="tgl init"
+            ng-click="showCategories=!showCategories"
+            type="checkbox"
+        >
+        <label class="tgl-btn" for="categories"></label>
+    </div>
+</div>
+<div class="form-field">
+    <div ng-show="showCategories">
+        <div class="form-field checkbox">
+            <label>
+                <input
+                  type="checkbox"
+                  ng-checked="flattened.length === selected.length"
+                  ng-click="selectAll()"
+                />
+                <span translate="category.select_all"></span>
+            </label>
+        </div>
+        <div class="form-field checkbox" ng-repeat="category in available">
+            <label>
+                <input
+                  type="checkbox"
+                  ng-checked="selected.includes(category.id)"
+                  ng-click="selectParent(category)"
+                />
+                {{category.tag}}
+            </label>
+            <div class="form-field checkbox" ng-if="category.children" ng-repeat="child in category.children">
+                <label>
+                    <input
+                      type="checkbox"
+                      ng-checked="selected.includes(child.id)"
+                      ng-click="selectChild(child)"
+                    />
+                    {{child.tag}}
+                </label>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -715,6 +715,7 @@
         "delete_category" : "Delete category",
         "delete_this_category" : "Delete this category",
         "delete_category_desc" : "<strong>If you delete this category</strong>, it will no longer be associated with any posts. Proceed with caution.",
+        "show_categories" : "Show available categories",
         "select_all" : "Select All",
         "choose_roles" : "Choose Roles",
         "create_tag" : "Create Category",

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -191,49 +191,17 @@
           </label>
         </div>
       </div>
-
     <!-- type: categories -->
-      <div ng-switch-when="tags">
-        <div 
-          class="form-field checkbox"
-          ng-repeat="option in attribute.options"
-          ng-if="option.parent_id === null"
-          >
-        <label>
-          <input 
-                type="checkbox"
-                checklist-model="post.values[attribute.key]"
-                name="values_{{attribute.id}}_{{option}}"
-                checklist-value="option.id"
-                value="option.id"
-                ng-click="selectParent(option, attribute.key)"
-            >
-                {{option.tag}}
-        </label>
-        <div 
-          class="form-field checkbox"
-          ng-if="option.children"
-          ng-repeat="child in option.children"
-        >
-          <label>
-          <input 
-            type="checkbox"
-            checklist-model="post.values[attribute.key]"
-            name="values_{{attribute.id}}_{{child}}"
-            checklist-value="child.id"
-            value="child.id"
-            ng-click="selectChild(child, attribute.key)"
-          >
-            {{child.tag}}
-        </label>
-    </div> 
-    </div>
-
-      <add-category
-        form-id="post.form.id"
-        attribute="attribute"
-        post-value="post.values[attribute.key]"
-      ></add-category>
+    <div ng-switch-when="tags">
+        <category-selector
+            available="attribute.options"
+            selected="post.values[attribute.key]"
+        ></category-selector>
+        <add-category
+            form-id="post.form.id"
+            attribute="attribute"
+            post-value="post.values[attribute.key]"
+        ></add-category>
     </div>
     <div class="alert error" ng-show="form['values_' + attribute.id].$dirty && taskIsMarkedCompleted()" ng-repeat="(error, value) in form['values_' + attribute.id].$error">
         <svg class="iconic">

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -31,35 +31,12 @@
    </div>
    <!-- editing/adding categories -->
     <div class="form-field" ng-if="editAttribute.input ==='tags'">
-      <label translate>Which categories should be available</label>
-        <div
-          class="form-field checkbox"
-          ng-repeat="category in availableCategories"
-        >
-            <label>
-              <input
-                type="checkbox"
-                checklist-model="editAttribute.options"
-                checklist-value="category.id"
-              />
-              {{category.tag}}
-            </label>
-            <div
-              class="form-field checkbox"
-              ng-if="category.children"
-              ng-repeat="child in category.children">
-                <label>
-                <input
-                  type="checkbox"
-                  checklist-model="editAttribute.options"
-                  checklist-value="child.id"
-                  ng-click="selectChild(child)"
-                />
-                {{child.tag}}
-                </label>
-              </div>
-        </div>
-      </div>
+        <label translate>Which categories should be available</label>
+        <category-selector
+            available="availableCategories"
+            selected="editAttribute.options"
+        ></category-selector>
+    </div>
     <!-- End of editing/adding categories -->
         <div class="form-field" ng-if="editAttribute.input === 'relation'">
             <label translate>survey.field_allowed_relation_survey</label>


### PR DESCRIPTION
This pull request makes the following changes:
- creates and installs a reusable categories selector
- adds 'select all' option to category checklist when creating a post
- adds 'select all' option to category checklist when creating a survey
- adds ability to show/hide categories list when creating a post
- adds ability to show/hide categories list when creating a survey
- hides 'add category' link when add category form is visible

Testing checklist:
- [x] When I toggle "Show available categories", I can see a list of available categories.
- [x] When I click "Select All", all the categories in the list of available categories are selected.
- [x] When I manually select all the categories, "Select All" is automatically checked.
- [x] When I select a child category and the parent category is not selected, it selects the parent category automatically.
- [x] When I deselect a parent category and the child category is selected, it deselects the child category automatically.

Fixes ushahidi/platform#1800.
Fixes ushahidi/platform#1801.

Ping @ushahidi/platform
