### PR TITLE
Fix issue with saving a duplicated survey

### DIFF
--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -276,6 +276,7 @@ function SurveyEditorController(
                 delete $scope.survey.updated;
                 delete $scope.survey.url;
                 delete $scope.survey.can_create;
+                delete $scope.survey.tags;
 
                 // Reset Task and Attribute IDs
                 _.each($scope.survey.tasks, function (task) {


### PR DESCRIPTION
This pull request makes the following changes:
- removes "tags" property of survey when loading survey data for a duplicate survey, preventing an attempt to save a "tags" column that does not exist in the form table

Testing checklist:
- [x] When I attempt to save a new duplicated survey, I receive no error message and the survey is successfully saved.

Fixes ushahidi/platform#1809.

Ping @ushahidi/platform
