### PR TITLE
Fixed styling for datepicker opened with filter modal

### DIFF
--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -1,26 +1,38 @@
 <fieldset>
-    <legend translate>global_filter.date_range</legend>
-    <div class="form-field date">
-        <label class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
-        <div class="input-with-icon">
-            <svg class="iconic">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
-            </svg>
-            <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
-        </div>
+  <legend translate>global_filter.date_range</legend>
+  <div class="form-field date">
+    <label class="hidden" translate="global_filter.filter_tabs.created_after">
+      Start date
+    </label>
+    <div class="input-with-icon">
+      <svg class="iconic">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
+      </svg>
+      <input
+        type="date"
+        pick-a-date="dateAfter"
+        pick-a-date-options="dateFormat"
+        placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}"
+        ng-model="dateAfterModel"
+      />
     </div>
-            <span class="date-joiner">to</span>
-
-
-    <div class="form-field date">
-        <label class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
-        <div class="input-with-icon">
-            <svg class="iconic">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
-            </svg>
-        <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
+  </div>
+  <span class="date-joiner">to</span>
+  <div class="form-field date">
+    <label class="hidden" translate="global_filter.filter_tabs.created_before">
+      End date
+    </label>
+    <div class="input-with-icon">
+      <svg class="iconic">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
+      </svg>
+      <input
+        type="date"
+        pick-a-date="dateBefore"
+        pick-a-date-options="dateFormat"
+        placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}"
+        ng-model="dateBeforeModel"
+      />
     </div>
-</div>
-
-
+  </div>
 </fieldset>


### PR DESCRIPTION
This pull request makes the following changes:
- changes "pick-a-date-options" property from "options" to "dateFormat", which fixes styling for datepicker when opened with filter modal

Testing checklist:
- [ ]

Fixes ushahidi/platform#1803.

Ping @ushahidi/platform
