### PR TITLE
Fix fields not loading after creating a new survey

### DIFF
--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -563,6 +563,11 @@ function SurveyEditorController(
             // Second save the survey tasks
             saveTasks();
             saveRoles();
+            // Set ID and reload data if new survey
+            if ($scope.surveyId !== survey.id) {
+                $scope.surveyId = survey.id;
+                loadFormData();
+            }
         }, handleResponseErrors);
         $scope.saving_survey = false;
     }


### PR DESCRIPTION
This pull request makes the following changes:
- Sets survey ID and reloads form data after saving a new survey

Testing checklist:
- [x] After creating a survey and saving, the survey fields are visible

Fixes ushahidi/platform#1815.
Fixes ushahidi/platform#1750.

Ping @ushahidi/platform
