### PR TITLE
Removed auto-focus on posts so default view is always used

### DIFF
--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -78,9 +78,6 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
             markers.addTo(map);
 
-            if (posts.features.length > 0) {
-                map.fitBounds(geojson.getBounds());
-            }
             // Focus map on data points but..
             // Avoid zooming further than 15 (particularly when we just have a single point)
             if (map.getZoom() > 15) {


### PR DESCRIPTION
This pull request makes the following changes:
- removes auto-focus on posts so default view is always used

Testing checklist:
- [x] When I add posts to a new deployment, the map does not automatically zoom in on the posts, instead the map always uses the default map configuration settings.

Fixes ushahidi/platform#1736.

Ping @ushahidi/platform
