### PR TITLE
Label and input ids were conflicting for task configure tab

### DIFF
--- a/app/main/posts/modify/post-tabs.directive.js
+++ b/app/main/posts/modify/post-tabs.directive.js
@@ -4,7 +4,6 @@ PostVerticalTabs.$inject = [];
 function PostVerticalTabs() {
     return {
         restrict: 'E',
-        replace: true,
         scope: {
             form: '=',
             post: '=',
@@ -12,8 +11,8 @@ function PostVerticalTabs() {
             attributes: '=',
             visibleStage: '='
         },
-        controller: PostVerticalTabsController,
-        template: require('./post-tabs.html')
+        template: require('./post-tabs.html'),
+        controller: PostVerticalTabsController
     };
 }
 
@@ -37,6 +36,7 @@ function PostVerticalTabsController(
     $scope.stageIsComplete = stageIsComplete;
     $scope.toggleStageCompletion = toggleStageCompletion;
 
+
     activate();
 
     function activate() {
@@ -48,11 +48,10 @@ function PostVerticalTabsController(
     }
 
     function stageIsComplete(stageId) {
-        return _.includes($scope.post.completed_stages, stageId);
+        return $scope.post.completed_stages.indexOf(stageId) > -1;
     }
 
     function toggleStageCompletion(stageId) {
-
         stageId = parseInt(stageId);
         if (_.includes($scope.post.completed_stages, stageId)) {
             $scope.post.completed_stages = _.without($scope.post.completed_stages, stageId);

--- a/app/main/posts/modify/post-tabs.html
+++ b/app/main/posts/modify/post-tabs.html
@@ -8,11 +8,12 @@
         <div class="toggle-switch">
             <input
                 class="tgl"
-                id="switchT"
+                ng-attr-id="{{ 'toggle-complete-' + stage.id }}"
                 type="checkbox"
-                ng-checked="stageIsComplete(stage.id)"
+                
                 ng-click="toggleStageCompletion(stage.id)">
-            <label class="tgl-btn" for="switchT"></label>
+            <label class="tgl-btn" for="toggle-complete-{{stage.id}}" ng-attr-id="{{ 'toggle-complete-label-' + stage.id }}"></label>
+        
         </div>
     </div>
     <post-value-edit

--- a/app/main/posts/modify/post-tabs.html
+++ b/app/main/posts/modify/post-tabs.html
@@ -10,7 +10,7 @@
                 class="tgl"
                 ng-attr-id="{{ 'toggle-complete-' + stage.id }}"
                 type="checkbox"
-                
+                ng-checked="stageIsComplete(stage.id)"
                 ng-click="toggleStageCompletion(stage.id)">
             <label class="tgl-btn" for="toggle-complete-{{stage.id}}" ng-attr-id="{{ 'toggle-complete-label-' + stage.id }}"></label>
         

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -333,18 +333,18 @@
           <div class="form-field switch">
             <label translate="survey.required">Required</label>
             <p data-fieldgroup-target="require-review-message" ng-show="task.required" translate="survey.required_desc">Require this section be completed before a post can be visible to the public.</p>
-            <div class="toggle-switch">
-                <input class="tgl" id="task-required" type="checkbox" ng-model="task.required">
-                <label class="tgl-btn" for="task-required"></label>
+            <div class="toggle-switch" ng-attr-id="{{ 'toggle-switch-required-' + task.id }}">
+                <input class="tgl" ng-attr-id="{{ 'task-required-' + task.id }}" type="checkbox" ng-model="task.required">
+                <label class="tgl-btn" for="task-required-{{task.id}}" ng-attr-id="{{ 'task-required-label-' + task.id }}"></label>
             </div>
         </div>
           <div class="form-field switch checked">
               <label translate="survey.show_this_task_to">Show this task to everyone when published</label>
               <p data-fieldgroup-target="show_section-message" class="active" ng-show="task.show_when_published" translate="survey.show_this_task_to_desc">When a survey response is published, data from this section will be displayed.</p>
-              <div class="toggle-switch">
-                  <input class="tgl init" id="show_section" type="checkbox" data-fieldgroup-toggle="show_section-message" ng-model="task.show_when_published">
+              <div class="toggle-switch" ng-attr-id="{{ 'toggle-switch-show-' + task.id }}">
+                  <input class="tgl init" ng-attr-id="{{ 'show_section-' + task.id }}" type="checkbox" data-fieldgroup-toggle="show_section-message" ng-model="task.show_when_published">
 
-                  <label class="tgl-btn" for="show_section"></label>
+                  <label class="tgl-btn" for="show_section-{{task.id}}" ng-attr-id="{{ 'show_section-label-' + task.id }}"></label>
               </div>
           </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Set not conflicting ids for Task Configure Tab inputs and labels

Testing checklist:
- [x] Create a new survey
- [x] Add one task to the survey, click on the 'Configure' tab for the task
- [x] Toggle the 'Required' and 'Show this task to everyone when published' and ensure they turn on and off correctly
- [x] Add a second task to the survey, click on the 'Configure' tab for the task
- [x] Toggle the 'Required' and 'Show this task to everyone when published' and ensure they turn on and off correctly
- [x] Save the Survey
- [ ] Set the 'Required' toggle for the first task, confirm this works as expected by attempting to create a Post of this type
- [ ] Set the 'Required' toggle for the second task, confirm this works as expected by attempting to create a Post of this type
- [x] Set the 'Show this task to everyone when published' toggle for the second task, confirm this works as expected by attempting to create a Post of this type and publish it
- [x] Set the 'Show this task to everyone when published' toggle for the second task, confirm this works as expected by attempting to create a Post of this type and publish it

Fixes ushahidi/platform#1846

Ping @ushahidi/platform
