### PR TITLE
Set default location for each attribute and remove default location from general settings

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -67,6 +67,7 @@ angular.module('ushahidi.common', [
 .directive('iconPicker', require('./directives/iconpicker.js'))
 
 .directive('colorPicker', require('./directives/color-picker.js'))
+.directive('locationPicker', require('./directives/location-picker.directive.js'))
 .directive('firstTimeConfig', require('./directives/first-time-config.js'))
 .directive('ushModalContainer', require('./directives/modal-container.directive.js'))
 .directive('modalBody', require('./directives/modal-body.directive.js'))

--- a/app/common/directives/location-picker.directive.js
+++ b/app/common/directives/location-picker.directive.js
@@ -70,6 +70,12 @@ function LocationPickerDirective($http, L, Geocoding, Maps, _, Notify, $window) 
                     }).addTo(map);
                 }
                 // @todo: Should we watch the model and update map?
+
+                // Ensure map is fully loaded with modal and switch
+                setTimeout(function () {
+                    map.invalidateSize();
+                });
+
             });
         }
 
@@ -88,6 +94,12 @@ function LocationPickerDirective($http, L, Geocoding, Maps, _, Notify, $window) 
                 lat: lat,
                 lon: lon
             };
+
+            // Update parent scope when editing default location
+            if ($scope.$parent.editAttribute) {
+                $scope.$parent.editAttribute.default = $scope.model;
+            }
+
         }
 
         function updateMarkerPosition(lat, lon) {

--- a/app/common/directives/location-picker.directive.js
+++ b/app/common/directives/location-picker.directive.js
@@ -9,6 +9,7 @@ function LocationPickerDirective($http, L, Geocoding, Maps, _, Notify, $window) 
         scope: {
             id: '@',
             name: '@',
+            default: '=',
             model: '=',
             required: '='
         },
@@ -39,6 +40,16 @@ function LocationPickerDirective($http, L, Geocoding, Maps, _, Notify, $window) 
             Maps.createMap(element[0].querySelector('.map'))
             .then(function (data) {
                 map = data;
+
+                // If default property provided, set model to default value
+                if ($scope.default) {
+                    $scope.model = $scope.default;
+                }
+
+                // If model was stringified for save, parse model into object
+                if (typeof $scope.model === 'string') {
+                    $scope.model = JSON.parse($scope.model);
+                }
 
                 // init marker with current model value
                 if ($scope.model &&

--- a/app/common/directives/location-picker.directive.js
+++ b/app/common/directives/location-picker.directive.js
@@ -1,7 +1,8 @@
-module.exports = PostLocationDirective;
+module.exports = LocationPickerDirective;
 
-PostLocationDirective.$inject = ['$http', 'Leaflet', 'Geocoding', 'Maps', '_', 'Notify', '$window'];
-function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
+LocationPickerDirective.$inject = ['$http', 'Leaflet', 'Geocoding', 'Maps', '_', 'Notify', '$window'];
+
+function LocationPickerDirective($http, L, Geocoding, Maps, _, Notify, $window) {
     return {
         restrict: 'E',
         replace: true,
@@ -11,11 +12,11 @@ function PostLocationDirective($http, L, Geocoding, Maps, _, Notify, $window) {
             model: '=',
             required: '='
         },
-        template: require('./location.html'),
-        link: PostLocationLink
+        template: require('./location-picker.html'),
+        link: LocationPickerLink
     };
 
-    function PostLocationLink($scope, element, attrs) {
+    function LocationPickerLink($scope, element, attrs) {
         var currentPositionControl, map, marker,
             zoom = 8;
 

--- a/app/common/directives/location-picker.html
+++ b/app/common/directives/location-picker.html
@@ -1,4 +1,3 @@
- 
 <div class="location-wrapper">
     <div id="{{id}}-map" class="map" style="height: 265px; width: 100%;"></div>
     <form 

--- a/app/common/services/maps.js
+++ b/app/common/services/maps.js
@@ -69,8 +69,6 @@ function Maps(ConfigEndpoint, L, _, CONST) {
             return angular.extend(defaultConfig(),
             {
                 layers: [L.tileLayer(defaultLayer.url, defaultLayer.layerOptions)],
-                center: [config.default_view.lat, config.default_view.lon],
-                zoom: config.default_view.zoom,
                 clustering: config.clustering
             });
         });
@@ -114,7 +112,7 @@ function Maps(ConfigEndpoint, L, _, CONST) {
         return {
             scrollWheelZoom: false,
             center: [-1.2833, 36.8167], // Default to centered on Nairobi
-            zoom: 8,
+            zoom: 0,
             layers: [L.tileLayer(layers.baselayers.streets.url, layers.baselayers.streets.layerOptions)]
         };
     }

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -116,17 +116,20 @@
                   name="values_{{attribute.id}}"
                   model="post.values[attribute.key][key]"
                   ng-required="attribute.required"
-                  ng-switch-when="relation"></post-relation>
+                  ng-switch-when="relation"
+              ></post-relation>
               <!-- type: location -->
-              <post-location
+              <location-picker
                   attribute="attribute"
                   key="key"
                   id="values[{{attribute.key}}][{{key}}]"
                   name="values_{{attribute.id}}"
+                  default="attribute.default"
                   model="post.values[attribute.key][key]"
                   ng-model="post.values[attribute.key][key]"
                   ng-required="attribute.required"
-                  ng-switch-when="location"></post-location>
+                  ng-switch-when="location"
+              ></location-picker>
               <!-- type: upload -->
               <post-media
                   ng-switch-when="upload"

--- a/app/main/posts/posts-module.js
+++ b/app/main/posts/posts-module.js
@@ -22,7 +22,6 @@ angular.module('ushahidi.posts', [])
 .directive('postMedia', require('./modify/post-media.directive.js'))
 .directive('postVideoInput', require('./modify/post-video.directive.js'))
 .directive('postDatetime', require('./modify/post-datetime-value.directive.js'))
-.directive('postLocation', require('./modify/location.directive.js'))
 .directive('postRelation', require('./modify/post-relation.directive.js'))
 
 // Post editing workflows

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -78,9 +78,16 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
             markers.addTo(map);
 
-            if (posts.features.length > 0) {
+            // Fit bounds when posts exist
+            if (posts.features.length >= 10) {
                 map.fitBounds(geojson.getBounds());
+            } else if (posts.features.length > 0) {
+                // Limit max zoom when there are less than 10 posts
+                map.fitBounds(geojson.getBounds(), { maxZoom: 5 });
+            } else {
+                map.fitWorld();
             }
+
             // Focus map on data points but..
             // Avoid zooming further than 15 (particularly when we just have a single point)
             if (map.getZoom() > 15) {

--- a/app/settings/site/map.directive.js
+++ b/app/settings/site/map.directive.js
@@ -16,7 +16,8 @@ function (
         },
         template: require('./map.html'),
         link: function ($scope, $element, $attrs) {
-            var map, marker;
+
+            var map;
 
             $scope.patternDigitsOnly = /^[0-9]+$/;
             $scope.patternFloat = /[-+]?(\d*[.])?\d+/;
@@ -38,17 +39,10 @@ function (
                     map = data.map;
                     angular.extend($scope.config, data.config);
 
-                    marker = L.marker(map.getCenter(), {
-                        draggable: true,
-                        icon: Maps.pointIcon()
-                    });
-                    marker.addTo(map);
-
                     // Get zoom limits from leaflet
                     getMapZoomLevels();
 
                     // Set up event handlers
-                    marker.on('dragend', handleDragEnd);
                     map.on('zoomend', handleMoveEnd);
                     map.on('click', handleClick);
                 });
@@ -78,20 +72,6 @@ function (
                     [$scope.config.default_view.lat, $scope.config.default_view.lon],
                     $scope.config.default_view.zoom
                 );
-
-                // Update our draggable marker to the default.
-                marker.setLatLng([$scope.config.default_view.lat, $scope.config.default_view.lon]);
-            }
-
-            // Update our map defaults when the marker is dragged to a new spot.
-            function handleDragEnd(e) {
-                $scope.$evalAsync(function () {
-                    var latLng = e.target.getLatLng().wrap();
-                    $scope.config.default_view.lat = latLng.lat;
-                    $scope.config.default_view.lon = latLng.lng;
-
-                    $scope.updateMapPreview();
-                });
             }
 
             function handleClick(e) {

--- a/app/settings/site/map.html
+++ b/app/settings/site/map.html
@@ -1,37 +1,11 @@
 <div>
-
-    <div class="form-field">
-        <label class="input-label" translate>settings.map_default_location</label>
-        <div id="settings-map" style="height: 300px; width: 100%;"></div>
-    </div>
-
     <div class="form-field">
         <label translate>settings.map_default_baselayer</label>
         <select id="map-settings-base-layer" class="form-control" ng-model="config.default_view.baselayer" ng-change="updateMapPreviewLayer()" ng-options="index as layer.name for (index, layer) in baselayers">
         </select>
     </div>
-
     <div class="form-field">
-       <label class="input-label"
-            ng-class="{'error': map.latitude.$valid}"
-            for="map-settings-latitude" translate>settings.map_default_latitude</label>
-        <input name="latitude" id="map-settings-latitude" type="number" step="any" ng-min="-90" ng-max="90" required
-            ng-class="{'error': map.latitude.$valid}"
-            ng-model="config.default_view.lat" ng-pattern="patternFloat" ng-change="updateMapPreview()" />
-    </div>
-
-    <div class="form-field">
-        <label class="input-label"
-            ng-class="{'error': map.latitude.$valid}"
-            for="map-settings-longitude" translate>settings.map_default_longitude</label>
-        <input name="longitude" id="map-settings-longitude" type="number" step="any" ng-min="-180" ng-max="180" required
-            ng-class="{'error': map.longitude.$valid}"
-            ng-model="config.default_view.lon" ng-pattern="patternFloat" ng-change="updateMapPreview()" />
-    </div>
-
-    <div class="form-field">
-        <label class="input-label" for="map-settings-zoom" translate>settings.map_default_zoom_level</label>
-        <input id="map-settings-zoom" type="number" ng-min="minZoom" ng-max="maxZoom" required class="form-control" ng-model="config.default_view.zoom" ng-pattern="onlyNumbers" ng-change="updateMapPreview()" />
+        <div id="settings-map" style="height: 300px; width: 100%;"></div>
     </div>
     <div class="form-field checkbox">
         <input type="checkbox" ng-model="config.clustering" id="map-settings-clustering">

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -11,15 +11,31 @@ function (
         restrict: 'E',
         template: require('./attribute-editor.html'),
         link: function ($scope, $element, $attrs) {
-            $scope.defaultValueToggle = false;
+
+            if ($scope.editAttribute.default) {
+                $scope.defaultValueToggle = true;
+            } else {
+                $scope.defaultValueToggle = false;
+            }
+
             $scope.descriptionToggle = false;
+
             $scope.editName = function () {
                 if (!$scope.editAttribute.id) {
                     $scope.editAttribute.label = '';
                 }
             };
+
+            $scope.toggleDefaultValue = function () {
+                $scope.defaultValueToggle = !$scope.defaultValueToggle;
+            };
+
             $scope.closeModal = function () {
                 ModalService.close();
+                // Remove default value when toggled off
+                if ($scope.defaultValueToggle === false) {
+                    $scope.editAttribute.default = null;
+                }
             };
 
             $scope.onlyOptional = function () {
@@ -29,6 +45,7 @@ function (
             $scope.canDisplay = function () {
                 return $scope.editAttribute.input !== 'upload' && $scope.editAttribute.type !== 'title' && $scope.editAttribute.type !== 'description' && $scope.editAttribute.input !== 'tags';
             };
+
             $scope.selectChild = function (child) {
                 if (!_.contains($scope.editAttribute.options, child.parent.id) && _.contains($scope.editAttribute.options, child.id)) {
                     $scope.editAttribute.options.push(child.parent.id);

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -95,13 +95,20 @@
        <div class="form-field switch" ng-if="canDisplay()">
             <label translate="app.default_value">Default value</label>
             <div class="toggle-switch">
-                <input class="tgl init" id="include-default-value-new" type="checkbox" data-fieldgroup-toggle="field-default-value-new" ng-click="defaultValueToggle=!defaultValueToggle">
+                <input class="tgl init" id="include-default-value-new" type="checkbox" data-fieldgroup-toggle="field-default-value-new" ng-click="toggleDefaultValue()" ng-checked="defaultValueToggle">
                 <label class="tgl-btn" for="include-default-value-new"></label>
             </div>
-
-            <div class="form-field" data-fieldgroup-target="field-default-value-new" ng-show="defaultValueToggle">
+            <div class="form-field" data-fieldgroup-target="field-default-value-new" ng-class="{'location': editAttribute.input === 'location'}" ng-if="defaultValueToggle">
               <div ng-switch="editAttribute.input">
-                  <input ng-switch-when="location" type="text" placeholder="{{ 'form.default_location_placeholder'|translate }}" ng-model="editAttribute.default">
+                  <location-picker
+                      attribute="editAttribute"
+                      key="key"
+                      id="values[{{editAttribute.key}}][{{key}}]"
+                      model="editAttribute.default"
+                      ng-model="editAttribute.default"
+                      ng-required="editAttribute.required"
+                      ng-switch-when="location"
+                  ></location-picker>
                   <input ng-switch-when="date" type="text" date-time="editAttribute.default" ng-model="editAttribute.default">
                   <input ng-switch-when="int" type="number" step="1" ng-model="editAttribute.default">
                   <input ng-switch-when="decimal" type="number" ng-model="editAttribute.default">
@@ -111,7 +118,7 @@
         </div>
    </div>
    <div class="form-field">
-      <button ng-show="!editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask)" translate="app.add_and_close">Add &amp; close</button>
-      <button ng-show="editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask)" translate="app.update_and_close">Update &amp; close</button>
+      <button ng-show="!editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask); closeModal();" translate="app.add_and_close">Add &amp; close</button>
+      <button ng-show="editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="addNewAttribute(editAttribute, activeTask); closeModal();" translate="app.update_and_close">Update &amp; close</button>
    </div>
 </div>

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -458,7 +458,6 @@ function SurveyEditorController(
     }
 
     function addNewAttribute(attribute, task) {
-        ModalService.close();
         // Set active task as form_stage_id
         // If this task is new and has not been saved
         // it won't have an id so in this instance we use its label
@@ -612,6 +611,10 @@ function SurveyEditorController(
                     attribute.options = _.filter(attribute.options, function (option) {
                         return !isNaN(option);
                     });
+                }
+                // If default location object, stringify before save
+                if (attribute.type === 'point' && attribute.default && typeof attribute.default === 'object') {
+                    attribute.default = JSON.stringify(attribute.default);
                 }
                 attribute.form_stage_id = task.id;
                 calls.push(

--- a/test/unit/common/directives/location-picker.directive.spec.js
+++ b/test/unit/common/directives/location-picker.directive.spec.js
@@ -28,7 +28,7 @@ describe('post location directive', function () {
         };
         var testApp = makeTestApp();
 
-        testApp.directive('postLocation', require('app/main/posts/modify/location.directive'))
+        testApp.directive('locationPicker', require('app/common/directives/location-picker.directive'))
         .service('Leaflet', () => {
             return L;
         })
@@ -61,7 +61,7 @@ describe('post location directive', function () {
             lat: 3,
             lon: 4
         };
-        element = '<post-location attribute="attribute" key="key" model="model" id="1"></post-location>';
+        element = '<location-picker attribute="attribute" key="key" model="model" id="1"></location-picker>';
         element = $compile(element)($scope);
         $scope.$digest();
         isolateScope = element.children().scope();

--- a/test/unit/settings/site/setting-map-directive-spec.js
+++ b/test/unit/settings/site/setting-map-directive-spec.js
@@ -75,8 +75,6 @@ describe('setting map directive', function () {
 
     it('should create a map', function () {
         expect(Maps.createMap).toHaveBeenCalled();
-        expect(L.marker).toHaveBeenCalled();
-        expect(marker.addTo).toHaveBeenCalledWith(map);
     });
 
     it('should set scope.config to map config', function () {
@@ -111,14 +109,6 @@ describe('setting map directive', function () {
         expect(map.setView).toHaveBeenCalledWith([3, 4], 9);
     });
 
-    it('should update marker when lat/lon changes', function () {
-        isolateScope.config.default_view.lat = 48;
-        isolateScope.config.default_view.lon = 36;
-        isolateScope.updateMapPreview();
-
-        expect(marker.setLatLng).toHaveBeenCalledWith([48, 36]);
-    });
-
     it('should save position when map clicked', function () {
         map.fireEvent('click', {
             latlng: L.latLng([10,12])
@@ -128,16 +118,6 @@ describe('setting map directive', function () {
 
         expect(isolateScope.config.default_view.lat).toBe(10);
         expect(isolateScope.config.default_view.lon).toBe(12);
-    });
-
-    it('should save position when marker dragged', function () {
-        marker._latlng = L.latLng([32, 24]);
-        marker.fireEvent('dragend', {});
-
-        $scope.$digest();
-
-        expect(isolateScope.config.default_view.lat).toBe(32);
-        expect(isolateScope.config.default_view.lon).toBe(24);
     });
 
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Renames `post-location` directive to `location-picker`
- Moves `location-picker` from post module to common module
- Implements `location-picker` when setting the value for a location attribute
- Implements `location-picker` when setting the default value for a location attribute
- Removes the ability to set a custom default location in general settings
- Removes the use of a custom default location when viewing a map
- Sets a max zoom when there are less than 10 posts

Testing checklist:
- [x] When I am creating or editing a location attribute in a survey, I can toggle on the default value and use the location picker to set the default value.
- [x] When I am creating or editing a post with a location attribute that has a pre-set default value, the default value is automatically set as the initial value.
- [x] When I am viewing a map without any bounds or setting the value of a location attribute that does not have a default value, I see a map of the whole world.
- [x] When I am viewing a map with less than 10 bounds, I see a map with a maximum zoom of 5.

Fixes ushahidi/platform#1339.
Fixes ushahidi/platform#1736.

Ping @ushahidi/platform
