### PR TITLE
Add attribute setting that allows admin to toggle visibility of location attribute.

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -206,6 +206,8 @@
         "markdown_desc" : "Allows the use of markdown syntax to style the field content.",
         "tasks" : "Tasks",
         "show_field_description" : "Show field description",
+        "use_geolocation" : "Use geolocation",
+        "use_geolocation_desc": "When turned on, responses will be geolocated in your deployment's \"Map\" view using data from this field.",
         "add_task" : "Add task",
         "add_field" : "Add field",
         "edit_field" : "Edit field",

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -36,6 +36,10 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 posts: posts
             })
             .then(function (data) {
+                // Filter out posts with use_geolocation set to false
+                data.posts.features = data.posts.features.filter(function (feature) {
+                    return feature.properties.use_geolocation !== false;
+                });
                 addPostsToMap(data.posts);
                 return data;
             })

--- a/app/settings/surveys/attribute-create.directive.js
+++ b/app/settings/surveys/attribute-create.directive.js
@@ -19,7 +19,8 @@ function (
                 required: false,
                 options: [],
                 config: {},
-                priority: 0
+                priority: 0,
+                use_geolocation: true
             };
 
             $scope.createNewAttribute = function (type) {

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -92,6 +92,16 @@
              <label class="tgl-btn" for="switchprivateresponse"></label>
           </div>
        </div>
+       <div class="form-field switch" ng-if="editAttribute.type === 'point'">
+         <label translate="survey.use_geolocation">Use geolocation</label>
+         <p class="init active" translate="survey.use_geolocation_desc" ng-show="editAttribute.use_geolocation">
+             When turned on, responses will be geolocated in your deployment's "Map" view using data from this field.
+         </p>
+         <div class="toggle-switch">
+             <input class="tgl init" id="use-geolocation" type="checkbox" ng-click="editAttribute.use_geolocation=!editAttribute.use_geolocation" ng-checked="editAttribute.use_geolocation">
+             <label class="tgl-btn" for="use-geolocation"></label>
+         </div>
+       </div>
        <div class="form-field switch" ng-if="canDisplay()">
             <label translate="app.default_value">Default value</label>
             <div class="toggle-switch">


### PR DESCRIPTION
This pull request makes the following changes:
- Saves `use_geolocation` value per post when updated in attribute settings
- Sets `use_geolocation` value to true when creating a new survey
- Adds `use_geolocation` toggle and description to `attribute-editor`
- Filters out posts with `use_geolocation` set to `false` on map view

Testing checklist:
- [x] When I update the `Use geolocation` setting, all posts that belong to the survey are updated with the new setting.
- [x] When I view the map, I only see posts that have `use_geolocation` enabled.

Fixes ushahidi/platform#1339 (w/ ushahidi/platform#1867).

Ping @ushahidi/platform
