### PR TITLE
Adds missing instructions for title and description attributes

### DIFF
--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -121,9 +121,11 @@ function PostEditorController(
                 if (attr.type === 'title' || attr.type === 'description') {
                     if (attr.type === 'title') {
                         $scope.postTitleLabel = attr.label;
+                        $scope.postTitleInstructions = attr.instructions;
                     }
                     if (attr.type === 'description') {
                         $scope.postDescriptionLabel = attr.label;
+                        $scope.postDescriptionInstructions = attr.instructions;
                     }
                 } else {
                     attributes.push(attr);

--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -58,7 +58,12 @@
                 'error': postForm.title.$invalid && postForm.title.$dirty,
                 'success': !postForm.title.$invalid && postForm.title.$dirty
               }">
-                  <label>{{postTitleLabel}}</label>
+                  <label>
+                      {{postTitleLabel}}
+                  </label>
+                  <p>
+                      {{postTitleInstructions}}
+                  </p>
                   <input id="title"
                       name="title" type="text" ng-model="post.title" ng-required="true" ng-minlength=2 ng-maxlength=150 adaptive-input>
 
@@ -84,6 +89,9 @@
                   <label>
                       {{postDescriptionLabel}}
                   </label>
+                  <p>
+                      {{postDescriptionInstructions}}
+                  </p>
                     <textarea id="content" name="content" data-min-rows="1" rows="1"
                       ng-model="post.content" ng-required="true" adaptive-input msd-elastic>
                     </textarea>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds missing instructions for title and description attributes

Testing checklist:
- [x] When I add instructions to the `title` and `description` attributes, I see the instructions in the post form when I am creating or editing a post.

Fixes ushahidi/platform#1917 (w/ ushahidi/platform-pattern-library#139).

Ping @ushahidi/platform
