### PR TITLE
Add no results and searching indicators to related post search

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -67,6 +67,7 @@
         "description" : "Description",
         "color" : "Color",
         "search_users" : "Search users",
+        "searching" : "Searching",
         "fields" : "Fields",
         "filter_by" :"Filter by...",
         "apply_filters" : "Apply filters",

--- a/app/main/posts/modify/post-relation.directive.js
+++ b/app/main/posts/modify/post-relation.directive.js
@@ -18,6 +18,10 @@ function (
         },
         template: require('./relation.html'),
         link: function ($scope) {
+
+            $scope.noResults = false;
+            $scope.searching = false;
+
             $scope.$watch(function () {
                 return $scope.model;
             }, function (newValue, oldValue) {
@@ -34,8 +38,15 @@ function (
                     query.form = $scope.attribute.config.input.form.join(',');
                 }
 
+                $scope.noResults = false;
+                $scope.searching = true;
+
                 PostEndpoint.query(query).$promise.then(function (response) {
+                    $scope.searching = false;
                     $scope.results = response.results;
+                    if (!response.results.length) {
+                        $scope.noResults = true;
+                    }
                 });
             };
 

--- a/app/main/posts/modify/relation.html
+++ b/app/main/posts/modify/relation.html
@@ -2,8 +2,22 @@
 	<p ng-if="model">{{ selectedPost.title }} ({{ model }}) <button class="button-secondary icon-only alt trash" type="button" ng-click="clearPost()" translate></button></p>
     <div class="input-inline">
         <input class="form-control" type="text" placeholder="Search.." ng-model="searchTerm">
-        <button class="btn btn-info" type="button" ng-click="search($event)" translate>nav.search</button>
+        <button type="button" ng-click="search($event)">
+						<div class="loading" ng-if="searching">
+								<div class="line"></div>
+								<div class="line"></div>
+								<div class="line"></div>
+						 </div>
+						<span class="button-label" translate="nav.search" ng-if="!searching">Search</span>
+						<span class="button-label" translate="app.searching" ng-if="searching">Searching</span>
+				</button>
     </div>
+		<div class="alert error" ng-if="noResults">
+				<svg class="iconic">
+					<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+				</svg>
+				<span translate="post.no_search_results">Your search didn't match any posts</span>
+		</div>
     <ul>
     	<li ng-repeat="post in results">
     		<button type="button" class="button-secondary icon-only check" ng-click="selectPost(post)" translate></button> {{ post.id }} : {{ post.title }}


### PR DESCRIPTION
This pull request makes the following changes:
- Adds no results and searching indicators to `post-relation`

Testing checklist:
- [x] When I search for posts and the search is in progress, I see a searching indicator
- [x] When I search for posts and the search is complete with no results, I see a no results indicator

Fixes ushahidi/platform#1860.

Ping @ushahidi/platform
