### PR TITLE
Hide tasks from anyone without 'manage posts' permissions in post-editor

### DIFF
--- a/app/common/directives/add-category.html
+++ b/app/common/directives/add-category.html
@@ -1,8 +1,8 @@
 <div class="form-field inline" ng-class="{'hidden': !showInput}">
-    <label class="hidden">Category name</label>
+    <label class="hidden" translate="category.editor.name">Category name</label>
         <input
             type="text"
-            placeholder="Category name..."
+            placeholder="{{'category.editor.name' | translate}}"
             style="width: 240px;"
             ng-model="categoryName"
         />
@@ -15,7 +15,7 @@
             <svg class="iconic">
                 <use xlink:href="/img/iconic-sprite.svg#check"></use>
             </svg>
-        <span class="hidden">Add</span>
+        <span class="hidden" translate="app.add">Add</span>
         </button>
         <button
             type="button"
@@ -25,9 +25,9 @@
             <svg class="iconic">
                 <use xlink:href="/img/iconic-sprite.svg#trash"></use>
             </svg>
-            <span class="hidden">Delete</span>
+            <span class="hidden" translate="category.delete">Delete</span>
         </button>
 </div>
 <div class="form-field init" ng-click="showInputToggle()" ng-if="userCanAddCategory">
-    <a data-toggle="add-label">+ Add new category</a>
+    <a data-toggle="add-label" translate="app.add_new_category">+ Add new category</a>
 </div>

--- a/app/common/directives/role-selector.directive.js
+++ b/app/common/directives/role-selector.directive.js
@@ -25,10 +25,6 @@ function RoleSelectorController($scope, RoleEndpoint, $translate) {
         RoleEndpoint.query().$promise.then(function (roles) {
             $scope.roles = roles;
         });
-
-        //translating title
-        $scope.title = $translate.instant($scope.title);
-
     }
 
     // adding all available roles to model if user clicks 'Everyone'

--- a/app/common/directives/role-selector.html
+++ b/app/common/directives/role-selector.html
@@ -1,19 +1,19 @@
     <!--// Who can add //-->
     <fieldset>
-        <legend>{{title}}</legend>
-        <div 
-            class="form-field radio icon-input" 
+        <legend translate="{{title}}"></legend>
+        <div
+            class="form-field radio icon-input"
             ng-class="{ 'checked': !model.role.length }"
         >
             <label for="add_everyone">
                 <svg class="iconic">
                     <use xlink:href="/img/iconic-sprite.svg#globe"></use>
                 </svg>
-                <input 
+                <input
                     name="add"
                     id="add_everyone"
-                    ng-value="true" 
-                    checked="" 
+                    ng-value="true"
+                    checked=""
                     type="radio"
                     ng-model="everyone"
                     ng-click="setEveryone()"
@@ -22,7 +22,7 @@
             </label>
         </div>
 
-        <div 
+        <div
             class="form-field radio icon-input"
             ng-class="{ 'checked': model.role.length }"
         >
@@ -30,29 +30,29 @@
                 <svg class="iconic">
                     <use xlink:href="/img/iconic-sprite.svg#people"></use>
                 </svg>
-                <input 
-                    class="init" 
-                    name="add" 
-                    id="add_roles" 
+                <input
+                    class="init"
+                    name="add"
+                    id="add_roles"
                     ng-value="false"
-                    ng-modaldata-fieldgroup-toggle="add_roles" 
-                    type="radio" 
+                    ng-modaldata-fieldgroup-toggle="add_roles"
+                    type="radio"
                     ng-model="everyone"
                 >
                 <span translate="app.specific_roles">Specific roles...</span>
             </label>
 
-            <div 
-                class="form-fieldgroup init" 
-                data-fieldgroup-target="add_roles" 
+            <div
+                class="form-fieldgroup init"
+                data-fieldgroup-target="add_roles"
                 ng-class="{true:'', false:'active'}[everyone]"
             >
 
                 <div class="form-field checkbox" ng-repeat="role in roles">
                     <label>
-                    <input 
-                        type="checkbox" 
-                        checklist-model="model.role" 
+                    <input
+                        type="checkbox"
+                        checklist-model="model.role"
                         checklist-value="role.name"
                     >
                     {{role.display_name}}

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -60,6 +60,7 @@
         "categories" : "Categories",
         "edit_category" : "Edit Category",
         "add_category" : "Add Category",
+        "categories_count" : "{{count}} categories",
         "plans" : "Plans",
         "delete" : "Delete",
         "description" : "Description",
@@ -82,7 +83,13 @@
         "return_to_all_posts" : "Return to all posts",
         "this_deplyment_is_private" : "This deployment is private",
         "private_deployment" : "Private Deployment",
-        "mark_as" : "Mark as"
+        "mark_as" : "Mark as",
+        "who_can_see_this_category" : "Who can see this category?",
+        "this_category_is_child_to" : "This category is a child to <strong>{{parent}}</strong>",
+        "nothing" : "Nothing",
+        "who_can_see_this" : "Who can see this?",
+        "add" : "Add",
+        "add_new_category" : "+ Add new category"
     },
     "toolbar": {
         "searchbar" : {

--- a/app/main/posts/collections/editor.html
+++ b/app/main/posts/collections/editor.html
@@ -37,7 +37,7 @@
         </div>
     </div>
     <!-- Who can see -->
-    <role-selector model="cpyCollection" title="'Who can see this?'"></role-selector>
+    <role-selector model="cpyCollection" title="'app.who_can_see_this'"></role-selector>
 
     <div class="modal-actions">
         <div class="form-field">

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -34,7 +34,8 @@ PostEditorController.$inject = [
     'Notify',
     '_',
     'PostActionsService',
-    'MediaEditService'
+    'MediaEditService',
+    '$rootScope'
   ];
 
 function PostEditorController(
@@ -55,7 +56,8 @@ function PostEditorController(
     Notify,
     _,
     PostActionsService,
-    MediaEditService
+    MediaEditService,
+    $rootScope
   ) {
 
     // Setup initial stages container
@@ -64,6 +66,7 @@ function PostEditorController(
     $scope.validationErrors = [];
     $scope.visibleStage = 1;
     $scope.enableTitle = true;
+    $scope.hasPermission = $rootScope.hasPermission;
 
     $scope.setVisibleStage = setVisibleStage;
     $scope.fetchAttributesAndTasks = fetchAttributesAndTasks;

--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -99,7 +99,7 @@
               <!-- End post stage default fields -->
 
               <!-- Start Post custom fields -->
-            
+
               <post-value-edit
                   ng-repeat="attribute in tasks[0].attributes | orderBy: 'priority' as filtered_result track by attribute.id"
                   post="post"
@@ -126,7 +126,7 @@
 
          </div>
          <post-tabs
-             ng-show="tasks.length > 1"
+             ng-show="tasks.length > 1 && hasPermission('Manage Posts')"
              form="postForm"
              post="post"
              stages="tasks"

--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -34,7 +34,7 @@
         </div>
     </div>
     <!-- Who can see? -->
-    <role-selector model="savedSearch" title="'Who can see this?'"></role-selector>
+    <role-selector model="savedSearch" title="'app.who_can_see_this'"></role-selector>
     <div class="modal-actions">
         <div class="form-field">
             <button type="button" class="button-link  modal-trigger" ng-click="cancel()" translate>app.cancel</button>

--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -54,8 +54,7 @@
             auto-close="outsideClick"
             ng-show="form.tags.length > 0 && form.post_count > 0"
             >
-            <legend class="init" data-toggle="form-fieldgroup" dropdown-toggle ng-class="{ selected : filters.tags.length }">
-            {{form.tags.length}} categories
+            <legend class="init" data-toggle="form-fieldgroup" dropdown-toggle ng-class="{ selected : filters.tags.length }" translate="app.categories_count" translate-values="{ count: form.tags.length }">
             </legend>
 
             <div class="form-fieldgroup init" dropdown-menu>

--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -63,9 +63,7 @@
                   data-toggle="dropdown-menu"
                   dropdown-toggle
                 >
-                  <span class="legend-label">This category is a child to
-                    <span class="custom-fieldset-value">{{getParentName()}}</span>
-                  </span>
+                  <span class="legend-label" translate="app.this_category_is_child_to" translate-values="{ parent: getParentName() }">This category is a child to</span>
                   <svg class="iconic chevron">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
                   </svg>
@@ -81,7 +79,7 @@
                             ng-checked="category.parent_id === null"
                             ng-model="category.parent_id"
                             />
-                          Nothing
+                          <span translate="app.nothing">Nothing</span>
                       </label>
                   </div>
 
@@ -101,7 +99,7 @@
                 </div>
               </fieldset>
               <!-- Who can see and add -->
-              <role-selector model="category" title="'Who can see this category'"></role-selector>
+              <role-selector model="category" title="'app.who_can_see_this_category'"></role-selector>
             </div>
           </form>
           <div class="form-sheet" ng-show="category.id">


### PR DESCRIPTION
- Hide tasks from anyone without 'manage posts' permissions in post-editor

Testing checklist:
- [x] Load create post form while not logged in, tasks should not appear
- [x] Load create post form while logged in as normal user, tasks should not appear
- [x] Load create post form while logged in as admin, tasks should appear

Refs ushahidi/platform#1848

Ping @ushahidi/platform