### PR TITLE
Hide create collection button when user is not authorized

### DIFF
--- a/app/main/posts/collections/listing.directive.js
+++ b/app/main/posts/collections/listing.directive.js
@@ -45,6 +45,7 @@ function CollectionListingController(
     $scope.collectionClickHandler = collectionClickHandler;
     $scope.createNewCollection = createNewCollection;
     $scope.searchCollections = loadCollections;
+    $scope.currentUser = $rootScope.currentUser;
 
     activate();
 

--- a/app/main/posts/collections/listing.html
+++ b/app/main/posts/collections/listing.html
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <div class="modal-actions">
+    <div class="modal-actions" ng-if="currentUser">
         <div class="form-field">
             <button type="button" class="button-beta" ng-click="createNewCollection()">
                 <svg class="iconic">


### PR DESCRIPTION
This pull request makes the following changes:
- Hides the create new button if user is not logged in

Testing checklist:
- [x] When I am logged in, I see the create new button
- [x] When I am not logged in, I do not see the create new button

Fixes ushahidi/platform#1926.

Ping @ushahidi/platform
