### PR TITLE
Refactor endpoints to use a generic endpoint class [WIP]

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -24,6 +24,7 @@ angular.module('ushahidi.common', [
 .directive('ushSlider', require('./notifications/slider.directive.js'))
 
 // API Endpoint wrappers
+.factory('EndpointFactory', require('./services/endpoints/endpointFactory.js'))
 .service('ConfigEndpoint', require('./services/endpoints/config.js'))
 .service('UserEndpoint', require('./services/endpoints/user-endpoint.js'))
 .service('FormEndpoint', require('./services/endpoints/form.js'))

--- a/app/common/services/endpoints/endpoint.js
+++ b/app/common/services/endpoints/endpoint.js
@@ -1,0 +1,145 @@
+class Endpoint {
+    constructor(id, url, params, methods, $resource, CacheFactory, $q) {
+        this.initCache(CacheFactory, id);
+        this.initResource($resource, url, params, methods);
+        this.$q = $q;
+    }
+
+    initCache(CacheFactory, id) {
+        if (!(this.cache = CacheFactory.get(id))) {
+            this.cache = new CacheFactory(id);
+        }
+        return this.cache;
+    }
+
+    initResource($resource, url, params, methods) {
+        let defaultParams = {};
+        let defaultMethods = {
+            query: {
+                method: 'GET',
+                isArray: true,
+                transformResponse: function (data) {
+                    return angular.fromJson(data).results;
+                }
+            },
+            save: {
+                method: 'POST'
+            },
+            update: {
+                method: 'PUT'
+            },
+            get: {
+                method: 'GET'
+            },
+            delete: {
+                method: 'DELETE'
+            }
+        };
+
+        this.resource = $resource(url, params);
+    }
+
+    /**
+     * [query description]
+     * @return {[type]} [description]
+     */
+    query(params, cb, options) {
+        let cacheId = JSON.stringify(params);
+        let result;
+        if (!(result = this.cache.get(cacheId)) || options.fresh) {
+            result = this.resource.query(params);
+
+            result.$promise.then((result) => {
+                this.cache.put(cacheId, result);
+            });
+        }
+
+        return result;
+    }
+    // Legacy
+    queryFresh(params, cb) {
+        this.query(params, cb, { fresh : true });
+    }
+
+    get(params, cb, options) {
+        // @todo make keys shorter?? specify ids?
+        let cacheId = JSON.stringify(params);
+        let result;
+
+        options = options || {};
+        if (!(result = this.cache.get(cacheId)) || options.fresh) {
+            result = this.resource.get(params);
+
+            result.$promise.then((result) => {
+                this.cache.put(cacheId, result);
+            });
+        } else {
+            // @todo check is result is an existing in-progress request
+            // Add $promise to our response, even when it comes from the cache
+            result.$promise = this.$q.when(result);
+        }
+
+        // Run the callback
+        result.$promise.then(cb);
+
+        return result;
+    }
+    // Legacy
+    getFresh(params, cb) {
+        this.get(params, cb, { fresh : true });
+    }
+
+    save(data, cb) {
+        let request = this.resource.save(params);
+        // @todo make keys shorter?? specify ids?
+        let cacheId = JSON.stringify(params);
+
+        request.$promise.then((result) => {
+            this.cache.put(cacheId, result);
+        });
+
+        return request;
+    }
+    // Legacy alias
+    saveCache(data, cb) {
+        this.save(data, cb);
+    }
+
+    update(params, data, cb) {
+        let request = this.resource.update(params);
+        // @todo make keys shorter?? specify ids?
+        let cacheId = JSON.stringify(params);
+
+        request.$promise.then((result) => {
+            this.cache.remove(cacheId, result);
+        });
+
+        return request;
+    }
+
+    delete(params, cb) {
+        let request = this.resource.delete(params);
+        // @todo make keys shorter?? specify ids?
+        let cacheId = JSON.stringify(params);
+
+        request.$promise.then((result) => {
+            this.cache.remove(cacheId, result);
+        });
+
+        return request;
+    }
+
+    invalidateCache() {
+        this.cache.clearAll();
+    }
+}
+
+function resolvePromiseWithResult(result) {
+    resolvePromise(result.data, result.status, shallowCopy(result.headers()), result.statusText);
+}
+
+function isPromiseLike(obj) {
+  return obj && angular.isFunction(obj.then);
+}
+
+export default Endpoint

--- a/app/common/services/endpoints/endpoint.spec.js
+++ b/app/common/services/endpoints/endpoint.spec.js
@@ -1,0 +1,165 @@
+import Endpoint from './endpoint';
+import angular from 'angular';
+import ngResource from 'angular-resource';
+import ngCache from 'angular-cache';
+
+describe('Endpoint service', () => {
+  let endpoint, $httpBackend, $rootScope;
+
+  beforeEach(() => {
+    let appModule = angular.module('endpointModule', [
+        ngResource,
+        ngCache
+      ])
+      .name;
+
+    return window.module(appModule);
+  });
+
+  beforeEach(inject(($injector) => {
+    $httpBackend = $injector.get('$httpBackend');
+    $rootScope = $injector.get('$rootScope');
+    let CacheFactory = $injector.get('CacheFactory');
+    let $resource = $injector.get('$resource');
+    let $q = $injector.get('$q');
+
+    CacheFactory.destroyAll();
+
+    endpoint = new Endpoint('tags', 'http://backend/tags/:id', {}, {}, $resource, CacheFactory, $q);
+  }));
+
+  it('should return data from $http', (done) => {
+    $httpBackend.expectGET('http://backend/tags/1')
+      .respond({
+        id: 1,
+        url: 'http://backend/tags/1',
+        tag: "A tag!"
+      });
+
+    let tag = endpoint.get({id : 1}, (cbData) => {
+      expect(cbData.id).toEqual(1);
+      done();
+    });
+
+    $httpBackend.flush();
+
+    expect(tag.id).toEqual(1);
+  });
+
+  it('should return data from cache after first request', (done) => {
+    $httpBackend.expectGET('http://backend/tags/2')
+      .respond({
+        id: 2,
+        url: 'http://backend/tags/2',
+        tag: "A tag!"
+      });
+
+    let tagResponse1 = endpoint.get({id : 2});
+    $httpBackend.flush();
+
+    let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
+      expect(cbData.id).toEqual(2);
+      done();
+    });
+
+    $rootScope.$apply();
+
+    expect(tagResponse2.id).toEqual(2);
+  });
+
+  it('should always load data from $http if `fresh: true`', (done) => {
+    // Setup the backend
+    $httpBackend.expectGET('http://backend/tags/2')
+      .respond({
+        id: 2,
+        url: 'http://backend/tags/2',
+        tag: "A tag!"
+      });
+
+    // Load up tag 2
+    let tagResponse1 = endpoint.get({id : 2});
+    // Return a result from the backend
+    $httpBackend.flush();
+    // And verify that result
+    expect(tagResponse1.tag).toEqual('A tag!');
+
+    // Set up the backend for *reloading* tag 2
+    $httpBackend.expectGET('http://backend/tags/2')
+      .respond({
+        id: 2,
+        url: 'http://backend/tags/2',
+        tag: "An updated tag"
+      });
+
+    // Load it again, and make sure we ask for it 'fresh'
+    let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
+      // Check that the callback gets call too!
+      expect(cbData.id).toEqual(2);
+      // And mark this test DONE
+      done();
+    }, { fresh: true });
+
+    // Return some responses
+    $httpBackend.flush();
+
+    // Check that we got an updated response, not the same tag again
+    expect(tagResponse2.tag).toEqual('An updated tag');
+  });
+
+  it('should return a $promise which is resolved with the API response', (done) => {
+    $httpBackend.expectGET('http://backend/tags/2')
+      .respond({
+        id: 2,
+        url: 'http://backend/tags/2',
+        tag: "A tag!"
+      });
+
+    let tagResponse1 = endpoint.get({id : 2});
+
+    expect(tagResponse1.$promise).toEqual(jasmine.any(Object));
+    expect(tagResponse1.$promise.then).toEqual(jasmine.any(Function));
+    tagResponse1.$promise.then((cbResponse) => {
+      expect(cbResponse.id).toBe(2);
+      done();
+    });
+
+    $httpBackend.flush();
+  });
+
+  it('should return a $promise which is resolved from the cache', (done) => {
+    $httpBackend.expectGET('http://backend/tags/2')
+      .respond({
+        id: 2,
+        url: 'http://backend/tags/2',
+        tag: "A tag!"
+      });
+
+    let tagResponse1 = endpoint.get({id : 2});
+
+    $httpBackend.flush();
+
+    let tagResponse2 = endpoint.get({id : 2});
+
+    expect(tagResponse2.id).toEqual(2);
+    expect(tagResponse2.$promise).toEqual(jasmine.any(Object));
+    expect(tagResponse2.$promise.then).toEqual(jasmine.any(Function));
+
+    tagResponse2.$promise.then((cbResponse) => {
+      expect(cbResponse.id).toBe(2);
+      done();
+    });
+
+    $rootScope.$apply();
+  });
+
+  it('should populate the result from cache', () => {});
+  it('should update the cache on save', () => {});
+  it('should clear the cache on delete', () => {});
+  it('should not create multiple duplicate requests at once', () => {});
+
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+});

--- a/app/common/services/endpoints/endpoint.spec.js
+++ b/app/common/services/endpoints/endpoint.spec.js
@@ -28,134 +28,227 @@ describe('Endpoint service', () => {
     endpoint = new Endpoint('tags', 'http://backend/tags/:id', {}, {}, $resource, CacheFactory, $q);
   }));
 
-  it('should return data from $http', (done) => {
-    $httpBackend.expectGET('http://backend/tags/1')
-      .respond({
-        id: 1,
-        url: 'http://backend/tags/1',
-        tag: "A tag!"
+  describe('.get()', () => {
+    it('should return data from $http', (done) => {
+      $httpBackend.expectGET('http://backend/tags/1')
+        .respond({
+          id: 1,
+          url: 'http://backend/tags/1',
+          tag: "A tag!"
+        });
+
+      let tag = endpoint.get({id : 1}, (cbData) => {
+        expect(cbData.id).toEqual(1);
+        done();
       });
 
-    let tag = endpoint.get({id : 1}, (cbData) => {
-      expect(cbData.id).toEqual(1);
-      done();
+      $httpBackend.flush();
+
+      expect(tag.id).toEqual(1);
     });
 
-    $httpBackend.flush();
+    it('should return data from cache after first request', (done) => {
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "A tag!"
+        });
 
-    expect(tag.id).toEqual(1);
-  });
+      let tagResponse1 = endpoint.get({id : 2});
+      $httpBackend.flush();
 
-  it('should return data from cache after first request', (done) => {
-    $httpBackend.expectGET('http://backend/tags/2')
-      .respond({
-        id: 2,
-        url: 'http://backend/tags/2',
-        tag: "A tag!"
+      let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
+        expect(cbData.id).toEqual(2);
+        done();
       });
 
-    let tagResponse1 = endpoint.get({id : 2});
-    $httpBackend.flush();
+      $rootScope.$apply();
 
-    let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
-      expect(cbData.id).toEqual(2);
-      done();
+      expect(tagResponse2.id).toEqual(2);
     });
 
-    $rootScope.$apply();
+    it('should always load data from $http if `fresh: true`', (done) => {
+      // Setup the backend
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "A tag!"
+        });
 
-    expect(tagResponse2.id).toEqual(2);
-  });
+      // Load up tag 2
+      let tagResponse1 = endpoint.get({id : 2});
+      // Return a result from the backend
+      $httpBackend.flush();
+      // And verify that result
+      expect(tagResponse1.tag).toEqual('A tag!');
 
-  it('should always load data from $http if `fresh: true`', (done) => {
-    // Setup the backend
-    $httpBackend.expectGET('http://backend/tags/2')
-      .respond({
-        id: 2,
-        url: 'http://backend/tags/2',
-        tag: "A tag!"
-      });
+      // Set up the backend for *reloading* tag 2
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "An updated tag"
+        });
 
-    // Load up tag 2
-    let tagResponse1 = endpoint.get({id : 2});
-    // Return a result from the backend
-    $httpBackend.flush();
-    // And verify that result
-    expect(tagResponse1.tag).toEqual('A tag!');
+      // Load it again, and make sure we ask for it 'fresh'
+      let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
+        // Check that the callback gets call too!
+        expect(cbData.id).toEqual(2);
+        // And mark this test DONE
+        done();
+      }, { fresh: true });
 
-    // Set up the backend for *reloading* tag 2
-    $httpBackend.expectGET('http://backend/tags/2')
-      .respond({
-        id: 2,
-        url: 'http://backend/tags/2',
-        tag: "An updated tag"
-      });
+      // Return some responses
+      $httpBackend.flush();
 
-    // Load it again, and make sure we ask for it 'fresh'
-    let tagResponse2 = endpoint.get({id : 2}, (cbData) => {
-      // Check that the callback gets call too!
-      expect(cbData.id).toEqual(2);
-      // And mark this test DONE
-      done();
-    }, { fresh: true });
-
-    // Return some responses
-    $httpBackend.flush();
-
-    // Check that we got an updated response, not the same tag again
-    expect(tagResponse2.tag).toEqual('An updated tag');
-  });
-
-  it('should return a $promise which is resolved with the API response', (done) => {
-    $httpBackend.expectGET('http://backend/tags/2')
-      .respond({
-        id: 2,
-        url: 'http://backend/tags/2',
-        tag: "A tag!"
-      });
-
-    let tagResponse1 = endpoint.get({id : 2});
-
-    expect(tagResponse1.$promise).toEqual(jasmine.any(Object));
-    expect(tagResponse1.$promise.then).toEqual(jasmine.any(Function));
-    tagResponse1.$promise.then((cbResponse) => {
-      expect(cbResponse.id).toBe(2);
-      done();
+      // Check that we got an updated response, not the same tag again
+      expect(tagResponse2.tag).toEqual('An updated tag');
     });
 
-    $httpBackend.flush();
-  });
+    it('should return a $promise which is resolved with the API response', (done) => {
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "A tag!"
+        });
 
-  it('should return a $promise which is resolved from the cache', (done) => {
-    $httpBackend.expectGET('http://backend/tags/2')
-      .respond({
-        id: 2,
-        url: 'http://backend/tags/2',
-        tag: "A tag!"
+      let tagResponse1 = endpoint.get({id : 2});
+
+      expect(tagResponse1.$promise).toEqual(jasmine.any(Object));
+      expect(tagResponse1.$promise.then).toEqual(jasmine.any(Function));
+      tagResponse1.$promise.then((cbResponse) => {
+        expect(cbResponse.id).toBe(2);
+        done();
       });
 
-    let tagResponse1 = endpoint.get({id : 2});
-
-    $httpBackend.flush();
-
-    let tagResponse2 = endpoint.get({id : 2});
-
-    expect(tagResponse2.id).toEqual(2);
-    expect(tagResponse2.$promise).toEqual(jasmine.any(Object));
-    expect(tagResponse2.$promise.then).toEqual(jasmine.any(Function));
-
-    tagResponse2.$promise.then((cbResponse) => {
-      expect(cbResponse.id).toBe(2);
-      done();
+      $httpBackend.flush();
     });
 
-    $rootScope.$apply();
+    it('should return a $promise which is resolved from the cache', (done) => {
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "A tag!"
+        });
+
+      let tagResponse1 = endpoint.get({id : 2});
+
+      $httpBackend.flush();
+
+      let tagResponse2 = endpoint.get({id : 2});
+
+      expect(tagResponse2.id).toEqual(2);
+      expect(tagResponse2.$promise).toEqual(jasmine.any(Object));
+      expect(tagResponse2.$promise.then).toEqual(jasmine.any(Function));
+
+      tagResponse2.$promise.then((cbResponse) => {
+        expect(cbResponse.id).toBe(2);
+        done();
+      });
+
+      $rootScope.$apply();
+    });
+
+    it('should not create multiple duplicate requests at once', () => {
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "A tag!"
+        });
+
+      let tagResponse1 = endpoint.get({id : 2});
+      let tagResponse2 = endpoint.get({id : 2});
+
+      $httpBackend.flush();
+
+      expect(tagResponse1.id).toEqual(2);
+      expect(tagResponse2.id).toEqual(2);
+    });
   });
 
-  it('should populate the result from cache', () => {});
-  it('should update the cache on save', () => {});
-  it('should clear the cache on delete', () => {});
-  it('should not create multiple duplicate requests at once', () => {});
+  describe('.update()', () => {
+    it('should update the cache on save', () => {
+      $httpBackend.expectPUT('http://backend/tags/7', {
+          tag: "a tag!"
+        })
+        .respond({
+          id: 7,
+          url: 'http://backend/tags/2',
+          tag: "a tag!"
+        });
+
+      endpoint.update({id : 7}, {
+        tag: "a tag!"
+      });
+
+      $httpBackend.flush();
+
+      let tag = endpoint.get({id : 7});
+
+      expect(tag.tag).toBe("a tag!");
+      expect(tag.id).toBe(7);
+    });
+  });
+
+  describe('.save()', () => {
+    it('should update the cache on save', () => {
+      $httpBackend.expectPOST('http://backend/tags', {
+          tag: "a tag!"
+        })
+        .respond({
+          id: 10,
+          url: 'http://backend/tags/2',
+          tag: "a tag!"
+        });
+
+      endpoint.save({
+        tag: "a tag!"
+      });
+
+      $httpBackend.flush();
+
+      let tag = endpoint.get({id : 10});
+
+      expect(tag.tag).toBe("a tag!");
+      expect(tag.id).toBe(10);
+    });
+  });
+
+  describe('.delete()', () => {
+    it('should clear the cache on delete', (done) => {
+
+      $httpBackend.expectDELETE('http://backend/tags/2')
+        .respond({
+          id: 2,
+          url: 'http://backend/tags/2',
+          tag: "a tag!"
+        });
+
+      endpoint.delete({ id: 2 });
+
+      $httpBackend.flush();
+
+      $httpBackend.expectGET('http://backend/tags/2')
+        .respond(404);
+
+      let tag = endpoint.get({ id : 2 });
+
+      tag.$promise.then(() => {
+        fail("Tag was returned but should have 404'd");
+        done();
+      }, () => {
+        done();
+      })
+      .catch(angular.noop);
+
+      $httpBackend.flush();
+    });
+  });
 
   afterEach(() => {
     $httpBackend.verifyNoOutstandingExpectation();

--- a/app/common/services/endpoints/endpointFactory.js
+++ b/app/common/services/endpoints/endpointFactory.js
@@ -1,7 +1,7 @@
-EndpointFactoryFactory.$inject = ['$resource', 'CacheFactory', '$q', 'Util', 'Endpoint'];
-function EndpointFactoryFactory($resource, CacheFactory, $q, Util, Endpoint) {
+EndpointFactoryFactory.$inject = ['$resource', 'CacheFactory', '$q', '$httpParamSerializer', 'Util', 'Endpoint'];
+function EndpointFactoryFactory($resource, CacheFactory, $q, $httpParamSerializer, Util, Endpoint) {
 	return function EndpointFactory(id, url, params, methods) {
-		return new Endpoint(id, Util.apiUrl(url), params, methods, $resource, CacheFactory, $q)
+		return new Endpoint(id, Util.apiUrl(url), params, methods, $resource, CacheFactory, $q, $httpParamSerializer)
 	}
 }
 

--- a/app/common/services/endpoints/endpointFactory.js
+++ b/app/common/services/endpoints/endpointFactory.js
@@ -1,0 +1,8 @@
+EndpointFactoryFactory.$inject = ['$resource', 'CacheFactory', '$q', 'Util', 'Endpoint'];
+function EndpointFactoryFactory($resource, CacheFactory, $q, Util, Endpoint) {
+	return function EndpointFactory(id, url, params, methods) {
+		return new Endpoint(id, Util.apiUrl(url), params, methods, $resource, CacheFactory, $q)
+	}
+}
+
+export default EndpointFactoryFactory;

--- a/test/unit/spec.bundle.js
+++ b/test/unit/spec.bundle.js
@@ -36,3 +36,6 @@ var context = require.context('test/unit/', true, /spec\.js$/);
 // that will require the file and load it here. Context will
 // loop and require those spec files here.
 context.keys().forEach(context);
+
+let inlineTestsContext = require.context('app/', true, /\.spec\.js$/);
+inlineTestsContext.keys().forEach(inlineTestsContext);


### PR DESCRIPTION
This pull request makes the following changes:
- Create a generic endpoint class
- [ ] Convert existing endpoints to use this
- [ ] Add events to endpoint class

Testing checklist:
- [ ]

Refs ushahidi/platform#1922

Ping @ushahidi/platform
