### PR TITLE
fix setting rtl in language-switcher

### DIFF
--- a/app/common/services/translation.service.js
+++ b/app/common/services/translation.service.js
@@ -19,13 +19,13 @@ function (
     UserEndpoint,
     ConfigEndpoint
 ) {
-    var translate = function (language) {
-        $translate.use(language).then(function (langKey) {
+    var translate = function (lang) {
+        $translate.use(lang).then(function (langKey) {
             if (langKey) {
-                $translate.preferredLanguage(language);
+                $translate.preferredLanguage(langKey);
                 Languages.then(function (languages) {
                     angular.forEach(languages, function (language) {
-                        if (language.code === language) {
+                        if (language.code === langKey) {
                             $rootScope.rtlEnabled = language.rtl;
                         }
                     });


### PR DESCRIPTION
This pull request makes the following changes:
- Fix a bug in the translation-service that caused rtl to not be set properly.

Testing checklist:
- [ ] In the language-switcher, choose arabic or another rtl-language, view should change to right-left
- [ ] In settings-general, choose arabic or another rtl-language, and then save, view should change to  right-left.

Fixes ushahidi/platform#1940 .

Ping @ushahidi/platform