### PR TITLE
Remove race conditions in TranslationService.getLanguage()

### DIFF
--- a/app/common/services/translation.service.js
+++ b/app/common/services/translation.service.js
@@ -42,20 +42,31 @@ function (
         });
     };
 
-    var getLanguage = function () {
+    var getLanguage = function (config) {
         return $q(function (resolve, reject) {
                 if (Session.getSessionDataEntry('language')) {
                     resolve(Session.getSessionDataEntry('language'));
+                    return;
                 }
+
+                let configRequest = $q.when(config ? config : ConfigEndpoint.get({id: 'site'}).$promise);
+                let userRequest = $q.when(false);
+
                 if (Authentication.getLoginStatus()) {
-                    UserEndpoint.get({id: 'me'}).$promise.then(function (user) {
-                        if (user.language) {
-                            resolve(user.language);
-                        }
-                    });
+                    userRequest = UserEndpoint.get({id: 'me'}).$promise;
                 }
-                ConfigEndpoint.get({id: 'site'}).$promise.then(function (site) {
-                    site.language ? resolve(site.language) : resolve('en');
+
+                $q.all({
+                    user: userRequest,
+                    config: configRequest
+                }).then(function (result) {
+                    if (result.user && result.user.language) {
+                        resolve(result.user.language);
+                    } else if (result.config.language) {
+                        resolve(result.config.language);
+                    } else {
+                        resolve('en');
+                    }
                 });
             });
     };


### PR DESCRIPTION
- Make sure we wait for all requests to return before resolving
  the getLanguage promise. Otherwise its not clear if site config
  or user config takes precedence.
- Also accept site config as a parameter

Testing checklist:
- [x] Switch languages and check it works as expected
- [x] Switch languages, and reload the page... does language reset?
- [x] Configure conflicting languages in site and user config... does user config take precedence?

Ping @ushahidi/platform
