### PR TITLE
1948: After I click on a saved search in the list, it will navigate to it and close the saved search list window.

### DIFF
--- a/app/main/posts/savedsearches/saved-search-modal.directive.js
+++ b/app/main/posts/savedsearches/saved-search-modal.directive.js
@@ -10,12 +10,13 @@ function SavedSearchModal() {
     };
 }
 
-SavedSearchModalController.$inject = ['$scope', '$element', '$attrs', '$rootScope', 'UserEndpoint', 'SavedSearchEndpoint', '_', 'ModalService'];
-function SavedSearchModalController($scope, $element, $attrs, $rootScope, UserEndpoint, SavedSearchEndpoint, _, ModalService) {
+SavedSearchModalController.$inject = ['$scope', '$element', '$attrs', '$rootScope', '$location', 'UserEndpoint', 'SavedSearchEndpoint', '_', 'ModalService'];
+function SavedSearchModalController($scope, $element, $attrs, $rootScope, $location, UserEndpoint, SavedSearchEndpoint, _, ModalService) {
     var users = [];
 
     $scope.searchSearches = searchSearches;
     $scope.createNewSearch = createNewSearch;
+    $scope.goToSearch = goToSearch;
     activate();
 
     // Reload searches on login / logout events
@@ -47,6 +48,7 @@ function SavedSearchModalController($scope, $element, $attrs, $rootScope, UserEn
             });
         });
     }
+
     function createNewSearch() {
         // Copy the current filters into our search..
         ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', 'set.create_savedsearch', 'star', $scope, false, false);
@@ -56,4 +58,15 @@ function SavedSearchModalController($scope, $element, $attrs, $rootScope, UserEn
             q : query
         });
     }
+
+    /**
+     * @param searchId: the saved search id, used to identify it in the url path.
+     * We are just closing the modal before we go to the new saved search the user selected in the frontend.
+     * See: https://waffle.io/ushahidi/platform/cards/598289fa17b93500a65be936
+     */
+    function goToSearch(searchId) {
+        ModalService.close();
+        $location.url('/savedsearches/' + searchId);
+    }
+
 }

--- a/app/main/posts/savedsearches/saved-search-modal.html
+++ b/app/main/posts/savedsearches/saved-search-modal.html
@@ -8,15 +8,15 @@
             type="search"
             ng-model="savedSearchQuery"
             placeholder="{{ 'set.find_a_saved_search' | translate }}" ng-keydown="searchSearches(savedSearchQuery)"
-        > 
+        >
     </div>
 </div>
 
 <div class="modal-body">
-    <div class="listing">   
+    <div class="listing">
         <div class="listing-item" ng-repeat="search in searches">
             <div class="listing-item-primary">
-                <h2 class="listing-item-title"><a href="savedsearches/{{search.id}}">{{search.name}}</a></h2>
+                <h2 class="listing-item-title"><a href="#" ng-click="goToSearch(search.id)">{{search.name}}</a></h2>
             </div>
         </div>
     </div>


### PR DESCRIPTION
An attempt to fix  [waffle issue#1948 - ](https://waffle.io/ushahidi/platform/cards/598289fa17b93500a65be936).
Previous behavior: The window with saved search list doesn't go away. I have to manually X out of it.
Current behavior: After I click on a saved search in the list, it will navigate to it and close the saved search list window.

This pull request makes the following changes:
- Instead of just using the **searchId** in the <a> tag (ie: /savedsearches/:searchId), we now capture the click event and close the modal box before sending the user to the search result. 

Testing checklist:

* Check that the modal is closed automatically when a search is selected:
    - [ ] Log into Ushahidi
    - [ ] Open the map.
    - [ ] Click on the star icon next to the search bar to see the "saved search" modal box.
    - [ ] Select an option in the modal box (one of the saved searches)
        - [ ] The modal box should close itself with no other interactions
        - [ ] The website should take you to the selected saved search page
![video1948](https://user-images.githubusercontent.com/2434401/28993338-6bbbb7fc-798a-11e7-8c82-42b1003e8a25.gif)

* Check that you can still manually close the modal box.
    - [ ] Click on the Close button
        - [ ] The modal box should be closed after clicking the close button. 
        - [ ] The website url should remain as it was (in the same page and showing the same map information)

Fixes ushahidi/platform#1948

Ping @ushahidi/platform