### PR TITLE
#1862  - UX changes to add post title

### DIFF
--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -52,7 +52,7 @@
 
           <div class="form-sheet">
               <div class="post-band" ng-style="{backgroundColor: form.color}"></div>
-              <div class="form-field title init required"
+              <div class="form-field init required"
               adaptive-form
               ng-class="{
                 'error': postForm.title.$invalid && postForm.title.$dirty,


### PR DESCRIPTION
Removing title class so that the form element that holds the title text
can fall in line with other elements in the form.