### PR TITLE
Locking posts

### DIFF
--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -45,7 +45,10 @@ function (
             method: 'GET'
         },
         breakLock: {
-            url: Util.apiUrl('/posts/:id/lock'),
+            url: Util.apiUrl('/posts/:id/lock/:lock_id'),
+            params: {
+                lock_id: '@lock_id'
+            },
             method: 'PUT'
         },
         update: {

--- a/app/main/posts/common/post-actions.html
+++ b/app/main/posts/common/post-actions.html
@@ -12,8 +12,8 @@
   </button>
   <div class="dropdown-menu init" dropdown-menu>
     <ul>
-        <li ng-show="post.allowed_privileges.indexOf('update') !== -1 && !postLocked" class="hide-when-small">
-          <a ng-href="/posts/{{post.id}}/edit">
+        <li ng-show="post.allowed_privileges.indexOf('update') !== -1" class="hide-when-small">
+          <a ng-show="post.allowed_privileges.indexOf('update') !== -1" ng-click="openEditMode()">
               <svg class="iconic">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#pencil"></use>
               </svg>

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -130,7 +130,7 @@
         </div>
     </div>
 
-    <post-add-form post="post" ng-if="!post.form && post.allowed_privileges.indexOf('update') !== -1"></post-add-form>
+    <post-add-form post="post" ng-if="!post.form && post.allowed_privileges.indexOf('update') !== -1 && !postLocked"></post-add-form>
     <post-messages post="post" ng-if="post.contact.id"></post-messages>
     <ush-logo></ush-logo>
   </div>

--- a/app/main/posts/modify/main.html
+++ b/app/main/posts/modify/main.html
@@ -1,1 +1,1 @@
-<post-editor post="post" form="form" ng-if="form.id"></post-editor>
+<post-editor post="post" form="form" lock-id="lockId" ng-if="form.id"></post-editor>

--- a/app/main/posts/modify/post-edit.controller.js
+++ b/app/main/posts/modify/post-edit.controller.js
@@ -32,7 +32,6 @@ function (
         PostEndpoint.get({ id: $routeParams.id }).$promise
     ]).then(function (results) {
         var post = results[1];
-
         if (!results[0].id) {
             // Failed to get a lock
             // Bounce user back to the detail page where they will if admin/manage post perm
@@ -64,12 +63,11 @@ function (
                 }
             });
         } else {
-            $location.url('/posts/' + post.id);
+            PostEndpoint.breakLock({id: post.id}).$promise.then(function (results) {
+                $location.url('/posts/' + post.id);
+                PostEndpoint.requestLock({id: post.id});
+            });
         }
         $scope.post = post;
-
-        $scope.$on('$routeChangeStart', function (next, current) {
-            PostEndpoint.breakLock({id: $scope.post.id});
-        });
     });
 }];

--- a/app/main/posts/modify/post-edit.controller.js
+++ b/app/main/posts/modify/post-edit.controller.js
@@ -32,6 +32,7 @@ function (
         PostEndpoint.get({ id: $routeParams.id }).$promise
     ]).then(function (results) {
         var post = results[1];
+        $scope.lockId = results[0].id;
         if (!results[0].id) {
             // Failed to get a lock
             // Bounce user back to the detail page where they will if admin/manage post perm

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -9,7 +9,8 @@ function PostEditor() {
             post: '=',
             attributesToIgnore: '=',
             form: '=',
-            postMode: '='
+            postMode: '=',
+            lockId: '='
         },
         template: require('./post-editor.html'),
         controller: PostEditorController
@@ -57,7 +58,6 @@ function PostEditorController(
     PostActionsService,
     MediaEditService
   ) {
-
     // Setup initial stages container
     $scope.everyone = $filter('translate')('post.modify.everyone');
     $scope.isEdit = !!$scope.post.id;
@@ -237,7 +237,7 @@ function PostEditorController(
     }
 
     function cancel() {
-        PostEndpoint.breakLock({id: $scope.post.id}).$promise.then(function (result) {
+        PostEndpoint.breakLock({lock_id: $scope.lockId}).$promise.then(function (result) {
             var path = $scope.post.id ? '/posts/' + $scope.post.id : '/';
             $location.path(path);
         });


### PR DESCRIPTION
This pull request makes the following changes:
- Fixing problems with locking of:
- Structured posts, when a user that previously was editing and got unlocked by another user clicks 'cancel', the new lock from the unlocking user is not removed (heh, am I making sense here?)
- Unstructured posts, when a user starts editing an unlocked unstructured post, the post gets locked
- Unstructured posts, when a user wants to edit a locked unstructured post, they get notified and the edit-form is not shown.

- The edit-button is still visible even though a post is locked. That is because if a user wants to edit a post, misses the notification that the post is locked, there is no way for that user to see that message again, if they don't click the edit-button.

Testing checklist:
**Structured posts**
- [ ] Go to a structured post, start editing
- [ ] Go to the same structured post as another user, try edit
- [ ] Choose to unlock the other users lock
- [ ] Go back as the first user, click cancel and try to edit again, the post should be locked.

**Unstructured posts **
- [ ] Go to an unstructured post and start edit it
- [ ] No message about the post being locked should be visible.
- [ ] Go to the same unstructured post as another user, a message about the post being locked should be visible and the edit-form should not be shown.



Fixes ushahidi/platform#1986 .

Ping @ushahidi/platform