### PR TITLE
Displaying correct number of posts in survey-filter

### DIFF
--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -31,7 +31,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
         // Load forms
         $scope.forms = FormEndpoint.queryFresh();
         $scope.tags = TagEndpoint.queryFresh();
-        var postCountRequest = PostEndpoint.stats({ group_by: 'form', status: 'all', include_unmapped: true });
+        var postCountRequest = PostEndpoint.stats({ group_by: 'form', status:  ['draft', 'published'], include_unmapped: true });
         $q.all([$scope.forms.$promise, postCountRequest.$promise, $scope.tags.$promise]).then(function (responses) {
             if (!responses[1] || !responses[1].totals || !responses[1].totals[0]) {
                 return;

--- a/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
+++ b/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
@@ -30,6 +30,9 @@ describe('mode-context-form-filter directive', function () {
         spyOn(TagEndpoint, 'queryFresh').and.callThrough();
         spyOn(PostEndpoint, 'stats').and.callThrough();
         spyOn(PostFilters, 'getQueryParams').and.callThrough();
+
+        $scope.filters = PostFilters.getDefaults();
+
         element = '<mode-context-form-filter></mode-context-form-filter>';
         element = $compile(element)($scope);
         $scope.$digest();

--- a/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
+++ b/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
@@ -1,0 +1,91 @@
+describe('mode-context-form-filter directive', function () {
+    var $rootScope,
+        $scope,
+        element,
+        isolateScope,
+        PostEndpoint,
+        FormEndpoint,
+        TagEndpoint,
+        $location,
+        PostSurveyService,
+        PostFilters;
+    beforeEach(function () {
+        var testApp;
+        fixture.setBase('mocked_backend/api/v3');
+        testApp = makeTestApp();
+        testApp.directive('modeContextFormFilter', require('app/main/posts/views/mode-context-form-filter.directive.js'));
+        angular.mock.module('testApp');
+    });
+
+    beforeEach(inject(function (_$rootScope_, $compile, _FormEndpoint_, _PostEndpoint_, _TagEndpoint_, _PostSurveyService_, _PostFilters_, _$location_) {
+        $rootScope = _$rootScope_;
+        $scope = _$rootScope_.$new();
+        PostEndpoint = _PostEndpoint_;
+        FormEndpoint = _FormEndpoint_;
+        TagEndpoint = _TagEndpoint_;
+        PostSurveyService = _PostSurveyService_;
+        PostFilters = _PostFilters_;
+        $location = _$location_;
+        spyOn(FormEndpoint, 'queryFresh').and.callThrough();
+        spyOn(TagEndpoint, 'queryFresh').and.callThrough();
+        spyOn(PostEndpoint, 'stats').and.callThrough();
+        spyOn(PostFilters, 'getQueryParams').and.callThrough();
+        element = '<mode-context-form-filter></mode-context-form-filter>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.scope();
+        // isolateScope.filters = {q: '', created_after: '', created_before: '', status: 'published', published_to: '', center_point: '', within_km: '1', current_stage: [], tags: [], form: [1,2], set: []};
+    }));
+    describe('test directive-functions', function () {
+        it('should fetch forms from endpoint', function () {
+            expect(FormEndpoint.queryFresh).toHaveBeenCalled();
+        });
+        it('should fetch tags from endpoint', function () {
+            expect(TagEndpoint.queryFresh).toHaveBeenCalled();
+        });
+        it('should fetch queryParams from service', function () {
+            expect(PostFilters.getQueryParams).toHaveBeenCalled();
+        });
+        it('should fetch post-stats from endpoint', function () {
+            expect(PostEndpoint.stats).toHaveBeenCalled();
+        });
+        it('should change the value of forms if filters are changed', function () {
+            spyOn(PostFilters, 'getFilters');
+            expect(PostFilters.getFilters).not.toHaveBeenCalled();
+            isolateScope.filters.status = 'archived';
+            $scope.$digest();
+            expect(PostFilters.getFilters).toHaveBeenCalled();
+        });
+        it('should change value of languageToggle on toggle', function () {
+            expect(isolateScope.showLanguage).toEqual(false);
+            isolateScope.languageToggle();
+            expect(isolateScope.showLanguage).toEqual(true);
+        });
+        it('should change form if a category is selected on a new form', function () {
+            isolateScope.forms = [{id: 1}, {id: 2}];
+            isolateScope.filters.tags = [1,2];
+            isolateScope.changeForms();
+            expect(isolateScope.filters.tags).toEqual([]);
+        });
+        it('should change filters when selecting show only', function () {
+            isolateScope.showOnly(2);
+            expect(isolateScope.filters.form.length).toEqual(1);
+            expect(isolateScope.filters.form[0]).toEqual(2);
+        });
+        it('should redirect to list-view', function () {
+            $location.path('/views/map');
+            isolateScope.goToUnmapped();
+            expect($location.path()).toEqual('/views/list');
+        });
+        it('should return the correct formatting for unmapped posts', function () {
+            isolateScope.unmapped = 1;
+            expect(isolateScope.getUnmapped()).toEqual('1 post');
+            isolateScope.unmapped = 2;
+            expect(isolateScope.getUnmapped()).toEqual('2 posts');
+        });
+        it('should hide forms that are not selected', function () {
+            isolateScope.hide(2);
+            expect(isolateScope.filters.form.indexOf(2)).toEqual(-1);
+        });
+    });
+});

--- a/test/unit/mock/services/form.js
+++ b/test/unit/mock/services/form.js
@@ -15,8 +15,19 @@ module.exports = [function () {
                 then: function (successCallback, failCallback) {
                     successCallback([{
                         name: 'test form',
-                        id: 1
-                    }]);
+                        id: 1,
+                        tags: [{
+                            id: 1,
+                            tag: 'Test-tag'
+                        }]},
+                        {
+                        name: 'test form 2',
+                        id: 2,
+                        tags: [{
+                            id: 1,
+                            tag: 'Test-tag'
+                        }]}
+                    ]);
                 }
             }};
         },

--- a/test/unit/mock/services/post-filters.js
+++ b/test/unit/mock/services/post-filters.js
@@ -3,7 +3,7 @@ module.exports = [function () {
         q: '',
         created_after: '',
         created_before: '',
-        status: 'published',
+        status: ['published'],
         published_to: '',
         center_point: '',
         within_km: '1',
@@ -12,11 +12,29 @@ module.exports = [function () {
         form: [],
         set: []
     };
+    var defaultFilters = {
+            q: '',
+            date_after: '',
+            date_before: '',
+            status: ['published', 'draft'],
+            published_to: '',
+            center_point: '',
+            has_location: 'all',
+            within_km: '1',
+            current_stage: [],
+            tags: [],
+            form: [1, 2],
+            set: [],
+            user: false
+        };
+
     var filterMode = 'all';
 
     return {
         filterState: filterState,
-        getDefaults: function () {},
+        getDefaults: function () {
+            return defaultFilters;
+        },
         getQueryParams: function (filters) {
             return filters;
         },


### PR DESCRIPTION
This pull request makes the following changes:
- Displays the number of posts in the survey-filter-bar based on current filtering
- Excludes archived posts in the total count except when filtering for archived posts (imported from a uchaguzi-commit)

Testing checklist:
- [x] Go to views/map or views/list
- [x] Check the numbers in the survey-filter-bar
- [x] Choose a filter or saved search
- [x] The number in the survey-filter-bar should update according to the new search


Fixes ushahidi/platform#1997 and ushahidi/platform#1967  .

Ping @ushahidi/platform
