### PR TITLE
Savedsearch Roles

### DIFF
--- a/app/common/directives/role-selector.directive.js
+++ b/app/common/directives/role-selector.directive.js
@@ -7,7 +7,8 @@ function RoleSelectorDirective() {
         restrict: 'E',
         scope: {
             model: '=',
-            title: '='
+            title: '=',
+            name: '='
         },
         controller: RoleSelectorController,
         template: require('./role-selector.html')

--- a/app/common/directives/role-selector.html
+++ b/app/common/directives/role-selector.html
@@ -5,13 +5,13 @@
             class="form-field radio icon-input"
             ng-class="{ 'checked': !model.role.length }"
         >
-            <label for="add_everyone">
+            <label for="add_everyone-{{name}}">
                 <svg class="iconic">
                     <use xlink:href="/img/iconic-sprite.svg#globe"></use>
                 </svg>
                 <input
                     name="add"
-                    id="add_everyone"
+                    ng-attr-id="{{'add_everyone-' + name}}"
                     ng-value="true"
                     checked=""
                     type="radio"
@@ -21,19 +21,20 @@
                 <span class="label" translate="nav.everyone">Everyone</span>
             </label>
         </div>
+        
 
         <div
             class="form-field radio icon-input"
             ng-class="{ 'checked': model.role.length }"
         >
-            <label for="add_roles">
+            <label for="add_roles-{{name}}">
                 <svg class="iconic">
                     <use xlink:href="/img/iconic-sprite.svg#people"></use>
                 </svg>
                 <input
                     class="init"
                     name="add"
-                    id="add_roles"
+                    ng-attr-id="{{'add_roles-' + name}}"
                     ng-value="false"
                     ng-modaldata-fieldgroup-toggle="add_roles"
                     type="radio"
@@ -49,8 +50,9 @@
             >
 
                 <div class="form-field checkbox" ng-repeat="role in roles">
-                    <label>
+                    <label for="role-name-{{name}}-{{role.name}}">
                     <input
+                        ng-attr-id="{{'role-name-' + name + '-' + role.name}}"
                         type="checkbox"
                         checklist-model="model.role"
                         checklist-value="role.name"

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -92,6 +92,7 @@
         "this_category_is_child_to" : "This category is a child to <strong>{{parent}}</strong>",
         "nothing" : "Nothing",
         "who_can_see_this" : "Who can see this?",
+        "who_can_edit_this" : "Who can edit this?",
         "add" : "Add",
         "add_new_category" : "+ Add new category",
         "sort_by": "Sort By",

--- a/app/main/posts/collections/editor.html
+++ b/app/main/posts/collections/editor.html
@@ -37,7 +37,7 @@
         </div>
     </div>
     <!-- Who can see -->
-    <role-selector model="cpyCollection" title="'app.who_can_see_this'"></role-selector>
+    <role-selector name="'whocansee'" model="cpyCollection" title="'app.who_can_see_this'"></role-selector>
 
     <div class="modal-actions">
         <div class="form-field">

--- a/app/main/posts/savedsearches/editor-directive.js
+++ b/app/main/posts/savedsearches/editor-directive.js
@@ -7,7 +7,6 @@ module.exports = [
     '_',
     'Notify',
     'ViewHelper',
-    'RoleEndpoint',
 function (
     $q,
     $location,
@@ -16,8 +15,7 @@ function (
     SavedSearchEndpoint,
     _,
     Notify,
-    ViewHelper,
-    RoleEndpoint
+    ViewHelper
 ) {
     return {
         restrict: 'E',
@@ -33,18 +31,26 @@ function (
                 };
             }
 
-            $scope.featuredEnabled = function () {
-                return $rootScope.hasPermission('Manage Posts');
-            };
-
             $scope.isAdmin = $rootScope.isAdmin;
 
             $scope.views = ViewHelper.views();
 
             $scope.cpySavedSearch = _.clone($scope.savedSearch);
 
+            $scope.editableRoles = {
+                'role': $scope.cpySavedSearch.edit_role
+            };
+
+            $scope.featuredEnabled = function () {
+                return $rootScope.hasPermission('Manage Posts');
+            };
+
             $scope.save = function (savedSearch) {
                 var persist = savedSearch.id ? SavedSearchEndpoint.update : SavedSearchEndpoint.save;
+
+                // Add back editable roles
+                savedSearch.edit_role = $scope.editableRoles.role;
+
                 persist(savedSearch)
                 .$promise
                 .then(function (savedSearch) {

--- a/app/main/posts/savedsearches/mode-context.html
+++ b/app/main/posts/savedsearches/mode-context.html
@@ -120,9 +120,9 @@
 
         <mode-context-form-filter></mode-context-form-filter>
 
-        <post-active-filters></post-active-filters>
+        <post-active-filters ></post-active-filters>
 
-        <saved-search-update></saved-search-update>
+        <saved-search-update ng-show="canEdit"></saved-search-update>
 
     </div>
 </div>

--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -34,7 +34,10 @@
         </div>
     </div>
     <!-- Who can see? -->
-    <role-selector model="savedSearch" title="'app.who_can_see_this'"></role-selector>
+    <role-selector name="'whocansee'" model="savedSearch" title="'app.who_can_see_this'"></role-selector>
+    <!--// Who can add //-->
+    <role-selector name="'whocanedit'" model="editableRoles" title="'app.who_can_edit_this'"></role-selector>
+   
     <div class="modal-actions">
         <div class="form-field">
             <button type="button" class="button-link  modal-trigger" ng-click="cancel()" translate>app.cancel</button>

--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -99,7 +99,7 @@
                 </div>
               </fieldset>
               <!-- Who can see and add -->
-              <role-selector model="category" title="'app.who_can_see_this_category'" ng-show="!category.parent_id"></role-selector>
+              <role-selector name="'whocanseecategories'" model="category" title="'app.who_can_see_this_category'" ng-show="!category.parent_id"></role-selector>
               <div class="form-field" ng-show="category.parent_id">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#people"></use>

--- a/test/unit/common/directives/role-selector.directive.spec.js
+++ b/test/unit/common/directives/role-selector.directive.spec.js
@@ -21,8 +21,9 @@ describe('role-selector directive', function () {
 
         $scope = _$rootScope_.$new();
         $scope.title = 'This is title';
+        $scope.name = 'test';
         $scope.model = {};
-        element = '<role-selector title="title" model="model"></role-selector>';
+        element = '<role-selector name="name" title="title" model="model"></role-selector>';
 
         element = $compile(element)($scope);
         $scope.$digest();


### PR DESCRIPTION
This pull request makes the following changes:
- Add a 'who can edit this saved search' toggle to the saved search editor

Todo:
- [ ] Add the same toggle to collections


Test checklist:
- [ ] Create a saved search w/ restricted edit roles
- [ ] Change user and check you cannot edit it
- [ ] Change user to someone with edit role, and confirm you *can* edit it

Fixes ushahidi/platform#1956

Ping @ushahidi/platform
