### PR TITLE
Visual feedback to tell users which tasks and fields are public

### DIFF
--- a/app/main/posts/modify/post-tabs.html
+++ b/app/main/posts/modify/post-tabs.html
@@ -2,6 +2,9 @@
     <header class="form-sheet-summary">
         <h1 class="form-sheet-title section-title">{{stage.label}}</h1>
     </header>
+    <div ng-show="stage.show_when_published" class="alert">
+        <p translate="survey.task_visible_when_published">This task will be visible when post is published</p>
+    </div>
     <!-- Handle stage completion -->
     <div class="form-field switch">
         <label translate="post.task_completed">Task completed</label>
@@ -13,7 +16,7 @@
                 ng-checked="stageIsComplete(stage.id)"
                 ng-click="toggleStageCompletion(stage.id)">
             <label class="tgl-btn" for="toggle-complete-{{stage.id}}" ng-attr-id="{{ 'toggle-complete-label-' + stage.id }}"></label>
-        
+
         </div>
     </div>
     <post-value-edit

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -14,6 +14,9 @@
 
       <!-- Attribute Label -->
       <label for="values[{{attribute.key}}][0]">
+          <svg ng-show="attribute.response_private" class="iconic">
+            <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
+          </svg>
           {{attribute.label}}
       </label>
       <!-- Attribute Instructions -->


### PR DESCRIPTION
This pull request makes the following changes:
- Show lock next to private survey fields
- Show message at the top of public tasks

Testing checklist:
- [x] Submit to a survey with public tasks, check for info message
- [x] Submit to a survey with private attribute, check for lock

Fixes ushahidi/platform#1979

Ping @ushahidi/platform
