### PR TITLE
Show category names on post detail, not ids field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vault.txt
 *.svg
 server/www/img/icons/
 server/www/
+app/locales/

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -53,15 +53,6 @@
             ng-if="form_attributes[key].type === 'media'"
             label="{{form_attributes[key].label}}"
             media-id="value"></post-media-value>
-
-            <div ng-if="form_attributes[key].input === 'tags'">
-                <h2 class="form-label">{{form_attributes[key].label}}</h2>
-                    <svg class="iconic" style="margin-right:4px;">
-                        <use xlink:href="/img/iconic-sprite.svg#tag"></use>
-                    </svg>
-                    {{formatTags(post.values[key])}}
-                    </span>
-            </div>
         </div>
         <div
           ng-if="post.content"
@@ -71,10 +62,11 @@
 
         <post-value
           ng-repeat="(key,value) in post.values"
-          ng-if="form_attributes[key].type !== 'media' && isPostValue(key) && showType(form_attributes[key].type) && form_attributes[key].input !== 'tags'"
+          ng-if="form_attributes[key].type !== 'media' && isPostValue(key) && showType(form_attributes[key].type)"
           key="key"
           value="value"
           attribute="form_attributes[key]"
+          tags="tags"
           type="'post'">
         </post-value>
         <post-detail-map post-id="post.id"></post-detail-map>

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -120,6 +120,7 @@
             ng-show="form_attributes[key].form_stage_id === visibleTask"
             >
             <post-value
+              tags="tags"
               key="key"
               value="value"
               attribute="form_attributes[key]"

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -160,23 +160,6 @@ function (
             $scope.form_attributes[key].form_stage_id === $scope.post_task.id;
     };
 
-    // TODO Move to Service
-    $scope.formatTags = function (tagIds) {
-        // getting tag-names and formatting them for displaying
-        var formatedTags = ' ';
-        _.each(tagIds, function (tag, index) {
-            var tagObj = _.where($scope.tags, {id: parseInt(tag)});
-            if (tagObj[0]) {
-                tag = tagObj[0].tag;
-                if (index < tagIds.length - 1) {
-                    formatedTags += tag + ', ';
-                } else {
-                    formatedTags += tag;
-                }
-            }
-        });
-        return formatedTags;
-    };
     $scope.showType = function (type) {
         if (type === 'point') {
             return false;

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -159,6 +159,8 @@ function (
         return $scope.form_attributes[key] && $scope.post_task &&
             $scope.form_attributes[key].form_stage_id === $scope.post_task.id;
     };
+
+    // TODO Move to Service
     $scope.formatTags = function (tagIds) {
         // getting tag-names and formatting them for displaying
         var formatedTags = ' ';

--- a/app/main/posts/detail/post-value.directive.js
+++ b/app/main/posts/detail/post-value.directive.js
@@ -1,4 +1,4 @@
-module.exports = ['PostEndpoint', 'moment', function (PostEndpoint, moment) {
+module.exports = ['PostEndpoint', 'moment', '_', function (PostEndpoint, moment, _) {
     return {
         restrict: 'E',
         replace: true,
@@ -6,17 +6,39 @@ module.exports = ['PostEndpoint', 'moment', function (PostEndpoint, moment) {
             key: '=',
             value: '=',
             attribute: '=',
-            type: '='
+            type: '=',
+            tags: '='
         },
         template: require('./post-value.html'),
         link: function ($scope) {
+            // This whole directive is wrong and it should feel wrong
             // Depending on whether we are dealing with a post task or a standard task
             // the css class is swapped. This Boolean manages that distinction.
             $scope.standardTask = $scope.type === 'standard';
+            // TODO Move to Service
+            $scope.formatTags = function (tagIds) {
+                // getting tag-names and formatting them for displaying
+                var formatedTags = ' ';
+                _.each(tagIds, function (tag, index) {
+                    var tagObj = _.where($scope.tags, {id: parseInt(tag)});
+                    if (tagObj[0]) {
+                        tag = tagObj[0].tag;
+                        if (index < tagIds.length - 1) {
+                            formatedTags += tag + ', ';
+                        } else {
+                            formatedTags += tag;
+                        }
+                    }
+                });
+                return formatedTags;
+            };
             if ($scope.attribute.type === 'relation') {
                 $scope.value = $scope.value.map(function (entry) {
                     return PostEndpoint.get({ id : entry });
                 });
+            }
+            if ($scope.attribute.input === 'tags') {
+                $scope.value = $scope.formatTags($scope.value);
             }
             if ($scope.attribute.type === 'datetime') {
                 if ($scope.attribute.input === 'date') {

--- a/app/main/posts/detail/post-value.html
+++ b/app/main/posts/detail/post-value.html
@@ -1,13 +1,23 @@
 <div ng-class="{'postcard-field': !standardTask, 'listing-item-primary': standardTask}">
+
     <div ng-if="attribute.input !== 'video'">
       <h2 class="form-label">
           {{attribute.label}}
       </h2>
 
+      <div ng-if="attribute.input === 'tags'">
+        <svg class="iconic" style="margin-right:4px;">
+            <use xlink:href="/img/iconic-sprite.svg#tag"></use>
+        </svg>
+        {{value}}
+        </span>
+      </div>
+
+      
       <div ng-repeat="entry in value" ng-if="attribute.type === 'relation'">
           <a ng-href="/posts/{{entry.id}}">{{entry.title}}</a>
       </div>
-      <div ng-repeat="entry in value" ng-if="attribute.type !== 'relation'">
+      <div ng-repeat="entry in value" ng-if="attribute.type !== 'relation' && attribute.input !== 'tags'">
           <p ng-if="attribute.type !== 'markdown'">{{entry}}</p>
           <p ng-if="attribute.type === 'markdown'" markdown-to-html="entry"></p>
       </div>

--- a/app/main/posts/detail/post-value.html
+++ b/app/main/posts/detail/post-value.html
@@ -6,11 +6,12 @@
       </h2>
 
       <div ng-if="attribute.input === 'tags'">
+       <p>
         <svg class="iconic" style="margin-right:4px;">
             <use xlink:href="/img/iconic-sprite.svg#tag"></use>
         </svg>
-        {{value}}
-        </span>
+          {{value}}
+        </p>
       </div>
 
       


### PR DESCRIPTION
This pull request makes the following changes:
- Displaying name instead of Id to categories in tasks

Testing checklist:
- [x] Add a post to a survey with categories in a task and save the post. The categories selected should be displayed as names, not as ids when looking at the saved post.

Fixes ushahidi/platform#2022

Ping @ushahidi/platform
