### PR TITLE
Adding name instead of id to categories in tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ vault.txt
 *.svg
 server/www/img/icons/
 server/www/
+app/locales/
+

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -56,11 +56,12 @@
 
             <div ng-if="form_attributes[key].input === 'tags'">
                 <h2 class="form-label">{{form_attributes[key].label}}</h2>
+                <p>
                     <svg class="iconic" style="margin-right:4px;">
                         <use xlink:href="/img/iconic-sprite.svg#tag"></use>
                     </svg>
                     {{formatTags(post.values[key])}}
-                    </span>
+                </p>
             </div>
         </div>
         <div
@@ -116,15 +117,25 @@
           </div>
           <div
             ng-repeat="(key,value) in post.values"
-            ng-if="form_attributes[key].type !== 'media' && !isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)"
             ng-show="form_attributes[key].form_stage_id === visibleTask"
             >
             <post-value
+              ng-if="form_attributes[key].type !== 'media' && !isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)&& form_attributes[key].input !== 'tags'"
               key="key"
               value="value"
               attribute="form_attributes[key]"
               type="'standard'">
             </post-value>
+             <div class="listing-item-primary" ng-if="form_attributes[key].input === 'tags'">
+                <h2 class="form-label">{{form_attributes[key].label}}</h2>
+                <p>
+                    <svg class="iconic" style="margin-right:4px;">
+                        <use xlink:href="/img/iconic-sprite.svg#tag"></use>
+                    </svg>
+                    {{formatTags(post.values[key])}}
+                </p>
+            </div>
+
           </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Displaying name instead of Id to categories in tasks

Testing checklist:
- [ ] Add a post to a survey with categories in a task and save the post. The categories selected should be displayed as names, not as ids when looking at the saved post.

Fixes ushahidi/platform#2022 .

Ping @ushahidi/platform