### PR TITLE
1630: add warning when deleting fields/surveys

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1085,11 +1085,12 @@
             "edit_form_success" : "Survey {{name}} updated",
             "edit_stage_success" : "Survey task {{name}} updated",
             "delete_form_confirm" : "Are you sure you want to delete this survey?",
+            "delete_form_confirm_desc" : "This action cannot be undone. Deleting this survey will remove all of its data, including posts.",
             "destroy_form_success" : "Survey {{name}} deleted",
             "delete_stage_confirm" : "Are you sure you want to delete this task?",
             "destroy_stage_success" : "Survey task {{name}} deleted",
             "delete_attribute_confirm" : "Are you sure you want to delete this field?",
-            "delete_attribute_confirm_desc" : "Deleting this field will remove its data from all existing posts. Please proceed with caution.",
+            "delete_attribute_confirm_desc" : "This action cannot be undone. Deleting this field will remove its data from all existing posts.",
             "destroy_attribute_success" : "Field {{name}} deleted"
         },
         "collection" : {

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1088,6 +1088,7 @@
             "delete_form_confirm_desc" : "This action cannot be undone. Deleting this survey will remove all of its data, including posts.",
             "destroy_form_success" : "Survey {{name}} deleted",
             "delete_stage_confirm" : "Are you sure you want to delete this task?",
+            "delete_stage_confirm_desc" : "This action cannot be undone. Deleting this task will remove all of its fields, and any data in them.",
             "destroy_stage_success" : "Survey task {{name}} deleted",
             "delete_attribute_confirm" : "Are you sure you want to delete this field?",
             "delete_attribute_confirm_desc" : "This action cannot be undone. Deleting this field will remove its data from all existing posts.",

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -525,7 +525,7 @@ function SurveyEditorController(
 
     function deleteTask(task) {
 
-        Notify.confirmDelete('notify.form.delete_stage_confirm').then(function () {
+        Notify.confirmDelete('notify.form.delete_stage_confirm', 'notify.form.delete_stage_confirm_desc').then(function () {
             // If we haven't saved the task yet then we can just drop it
             if (!task.id || _.isString(task.id)) {
                 $scope.survey.tasks = _.filter($scope.survey.tasks, function (item) {

--- a/app/settings/surveys/surveys.controller.js
+++ b/app/settings/surveys/surveys.controller.js
@@ -42,8 +42,7 @@ function (
     };
 
     $scope.deleteSurvey = function (survey) {
-        Notify.confirmDelete('notify.form.delete_form_confirm').then(function () {
-
+        Notify.confirmDelete('notify.form.delete_form_confirm', 'notify.form.delete_form_confirm_desc').then(function () {
             // If we haven't saved the survey
             // just go back to the surveys views
             if (!survey.id) {


### PR DESCRIPTION
1630: add warning that deleting a survey or a survey field will result in major data loss
See https://github.com/ushahidi/platform/issues/1630
This pull request makes the following changes:
- Text changes in en.json for the alerts. Added a new key in en.js for the survey alert description.
- Called Notify.confirmDelete with a description instead of keeping the default value

TODO
- [x] Add task deletion warning: "This action cannot be undone. Deleting this task will remove all of its fields, and any data on them"

Testing checklist:
### To see the survey alert:
- [x] go to the survey list at {host}/settings/surveys and try to delete a survey.
    - [x] The alert should show "This action cannot be undone. Deleting this survey will remove all of its data, including posts" in the description
    - [x] The alert title should remain as it was ("Are you sure you want to delete this survey?")

- [x] inside the survey editor, attempt to delete a field
    - [x] The alert should show "This action cannot be undone. Deleting this field will remove its data from all existing posts"
    - [x] The alert title should remain as it was ("Are you sure you want to delete this field?")
 

Fixes ushahidi/platform#1630 .

Ping @ushahidi/platform