### PR TITLE
[WIP] 1677: Added a 'disable caption' option

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -199,6 +199,7 @@
         "title" : "Title",
         "field_allowed_relation_survey": "Allowed surveys",
         "disable_caption_field": "Disable caption field",
+        "disable_caption_field_explanation": "This will disable all captions for this field, but it won't delete them from the database. You will be able to re-enable them later.",
         "description" : "Description",
         "task_description" : "Task description",
         "post_fields" : "Post fields",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -198,6 +198,7 @@
         "add_task" : "Add Task",
         "title" : "Title",
         "field_allowed_relation_survey": "Allowed surveys",
+        "disable_caption_field": "Disable caption field",
         "description" : "Description",
         "task_description" : "Task description",
         "post_fields" : "Post fields",

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -51,6 +51,7 @@
 
           <post-media-value
             ng-if="form_attributes[key].type === 'media'"
+            media-caption-disabled="form_attributes[key].config.captionDisabled"
             label="{{form_attributes[key].label}}"
             media-id="value"></post-media-value>
         </div>

--- a/app/main/posts/detail/post-media-value.directive.js
+++ b/app/main/posts/detail/post-media-value.directive.js
@@ -4,7 +4,8 @@ module.exports = ['MediaEndpoint', '_', function (MediaEndpoint, _) {
         replace: true,
         scope: {
             mediaId: '=',
-            label: '@'
+            label: '@',
+            mediaCaptionDisabled: '='
         },
         template: require('./post-media-value.html'),
         link: function ($scope) {

--- a/app/main/posts/detail/post-media-value.html
+++ b/app/main/posts/detail/post-media-value.html
@@ -4,5 +4,5 @@
   </h2>
 
   <img ng-src="{{ media.original_file_url }}" class="postcard-image">
-  <p class="small"><em>{{ media.caption }}</em></p>
+  <p class="small" ng-if="!mediaCaptionDisabled"><em>{{ media.caption }}</em></p>
 </div>

--- a/app/main/posts/modify/media.html
+++ b/app/main/posts/modify/media.html
@@ -32,8 +32,7 @@
             </label>
         </div>
       </figure>
-  
-      <div>
+      <div ng-hide="mediaCaptionDisabled">
         <figure>
           <p class="small" translate>post.media.add_caption</p>
           <input

--- a/app/main/posts/modify/post-edit.controller.js
+++ b/app/main/posts/modify/post-edit.controller.js
@@ -26,7 +26,6 @@ function (
         if (post.allowed_privileges.indexOf('update') === -1) {
             $location.url('/posts/' + post.id);
         }
-
         // Make post tags numeric
         post.tags = post.tags.map(function (tag) {
             return parseInt(tag.id);

--- a/app/main/posts/modify/post-media.directive.js
+++ b/app/main/posts/modify/post-media.directive.js
@@ -20,11 +20,11 @@ function (
         scope: {
             mediaId: '=',
             media: '=',
-            name: '@'
+            name: '@',
+            mediaCaptionDisabled: '='
         },
         template: require('./media.html'),
         link: function ($scope, element, attr, formCtrl) {
-
             if ($scope.mediaId) {
                 MediaEndpoint.get({id: $scope.mediaId}).$promise.then(function (media) {
                     $scope.media = media;

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -134,6 +134,7 @@
               <post-media
                   ng-switch-when="upload"
                   name="values_{{attribute.id}}"
+                  media-caption-disabled="attribute.config.captionDisabled"
                   media-id="post.values[attribute.key][key]"
                   media="medias[attribute.key]"
                   ng-model="post.values[attribute.key][key]"

--- a/app/main/posts/views/post-preview-media.directive.js
+++ b/app/main/posts/views/post-preview-media.directive.js
@@ -15,7 +15,6 @@ function (
         },
         template: require('./post-preview-media.html'),
         link: function ($scope) {
-
             if (!$scope.post.form) {
                 return;
             }
@@ -27,12 +26,12 @@ function (
                     var mediaAttribute = _.find(attributes, function (attribute) {
                         return attribute.type === 'media';
                     });
-
                     // Get the media url and caption
                     if (mediaAttribute && !_.isUndefined($scope.post.values[mediaAttribute.key])) {
                         MediaEndpoint.get({id: $scope.post.values[mediaAttribute.key]}).$promise
                             .then(function (media) {
                                 $scope.media = media;
+                                $scope.mediaCaptionDisabled = mediaAttribute.config.captionDisabled;
                             });
                     }
                 });

--- a/app/main/posts/views/post-preview-media.html
+++ b/app/main/posts/views/post-preview-media.html
@@ -1,4 +1,5 @@
 <div class="postcard-field" ng-show="media">
-	<img ng-src="{{ media.original_file_url }}" alt="{{ media.caption }}" class="postcard-image">
+	<img ng-if="!mediaCaptionDisabled" ng-src="{{ media.original_file_url }}" alt="{{ media.caption }}" class="postcard-image">
+	<img ng-if="mediaCaptionDisabled" ng-src="{{ media.original_file_url }}" class="postcard-image">
 </div>
 

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -11,6 +11,12 @@ function (
         restrict: 'E',
         template: require('./attribute-editor.html'),
         link: function ($scope, $element, $attrs) {
+            /**
+             * FIXME: this is a hacky solution to replace the empty config array for an object literal.
+             * - What should happen is that we get an empty object literal, or NULL, directly from the backend.
+             * - What really happens is that we get an array, add a key on it, and then it cannot be stringified correctly, which prevents the information from getting to the backend.
+             */
+            $scope.editAttribute.config = (!$scope.editAttribute.config || (_.isArray($scope.editAttribute.config) && $scope.editAttribute.config.length === 0)) ? {} : $scope.editAttribute.config;
             $scope.defaultValueToggle = false;
             $scope.descriptionToggle = false;
             $scope.editName = function () {
@@ -37,6 +43,10 @@ function (
 
             $scope.canMakePrivate = function () {
                 return $scope.editAttribute.type !== 'tags';
+            };
+
+            $scope.canDisableCaption = function () {
+                return $scope.editAttribute.type === 'media' && $scope.editAttribute.input === 'upload';
             };
         }
     };

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -82,6 +82,12 @@
        <!-- start: media upload toggle to make caption an optional field-->
        <div class="form-field switch" ng-show="canDisableCaption()">
          <label translate="survey.disable_caption_field">Disable caption field</label>
+         <p data-fieldgroup-target="field-caption-disabled-warning" class="init active" translate="survey.disable_caption_field_explanation" ng-show="editAttribute.config.captionDisabled">
+           <svg class="iconic">
+               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
+           </svg>
+           This will disable all captions for this field, but it won't delete them from the database. You will be able to re-enable them later.
+         </p>
          <div class="toggle-switch">
            <input class="tgl" id="switch-captiondisabled" type="checkbox" ng-model="editAttribute.config.captionDisabled">
            <label class="tgl-btn" for="switch-captiondisabled"></label>

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -79,6 +79,15 @@
              <label class="tgl-btn" for="switchnewattribute"></label>
           </div>
        </div>
+       <!-- start: media upload toggle to make caption an optional field-->
+       <div class="form-field switch" ng-show="canDisableCaption()">
+         <label translate="survey.disable_caption_field">Disable caption field</label>
+         <div class="toggle-switch">
+           <input class="tgl" id="switch-captiondisabled" type="checkbox" ng-model="editAttribute.config.captionDisabled">
+           <label class="tgl-btn" for="switch-captiondisabled"></label>
+         </div>
+       </div>
+       <!-- end: media upload toggle to make caption an optional field-->
        <div class="form-field switch" ng-show="canMakePrivate()">
           <label translate="survey.make_response_private">Make responses private</label>
           <p data-fieldgroup-target="field-private-message-3" class="init active" translate="survey.response_private_desc" ng-show="editAttribute.response_private">


### PR DESCRIPTION
issue https://github.com/ushahidi/platform/issues/1677 
### This PR makes it possible to not have the caption field in the post creation form. 
![screen shot 2017-09-01 at 6 18 11 pm](https://user-images.githubusercontent.com/2434401/29988120-fdbd7768-8f41-11e7-888a-9758757fede5.png)

### This pull request makes the following changes:
- Added a 'disable caption' option in the UI so that admins can choose to have/not have captions in their media.
- Added captionDisabled field in config array to toggle on/off the input for media caption field
- UI/DATA:  hides captions when the user disables the caption field. (Jess's feedback) . 

### TODO tasks
* [x] more testing instructions should be added.
* [ ] check tests for this part of the app, if any. => Note : I don't think the e2e suite is running. I will discuss the implementation with Robbie today and decide on tests. Probably some unit tests for the captionDisabled field feature would be the best way to go.
* [ ] go through notes, get help or feedback => I will wait on Robbie's feedback before I move any further 
* [x] UI: add a note for users telling them that they can re-enable the captions at any time by turning them back on. (Jess's feedback) . 
* [x] UI/DATA:  hide captions when the user disables the caption field. (Jess's feedback) . 


### Notes
* Should I rename the captionDisabled field to "captionEnabled" ? It always feels a bit weird to have a name like `fieldnameDisabled`, but I don't know what the best way to go would be here. Is captionEnabled even an improvement as a name for this config option?  
     * * IMPORTANT:* If we go for captionEnabled we will have to migrate and by default set it up as true, otherwise it would break existing deployments. That should be a very simple migration but I'm noting it here so I don't forget. 

* About the `FIXME` note inside the file attribute-editor.directive.js , line 15: I tried some ideas to solve this from the backend to ensure the data was consistent and not need this line, but the backend seems to be forcing any empty values for that field into an empty array because of the *json flag in the getDefinition and the 'backendoptionJsonAlwaysArray' option on the  `transformJson` method of the data transformer. Do we have some way to make sure the backend transformer creates an object literal instead of an array in that field? 

### Testing checklist:

- [ ] When I add an image field to a survey, I have the option to disable its **caption** . 
    -    Add an image field 
    -    Use the toggle UI to disable the caption for that image field.
    -    Save the field
    -    save the survey 
    -    try to add a post for that survey type.
          -  [ ] you will see an image field with no caption field. 
- [ ] When I **edit** a survey's image field and disable its caption, I can no longer add a caption for that field when I add new posts.
    -   Edit a survey, and edit a pre-existing image field.
    -   Use the toggle UI to disable the image field caption
    -    Save the field
    -    save the survey 
    -  [ ]   try to add a post for that survey type.
          - [ ]  you will see an image field with no caption. 

- [ ] When I disable an image's caption and there's already data for it, I stop seeing the caption in pre-existing posts.
    -    Edit a survey, and edit a pre-existing image field.  That field should have data already preloaded for the images and the images' captions.
    -    Use the toggle UI to **disable** the caption field.
    -    Save the field.
    -    Save the survey 
    -    Select a post (from the same survey) that has an image _with a caption_, on the field you just disabled the caption for.
          - [ ] you will see an image but not a caption

- [ ] After disabling an image's caption for image fields with pre-existing data, I can decide to re-enable the caption field and see the caption data again.
    -    Edit a survey, and edit a pre-existing image field where the caption was disabled. That field should have data already preloaded for the images and the images' captions.
    -    Use the toggle UI to **enable** the caption field.
    -    Save the field.
    -    Save the survey 
    -    Select a post (from the same survey) that has an image _with a caption_, on the field you just disabled the caption for.
          - [ ] you will see an image AND the caption that the image had before it was disabled.
          
Fixes ushahidi/platform#1677 .

Ping @ushahidi/platform