### PR TITLE
Hotfix 1714 user profile

### DIFF
--- a/app/common/user-profile/user-profile.directive.js
+++ b/app/common/user-profile/user-profile.directive.js
@@ -1,11 +1,13 @@
 module.exports = [
     'UserEndpoint',
     'Notify',
+    'Session',
     '_',
     '$translate',
     function (
         UserEndpoint,
         Notify,
+        Session,
         _,
         $translate
     ) {
@@ -39,6 +41,7 @@ module.exports = [
 
                     update.$promise.then(function (user) {
                         Notify.notify('user_profile.update_success');
+                        Session.setSessionDataEntries({'email': user.email, 'realname': user.realname});
 
                         $scope.state.success = true;
                         $scope.state.processing = false;
@@ -48,7 +51,6 @@ module.exports = [
                         $scope.state.password = '';
 
                         $scope.user = user;
-
                         $scope.$emit('event:close');
                     }, function (errorResponse) { // error
                         Notify.apiErrors(errorResponse);

--- a/test/unit/common/user-profile/directives/user-profile-directive-spec.js
+++ b/test/unit/common/user-profile/directives/user-profile-directive-spec.js
@@ -6,6 +6,7 @@ describe('user profile directive', function () {
         $compile,
         UserEndpoint,
         Notify,
+        Session,
         element;
 
     beforeEach(function () {
@@ -20,13 +21,13 @@ describe('user profile directive', function () {
 
 
 
-    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _UserEndpoint_, _Notify_) {
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _UserEndpoint_, _Notify_, _Session_) {
         $rootScope = _$rootScope_;
         $compile = _$compile_;
         UserEndpoint = _UserEndpoint_;
         Notify = _Notify_;
+        Session = _Session_ ;
         $scope = _$rootScope_.$new();
-
         element = '<user-profile><user-profile>';
         element = $compile(element)($scope);
         $rootScope.$digest();

--- a/test/unit/mock/services/session.js
+++ b/test/unit/mock/services/session.js
@@ -12,6 +12,9 @@ module.exports = [function () {
         },
         setSessionDataEntry: function (key, value) {
             mockedSessionData[key] = value;
+        },
+        setSessionDataEntries: function (entries) {
+            mockedSessionData = angular.extend({}, mockedSessionData, entries);
         }
     };
 }];


### PR DESCRIPTION
This pull request makes the following changes:
- adds setSessionDataEntries mock
- add email and realname to Session (ls.email , ls.realname) on update function

Testing checklist:
- [x] Update a user in the user settings. Change email and save
    - [x] Check that the localStorage has saved the new email

- [x] Update a user in the user settings. Change realname and save
    - [x] Check that the localStorage has saved the new realname

Fixes ushahidi/platform#1714 .

Ping @ushahidi/platform