### PR TITLE
1816 rtl css switch [Do not merge]

### DIFF
--- a/app/common/services/translation.service.js
+++ b/app/common/services/translation.service.js
@@ -28,7 +28,17 @@ function (
                 Languages.then(function (languages) {
                     let language = languages.find(l => l.code === langKey);
 
-                    $rootScope.rtlEnabled = language.rtl;
+                    if ($rootScope.rtlEnabled !== language.rtl) {
+                        if (language.rtl) {
+                            require.ensure(['ushahidi-platform-pattern-library/assets/css/rtl-style.min.css'], () => {
+                                require('ushahidi-platform-pattern-library/assets/css/rtl-style.min.css');
+                                $rootScope.rtlEnabled = language.rtl;
+
+                            }, 'rtl');
+                        } else {
+                            $rootScope.rtlEnabled = language.rtl;
+                        }
+                    }
                 });
             }
         });

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
     </head>
 
     <!-- TODO: set layouts per view directive -->
-    <body ng-class="{ rtl : rtlEnabled, 'modal-visible': modalVisible }" class="{{ globalLayout }}" canvas>
+    <body ng-class="{ 'rtl-namespace' : rtlEnabled, 'ltr-namespace' : !rtlEnabled, 'modal-visible': modalVisible }" class="{{ globalLayout }}" canvas>
         <div id="bootstrap-loading">
             <!-- loading the document -->
             <div class="loading">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,8 @@
 var path    = require('path');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 var imgPath = path.resolve('node_modules/ushahidi-platform-pattern-library/assets/');
-
-var extractCss = new ExtractTextPlugin('[name].[chunkhash].bundle.css');
 
 module.exports = {
   devtool: 'source-map',
@@ -14,8 +11,8 @@ module.exports = {
     loaders: [
        { test: /\.js$/, exclude: [/app\/lib/, /node_modules/], loader: 'ng-annotate!babel' },
        { test: /\.html$/, loader: 'html?attrs[]=img:src&attrs[]=use:xlink:href&attrs[]=link:href&root='+imgPath },
-       { test: /\.scss$/, loader: extractCss.extract('style', 'css!resolve-url!sass?sourceMap') },
-       { test: /\.css$/, loader: extractCss.extract('style', 'css') },
+       { test: /\.scss$/, loader: 'style-loader!css-loader!resolve-url-loader!sass-loader?sourceMap' },
+       { test: /\.css$/, loader: 'style-loader!css-loader' },
        { test: /\.png/, loader: 'url?limit=10000' },
        { test: /\.svg/, loader: 'svg-url?limit=1' },
        { test: /\.woff/, loader: 'url?limit=10000' },
@@ -25,8 +22,6 @@ module.exports = {
     ]
   },
   plugins: [
-    extractCss,
-
     // Skip locales
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
 


### PR DESCRIPTION
This pull request makes the following changes:
- Make RTL switching work by using namespaces CSS
- Disable ExtractText Plugin for CSS, means JS is bundled with CSS
- Clean up language switcher code
- Relies on https://github.com/ushahidi/platform-pattern-library/pull/146

Testing checklist:
- [ ]

Fixes ushahidi/platform#1816

Ping @ushahidi/platform
