### PR TITLE
ushahidi/platform#2050 propagate dictionary with media items to task …

### DIFF
--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -139,6 +139,7 @@
              post="post"
              stages="tasks"
              attributes="attributes"
+             medias="medias"
              visible-stage="visibleStage">
           </post-tabs>
           <!-- <div class="form-sheet">

--- a/app/main/posts/modify/post-tabs.directive.js
+++ b/app/main/posts/modify/post-tabs.directive.js
@@ -9,7 +9,8 @@ function PostVerticalTabs() {
             post: '=',
             stages: '=',
             attributes: '=',
-            visibleStage: '='
+            visibleStage: '=',
+            medias: '='
         },
         template: require('./post-tabs.html'),
         controller: PostVerticalTabsController

--- a/app/main/posts/modify/post-tabs.html
+++ b/app/main/posts/modify/post-tabs.html
@@ -23,6 +23,7 @@
             ng-repeat="attribute in stage.attributes | orderBy: 'priority' as filtered_result track by attribute.id"
             post="post"
             form="form"
+            medias="medias"
             attribute="attribute"
     ></post-value-edit>
 </div>


### PR DESCRIPTION
…UI containers

This pull request makes the following changes:
- The medias scope object wasn't being propagated to the task containers

Testing checklist:
- Create survey with an additional task containing a media field
- Create post populating media field and submit

Fixes ushahidi/platform#2050 ushahidi/platform#2006 .

Ping @ushahidi/platform
