### PR TITLE
2044: users should be able to export all posts, not only published posts

### DIFF
--- a/app/main/posts/views/share/post-export.directive.js
+++ b/app/main/posts/views/share/post-export.directive.js
@@ -19,7 +19,8 @@ PostExportController.$inject = [
     'ConfigEndpoint',
     'Notify',
     '$q',
-    'PostFilters'
+    'PostFilters',
+    'PostActionsService'
 ];
 function PostExportController(
     $scope,
@@ -28,7 +29,8 @@ function PostExportController(
     ConfigEndpoint,
     Notify,
     $q,
-    PostFilters
+    PostFilters,
+    PostActionsService
 ) {
     $scope.loading = false;
     $scope.exportPosts = exportPosts;
@@ -39,6 +41,11 @@ function PostExportController(
 
             if (!$scope.filters) {
                 $scope.filters = [];
+                /**
+                 * If the user has not applied filters we can assume they will want to see all posts
+                 * The backend will filter out posts that do not match the user permissions.
+                 */
+                $scope.filters.status = PostActionsService.getStatuses();
             }
 
             var format = 'csv',  //@todo handle more formats


### PR DESCRIPTION
This pull request makes the following changes:
- Add all statuses by default when users export posts

Testing checklist:
- [ ] As an administrator or other user with privileges:
     - [ ] Click on Share to open the share toolbar
     - [ ] Click on Export to CSV, confirm. 
     - [ ] When the CSV is downloaded, you should see all posts, not only the published posts 

- [ ] As a non logged in user
     - [ ] Click on Share to open the share toolbar
     - [ ] Click on Export to CSV, confirm. 
     - [ ] When the CSV is downloaded, you should see ONLY published posts included in the CSV

Fixes ushahidi/platform#2044 .

Ping @ushahidi/platform
