### PR TITLE
toggling between noui and ui on embedded map

### DIFF
--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -23,7 +23,7 @@ function (
         controller: require('./views/post-views.controller.js'),
         template: require('./views/main.html')
     })
-    .when('/noui', {
+    .when('/map/noui', {
         controller: require('./views/post-view-noui.controller.js'),
         template: require('./views/post-view-noui.html')
     })

--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -23,6 +23,10 @@ function (
         controller: require('./views/post-views.controller.js'),
         template: require('./views/main.html')
     })
+    .when('/noui', {
+        controller: require('./views/post-view-noui.controller.js'),
+        template: require('./views/post-view-noui.html')
+    })
     .when('/collections/:id/:view?', {
         controller: require('./collections/collections-controller.js'),
         template: require('./collections/collections.html'),

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -1,7 +1,7 @@
 module.exports = PostViewMap;
 
-PostViewMap.$inject = ['PostEndpoint', 'Maps', '_', 'PostFilters', 'Leaflet', '$q', '$rootScope', '$compile', '$routeParams'];
-function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $compile, $routeParams) {
+PostViewMap.$inject = ['PostEndpoint', 'Maps', '_', 'PostFilters', 'Leaflet', '$q', '$rootScope', '$compile', '$location'];
+function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $compile, $location) {
     return {
         restrict: 'E',
         replace: true,
@@ -58,7 +58,8 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
         }
         function getUIClass() {
-            return $routeParams.noui === 'true' ? 'map-only' : 'full-size';
+            var params = $location.search();
+            return params.noui === 'true' ? 'map-only' : 'full-size';
         }
 
         function addPostsToMap(posts) {

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -58,8 +58,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
         }
         function getUIClass() {
-            var params = $location.search();
-            return params.noui === 'true' ? 'map-only' : 'full-size';
+            return $location.path() === '/noui' ? 'map-only' : 'full-size';
         }
 
         function addPostsToMap(posts) {

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -1,7 +1,7 @@
 module.exports = PostViewMap;
 
-PostViewMap.$inject = ['PostEndpoint', 'Maps', '_', 'PostFilters', 'Leaflet', '$q', '$rootScope', '$compile'];
-function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $compile) {
+PostViewMap.$inject = ['PostEndpoint', 'Maps', '_', 'PostFilters', 'Leaflet', '$q', '$rootScope', '$compile', '$routeParams'];
+function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $compile, $routeParams) {
     return {
         restrict: 'E',
         replace: true,
@@ -19,6 +19,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
         var limit = 200;
         var requestBlockSize = 5;
         var numberOfChunks = 0;
+        $scope.getUIClass = getUIClass;
 
         activate();
 
@@ -55,6 +56,9 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 map.removeLayer(markers);
                 markers = undefined;
             }
+        }
+        function getUIClass() {
+            return $routeParams.noui === 'true' ? 'map-only' : 'full-size';
         }
 
         function addPostsToMap(posts) {

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -58,7 +58,6 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
         }
         function getUIClass() {
-            console.log($location.path())
             return $location.path() === '/map/noui' ? 'map-only' : 'full-size';
         }
 

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -58,7 +58,8 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
         }
         function getUIClass() {
-            return $location.path() === '/noui' ? 'map-only' : 'full-size';
+            console.log($location.path())
+            return $location.path() === '/map/noui' ? 'map-only' : 'full-size';
         }
 
         function addPostsToMap(posts) {

--- a/app/main/posts/views/post-view-map.html
+++ b/app/main/posts/views/post-view-map.html
@@ -1,3 +1,3 @@
 <div class="map-view">
-	<div id="map" class="map full-size" ></div>
+    <div id="map" class="map" ng-class="getUIClass()" ></div>
 </div>

--- a/app/main/posts/views/post-view-noui.controller.js
+++ b/app/main/posts/views/post-view-noui.controller.js
@@ -1,7 +1,8 @@
 module.exports = PostViewNouiController;
 
-PostViewNouiController.$inject = ['$scope', '$translate', '$routeParams', 'PostFilters'];
-function PostViewNouiController($scope, $translate, $routeParams, PostFilters) {
+PostViewNouiController.$inject = ['$scope', '$rootScope', '$translate', '$routeParams', 'PostFilters'];
+function PostViewNouiController($scope, $rootScope, $translate, $routeParams, PostFilters) {
+    $rootScope.setLayout('layout-embed');
     $scope.filters = PostFilters.getFilters();
     $scope.$emit('event:allposts:show');
 }

--- a/app/main/posts/views/post-view-noui.controller.js
+++ b/app/main/posts/views/post-view-noui.controller.js
@@ -1,0 +1,7 @@
+module.exports = PostViewNouiController;
+
+PostViewNouiController.$inject = ['$scope', '$translate', '$routeParams', 'PostFilters'];
+function PostViewNouiController($scope, $translate, $routeParams, PostFilters) {
+    $scope.filters = PostFilters.getFilters();
+    $scope.$emit('event:allposts:show');
+}

--- a/app/main/posts/views/post-view-noui.html
+++ b/app/main/posts/views/post-view-noui.html
@@ -1,0 +1,4 @@
+<main role="main">
+    <post-view-map filters="filters" is-loading="{state:true}"></post-view-map>
+    <ush-logo></ush-logo>
+</main>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.1-rc.22"
+    "ushahidi-platform-pattern-library": "3.7.1-rc.24"
   },
   "engines": {
     "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.1-rc.20"
+    "ushahidi-platform-pattern-library": "3.7.1-rc.22"
   },
   "engines": {
     "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.1-rc.24"
+    "ushahidi-platform-pattern-library": "3.7.1-rc.26"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- adds a specific route for embedded map with no ui
- makes map-view directive toggle between classes `map-only` and `full-size` depending on path

Testing checklist:
- [ ] go to /map/noui
- [ ] a map without ui-elements should be visible
- [ ] try embed the map with the route /noui (you can test it here: http://jsfiddle.net/angamanga/Lqe6as41/), only the map without ui-elements should be visible

Fixes ushahidi/platform# .

Ping @ushahidi/platform