### PR TITLE
Adding a missing entry in en.json

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -221,6 +221,7 @@
         "video_desc" : "Allows Youtube or Vimeo videos to be embed in the post",
         "markdown_desc" : "Allows the use of markdown syntax to style the field content.",
         "tasks" : "Tasks",
+        "task_visible_when_published" : "This task will be visible when post is published.",
         "show_field_description" : "Show field description",
         "add_task" : "Add task",
         "add_field" : "Add field",


### PR DESCRIPTION
This pull request makes the following changes, and supersedes a previous PR made from a forked repo:
- Adds a translation entry in locales/en.json that was somehow missing.

Testing checklist:
- [ ] Does this string correctly appear now on a post with tasks?
- [ ] Do adjacent strings in en.json still appear?

Fixes ushahidi/platform#2041.
Fixes ushahidi/platform#2049.
Fixes ushahidi/platform#2034.

Ping @ushahidi/platform
