### PR TITLE
[WIP] propagating locale change to post-metadata directives

### DIFF
--- a/app/common/directives/language-switch.directive.js
+++ b/app/common/directives/language-switch.directive.js
@@ -12,8 +12,8 @@ function LanguageSwitchDirective() {
         template: require('./language-switch.html')
     };
 }
-LanguageSwitchController.$inject = ['$scope', 'Languages', 'TranslationService'];
-function LanguageSwitchController($scope, Languages, TranslationService) {
+LanguageSwitchController.$inject = ['$scope', 'Languages', 'TranslationService', 'moment'];
+function LanguageSwitchController($scope, Languages, TranslationService, moment) {
     $scope.changeLanguage = changeLanguage;
     $scope.$on('event:authentication:login:succeeded', TranslationService.setStartLanguage);
     $scope.$on('event:authentication:logout:succeeded', TranslationService.setStartLanguage);
@@ -26,8 +26,12 @@ function LanguageSwitchController($scope, Languages, TranslationService) {
     }
 
     function changeLanguage(code) {
+        console.log('Changing language to: ' + code);
+        require(['moment/locale/' + code + '.js'], function () {
+            moment.updateLocale(code);
+            console.log('found: moment/locale/' + code + '.js');
+        });
         TranslationService.setLanguage(code);
         TranslationService.translate(code);
     }
 }
-

--- a/app/common/global/language-settings.js
+++ b/app/common/global/language-settings.js
@@ -3,6 +3,7 @@ module.exports = [
     '$rootScope',
     '$translate',
     'TranslationService',
+    'ConfigEndpoint', //this was missing
     'Languages',
     'moment',
 function (
@@ -26,10 +27,8 @@ function (
 
     function translate(language) {
         TranslationService.translate(language);
-        if (language !== 'en') {
-            require(['moment/locale/' + language + '.js'], function () {
-                moment.locale(language);
+        require(['moment/locale/' + language + '.js'], function () {
+                moment.updateLocale(language);
             });
-        }
     }
 }];

--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -15,6 +15,7 @@ function PostListDirective() {
 }
 
 PostListController.$inject = [
+    '$rootScope',
     '$scope',
     '$q',
     '$translate',
@@ -28,6 +29,7 @@ PostListController.$inject = [
     'PostActionsService'
 ];
 function PostListController(
+    $rootScope,
     $scope,
     $q,
     $translate,
@@ -64,6 +66,16 @@ function PostListController(
     $scope.changeOrder = changeOrder;
     activate();
 
+
+    // whenever the translation changes, reload...everything?
+    //  not sure we want to include rootScope here, but angular-translate seems to
+    //  indicate this is the var to watch, and that it's only on rootScope
+    $rootScope.$on('$translateChangeSuccess', function () {
+            console.log('From postList -- translation event was caught!  current locale is: ', moment.locale());
+            getPosts();
+        });
+
+
     // whenever the filters changes, update the current list of posts
     $scope.$watch(function () {
         return $scope.filters;
@@ -73,6 +85,7 @@ function PostListController(
             getPosts();
         }
     }, true);
+
 
 
     function activate() {


### PR DESCRIPTION
This PR is mainly for discussion with @willdoran, but it makes the following changes:
-  fixes a small issue with dependencies on language-settings
- makes a (possibly hacky) fix for updating a directive on language change 
- explicitly updates moment's locale when the language is changed

(adds some logs to console, to be removed )

This does *not* fix an issue where moment.js's translation files aren't matching up with Transifex's language code names.

Related to ushahidi/platform#2065.