### PR TITLE
Use a cached location if available ushahidi/platform#2087

### DIFF
--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -56,7 +56,9 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 if (window.location.protocol === 'https:' || window.location.hostname === 'localhost') {
                     $scope.showCurrentPositionControl = true;
                     currentPositionControl = L.control.locate({
-                        follow: true
+                        locateOptions: {
+                            maximumAge: 60000 // 1 minute
+                        }
                     }).addTo(map);
                 }
                 // @todo: Should we watch the model and update map?

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "checklist-model": "~0.10.0",
     "d3": "^3.5.17",
     "leaflet": "~1.0.1",
-    "leaflet.locatecontrol": "^0.56.0",
+    "leaflet.locatecontrol": "^0.62.0",
     "leaflet.markercluster": "1.0.0",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",


### PR DESCRIPTION
- Use a cached location if available
- Update leaflet.locate control too

Testing checklist:
- Load / reload the site (from the map or timeline view)
- Click on the + sign to add a post to a form that has a location field
- Click the "Use your current location" button that appears when clicking on the location search bar. The location is detected and displayed in the map.
- Go back to the map view by clicking on its icon in the left sidebar
- Click on the + sign to add a post again (to the same form)
- Click the "Use your current location" button again

Fixes ushahidi/platform#2087

Ping @ushahidi/platform
