### PR TITLE
Rolling back d3 to 3.x 

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "angular-translate-loader-static-files": "^2.11.0",
     "angular-ui-bootstrap": "^2.5.0",
     "checklist-model": "~0.11.0",
-    "d3": "^4.8.0",
+    "d3": "^3.5.17",
     "leaflet": "~1.0.1",
     "leaflet.locatecontrol": "^0.62.0",
     "leaflet.markercluster": "1.0.5",


### PR DESCRIPTION
We can't upgrade to D3 4.x until nvd3 and nvd3-angular upgrade.

This pull request makes the following changes:
- D3 goes back to d3 3.x branch

Testing checklist:
- [ ] Open the console and login. 
-    You should not see an error that says `undefined is not an object (evaluating ‘s.scale.category20’)` 

Fixes ushahidi/platform# .

Ping @ushahidi/platform