### PR TITLE
Datasource buckets qa fixes

### DIFF
--- a/app/main/posts/views/filter-by-datasource.directive.js
+++ b/app/main/posts/views/filter-by-datasource.directive.js
@@ -14,8 +14,8 @@ function FilterByDatasourceDirective() {
     };
 }
 
-FilterByDatasourceController.$inject = ['$scope', '$rootScope', 'ConfigEndpoint', '_'];
-function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _) {
+FilterByDatasourceController.$inject = ['$scope', '$rootScope', 'ConfigEndpoint', '_', '$location'];
+function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $location) {
     $scope.dataSources = [];
     $scope.providers = [];
     $scope.formatHeading = formatHeading;
@@ -119,6 +119,7 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _) {
     function showOnlyIncoming(source) {
         $scope.filters.form = ['none'];
         $scope.filters.source = [source.toLowerCase()];
+        $location.path('/views/list');
     }
 
     function featureEnabled() {

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -95,6 +95,10 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
         if (queryParams.tags) {
             delete queryParams.tags;
         }
+        // deleting source, we want stats for all datasources to keep the datasource-bucket-stats unaffected by data-source-filters
+        if (queryParams.source) {
+            delete queryParams.source;
+        }
         return PostEndpoint.stats(queryParams);
     }
 
@@ -105,7 +109,11 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
         $scope.unmapped = stats.unmapped ? stats.unmapped : 0;
         // assigning count for all forms
         _.each($scope.forms, function (form) {
-            let posts = _.filter(stats.totals[0].values, { id: form.id });
+            let posts = _.filter(stats.totals[0].values, function (value) {
+                // checking source-type, hack to keep the stats in data-source-buckets the same even if adding a source-filter.
+                return value.id === form.id && _.contains($scope.filters.source, value.type);
+            });
+
             form.post_count = 0;
             // calculating totals
             if (posts) {

--- a/test/unit/main/post/views/filter-by-datasource.spec.js
+++ b/test/unit/main/post/views/filter-by-datasource.spec.js
@@ -4,7 +4,8 @@ describe('filter by datasource directive', function () {
         isolateScope,
         element,
         ConfigEndpoint,
-        hasPermission;
+        hasPermission,
+        $location;
 
     beforeEach(function () {
         var testApp;
@@ -14,10 +15,10 @@ describe('filter by datasource directive', function () {
         angular.mock.module('testApp');
     });
 
-    beforeEach(inject(function (_$rootScope_, $compile, _ConfigEndpoint_, _) {
+    beforeEach(inject(function (_$rootScope_, $compile, _ConfigEndpoint_, _, _$location_) {
         $rootScope = _$rootScope_;
         $scope = _$rootScope_.$new();
-
+        $location = _$location_;
         ConfigEndpoint = _ConfigEndpoint_;
         spyOn(ConfigEndpoint, 'get').and.callThrough();
 
@@ -83,6 +84,11 @@ describe('filter by datasource directive', function () {
             isolateScope.showOnlyIncoming('Email');
             expect(isolateScope.filters.source).toEqual(['email']);
             expect(isolateScope.filters.form).toEqual(['none']);
+        });
+        it('should redirect to timeline-view if choosing posts-without a form', function () {
+            $location.path('/views/map');
+            isolateScope.showOnlyIncoming('SMS');
+            expect($location.path()).toEqual('/views/list');
         });
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Relocate the user to timeline if on map-view when choosing to display only posts without a survey.
- Recalculates the stats to keep the datasource-buckets-stats unaffected by source-filters.

Testing checklist:
- [x] select 'show only' for one of the datasources
- [x] the survey-filter-stats should update to reflect nb of posts from that specific datasource
- [x] the data buckets not selected should be greyed out but still display the nb of posts from that datasource

**as logged in**
- [x] Go to map-view
- [x] Choose 'display only posts without a survey' for one of the datasources
- [x] You should be redirected to timeline


Fixes ushahidi/platform#1646 .

Ping @ushahidi/platform