### PR TITLE
1565  - fix spacing in export modal

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1129,7 +1129,7 @@
             "sent_to" : "Message sent to {{contact}}"
         },
         "export" : {
-            "in_progress" : "<h3>Your CSV export is in progress...</h3>You can navigate away from this window, we'll let you know when your download is complete.</p><br>",
+            "in_progress" : "<h3>Your CSV export is in progress...</h3>You can navigate away from this window, we'll let you know when your download is complete.",
             "complete" : "Your CSV export is complete.",
             "complete_data_found_message" : "The data from your export can be found in your browser's downloads" 
         }

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1129,7 +1129,7 @@
             "sent_to" : "Message sent to {{contact}}"
         },
         "export" : {
-            "in_progress" : "<p><h3>Your CSV export is in progress...</h3>You can navigate away from this window, we'll let you know when your download is complete</p><br>",
+            "in_progress" : "<h3>Your CSV export is in progress...</h3>You can navigate away from this window, we'll let you know when your download is complete.</p><br>",
             "complete" : "Your CSV export is complete.",
             "complete_data_found_message" : "The data from your export can be found in your browser's downloads" 
         }

--- a/app/main/posts/views/share/post-export.directive.js
+++ b/app/main/posts/views/share/post-export.directive.js
@@ -70,7 +70,7 @@ function PostExportController(
             Notify.apiErrors(err);
         } else {
             if (status === true) {
-                Notify.notifyProgress('notify.export.in_progress');
+                Notify.notifyProgress('<p translate="notify.export.in_progress"></p>');
             } else {
                 Notify.notify('<h3 translate="notify.export.complete">Your CSV export is complete.</h3><p translate="notify.export.complete_data_found_message">The data from your export can be found in your browser\'s downloads<p>');
             }


### PR DESCRIPTION
This pull request makes the following changes:
- Corrects a space in the modal for export feedback, which I broke when doing adjustments around 2044/2045/1565

Testing checklist:
- [ ] The modal should look like this; 

<img width="653" alt="screen shot 2017-09-28 at 11 14 58 am" src="https://user-images.githubusercontent.com/2434401/30971627-d353c3bc-a43e-11e7-90d6-fcd50d7d7993.png">
- [ ] The modal should not look like this: 

<img width="560" alt="screen shot 2017-09-28 at 11 19 18 am" src="https://user-images.githubusercontent.com/2434401/30971639-e2441610-a43e-11e7-99e4-c01b8bb603a2.png">


Fixes ushahidi/platform# .

Ping @ushahidi/platform
