### PR TITLE
795 - Uses the class assignment directly to play nice with Leaflet

### DIFF
--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -19,15 +19,15 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
         var limit = 200;
         var requestBlockSize = 5;
         var numberOfChunks = 0;
-        $scope.getUIClass = getUIClass;
+        $scope.getUIClass = $location.path() === '/map/noui' ? 'map-only' : 'full-size';
 
         activate();
 
         function activate() {
             // Start loading data
             var posts = loadPosts();
-            var createMap = Maps.createMap(element[0].querySelector('#map'))
-            .then(function (data) {
+            var createMapDirective =  Maps.createMap(element[0].querySelector('#map'));
+            var createMap = createMapDirective.then(function (data) {
                 map = data;
             });
 
@@ -56,9 +56,6 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 map.removeLayer(markers);
                 markers = undefined;
             }
-        }
-        function getUIClass() {
-            return $location.path() === '/map/noui' ? 'map-only' : 'full-size';
         }
 
         function addPostsToMap(posts) {

--- a/app/main/posts/views/post-view-map.html
+++ b/app/main/posts/views/post-view-map.html
@@ -1,3 +1,3 @@
 <div class="map-view">
-    <div id="map" class="map" ng-class="getUIClass()" ></div>
+    <div id="map" class="map {{getUIClass}}" ></div>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Makes class-assignment for the map-view not conflict with leaflets class-assignments. 

Testing checklist:
- [ ] Go to map-view as not logged in
- [ ] Log in
- [ ] Map should still be visible without reload

Fixes ushahidi/platform#795 .

Ping @ushahidi/platform
