### PR TITLE
2091: Filters remain active when switching between map and data views

### DIFF
--- a/app/main/posts/views/filters/filter-post-order-asc-desc.directive.js
+++ b/app/main/posts/views/filters/filter-post-order-asc-desc.directive.js
@@ -16,7 +16,7 @@ function FilterPostOrderAscDescDirective(moment, $rootScope, _) {
     function FilterPostOrderAscDescLink($scope, $element, $attrs, ngModel) {
         $scope.selectedValue = {
             value: 'desc',
-            labelTranslateKey: 'global_filter.sort.order.filter_type_tag'};
+            labelTranslateKey: 'global_filter.sort.order.desc'};
         $scope.activeOrderOptions = {
             labelTranslateKey: 'global_filter.sort.order.filter_type_tag',
             options: [
@@ -31,7 +31,17 @@ function FilterPostOrderAscDescDirective(moment, $rootScope, _) {
             ]
         };
         //$scope.$watch('activeOrderOptions', saveToView, true);
-        $scope.$watch('selectedValue', saveToViewSelected, true);
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('selectedValue', saveToViewSelected, true);
+        }
+        function renderModelValue() {
+            $scope.selectedValue = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.order.' + ngModel.$viewValue
+            };
+        }
+        activate();
         function saveToViewSelected(orderGroup) {
             ngModel.$setViewValue(angular.copy(orderGroup ? orderGroup.value.toString() : ''), 'radio');
         }

--- a/app/main/posts/views/filters/filter-post-sorting-options.directive.js
+++ b/app/main/posts/views/filters/filter-post-sorting-options.directive.js
@@ -16,7 +16,7 @@ function FilterPostSortingOptionsDirective(moment, $rootScope, _) {
     function PostSortingOptionsLink($scope, $element, $attrs, ngModel) {
         $scope.orderValue = {
             value: 'created',
-            labelTranslateKey: 'global_filter.sort.orderby.filter_type_tag'
+            labelTranslateKey: 'global_filter.sort.orderby.created'
         };
         $scope.orderByOptions = {
             value: 'created',
@@ -36,7 +36,17 @@ function FilterPostSortingOptionsDirective(moment, $rootScope, _) {
                 }
             ]
         };
-        $scope.$watch('orderValue', saveToView, true);
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('orderValue', saveToView, true);
+        }
+        function renderModelValue() {
+            $scope.orderValue = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.orderby.' + ngModel.$viewValue
+            };
+        }
+        activate();
         function saveToView(orderGroup) {
             /** @DEVNOTE  this is not something we should need.
              * We should be consistently getting the same type here. FIX FIX FIX before we merge

--- a/app/main/posts/views/filters/filter-saved-search.directive.js
+++ b/app/main/posts/views/filters/filter-saved-search.directive.js
@@ -12,26 +12,36 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope) {
     };
 
     function FilterSavedSearchLink(scope, element, attrs, ngModel) {
-        scope.selectedSavedSearch = '';
-
+        scope.selectedSavedSearch = null;
         function activate() {
+            ngModel.$render = renderModelValue;
+            if (ngModel.$viewValue.length > 0) {
+                scope.selectedSavedSearch = scope.searches[ngModel.$viewValue];
+            }
             scope.$watch('selectedSavedSearch', saveValueToView, true);
         }
         function saveValueToView(selectedSavedSearch) {
-            ngModel.$setViewValue(selectedSavedSearch ? selectedSavedSearch.toString() : '');
+            ngModel.$setViewValue(selectedSavedSearch && selectedSavedSearch.id ?
+                selectedSavedSearch.id.toString() : ngModel.$viewValue);
         }
 
-        activate();
+        function renderModelValue() {
+            scope.selectedSavedSearch = ngModel.$viewValue;
+            // Update savedSearch w/o breaking references used by selectedSavedSearch model
+        }
 
         // Load searches + users
-        (function loadSavedSearches(query) {
-            query = query || {};
-            SavedSearchEndpoint.query(query).$promise.then(function (searches) {
-                scope.searches = _.filter(searches, function (search) {
+        function loadSavedSearches() {
+            SavedSearchEndpoint.query({}).$promise.then(function (searches) {
+                var searchesTmp = _.filter(searches, function (search) {
                     var isOwner = (search.user && search.user.id === _.result($rootScope.currentUser, 'userId')) === true;
                     return search.featured || isOwner;
                 });
+                scope.searches = _.indexBy(searchesTmp, 'id');
+            }).then(function () {
+                activate();
             });
-        })();
+        }
+        loadSavedSearches();
     }
 }

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -3,11 +3,11 @@
     <div class="custom-select" ng-model-options="{ updateOn: 'default' }">
         <select
                 ng-model="selectedSavedSearch"
-                ng-options="search.id as search.name
-        for
-        search in searches"
+                ng-options="search.name
+                            for
+                            search in searches
+                            track by search.id"
         >
-            <option value="" selected translate="app.select_one"></option>
         </select>
     </div>
 </fieldset>

--- a/app/main/posts/views/filters/filter-transformers.service.js
+++ b/app/main/posts/views/filters/filter-transformers.service.js
@@ -5,72 +5,72 @@ FilterTransformersService.$inject = ['_', 'FormEndpoint', 'TagEndpoint', 'RoleEn
 function FilterTransformersService(_, FormEndpoint, TagEndpoint, RoleEndpoint,
                             UserEndpoint, SavedSearchEndpoint, PostMetadataService, $translate, $filter) {
     var roles, users, tags, forms, savedSearches = [];
-    return {
-        requestsFiltersData: function () {
-            RoleEndpoint.query().$promise.then(function (results) {
-                roles = _.indexBy(results, 'name');
-            });
-            UserEndpoint.query().$promise.then(function (results) {
-                users = _.indexBy(results.results, 'id');
-            });
-            TagEndpoint.query().$promise.then(function (results) {
-                tags = _.indexBy(results, 'id');
-            });
-            FormEndpoint.query().$promise.then(function (results) {
-                forms = _.indexBy(results, 'id');
-            });
-            SavedSearchEndpoint.query({}).$promise.then(function (searches) {
-                savedSearches = _.indexBy(searches, 'id');
-            });
-        },
-        transformers: {
-            order_unlocked_on_top: function (value) {
-                var boolText = value === 'true' ? 'yes' : 'no';
-                return $translate.instant('global_filter.filter_tabs.order_group.unlocked_on_top_' + boolText);
-            },
-            order: function (value) {
-                return $translate.instant('global_filter.filter_tabs.order_group.order.' + value.toLowerCase());
-            },
-            orderby: function (value) {
-                return $translate.instant('global_filter.filter_tabs.order_group.orderby.' + value);
-            },
-            tags : function (value) {
-                return tags[value] ? tags[value].tag : value;
-            },
-            user : function (value) {
-                return users[value] ? users[value].realname : value;
-            },
-            saved_search: function (value) {
-                return savedSearches[value] ? savedSearches[value].name : value;
-            },
-            center_point : function (value) {
-                return $translate.instant('global_filter.filter_tabs.location_value', {
-                    value: this.rawFilters.location_text ? this.rawFilters.location_text : value,
-                    km: this.rawFilters.within_km
-                });
-            },
-            created_before : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            created_after : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            date_before : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            date_after : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            status : function (value) {
-                return $translate.instant('post.' + value);
-            },
-            source : function (value) {
-                return PostMetadataService.formatSource(value);
-            },
-            form: function (value) {
-                return forms[value] ? forms[value].name : value;
-            }
-        },
-        rawFilters: {}
+    var self = this;
+    this.rawFilters = {};
+    this.requestsFiltersData = function () {
+        RoleEndpoint.query().$promise.then(function (results) {
+            roles = _.indexBy(results, 'name');
+        });
+        UserEndpoint.query().$promise.then(function (results) {
+            users = _.indexBy(results.results, 'id');
+        });
+        TagEndpoint.query().$promise.then(function (results) {
+            tags = _.indexBy(results, 'id');
+        });
+        FormEndpoint.query().$promise.then(function (results) {
+            forms = _.indexBy(results, 'id');
+        });
+        SavedSearchEndpoint.query({}).$promise.then(function (searches) {
+            savedSearches = _.indexBy(searches, 'id');
+        });
     };
+    this.transformers = {
+        order_unlocked_on_top: function (value) {
+            var boolText = value === 'true' ? 'yes' : 'no';
+            return $translate.instant('global_filter.filter_tabs.order_group.unlocked_on_top_' + boolText);
+        },
+        order: function (value) {
+            return $translate.instant('global_filter.filter_tabs.order_group.order.' + value.toLowerCase());
+        },
+        orderby: function (value) {
+            return $translate.instant('global_filter.filter_tabs.order_group.orderby.' + value);
+        },
+        tags : function (value) {
+            return tags[value] ? tags[value].tag : value;
+        },
+        user : function (value) {
+            return users[value] ? users[value].realname : value;
+        },
+        saved_search: function (value) {
+            return savedSearches[value] ? savedSearches[value].name : value;
+        },
+        center_point : function (value) {
+            return $translate.instant('global_filter.filter_tabs.location_value', {
+                value: self.rawFilters.location_text ? this.rawFilters.location_text : value,
+                km: self.rawFilters.within_km
+            });
+        },
+        created_before : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        created_after : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        date_before : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        date_after : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        status : function (value) {
+            return $translate.instant('post.' + value);
+        },
+        source : function (value) {
+            return PostMetadataService.formatSource(value);
+        },
+        form: function (value) {
+            return forms[value] ? forms[value].name : value;
+        }
+    };
+    return self;
 }

--- a/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
+++ b/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
@@ -18,7 +18,19 @@ function FilterUnlockedOnTopDirective(moment, $rootScope, _) {
             value: 'true',
             labelTranslateKey: 'global_filter.sort.unlockedOnTop.filter_type_tag'
         };
-        $scope.$watch('unlockedOnTop', saveToView, true);
+
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('unlockedOnTop', saveToView, true);
+        }
+
+        function renderModelValue() {
+            $scope.unlockedOnTop = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.unlockedOnTop.filter_type_tag'
+            };
+        }
+        activate();
         function saveToView(unlockedOnTop) {
             ngModel.$setViewValue(angular.copy(unlockedOnTop ? unlockedOnTop.value.toString() : ''));
         }

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -193,7 +193,10 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         // If mode changes, reset filters
         if (newMode !== filterMode) {
             filterMode = newMode;
-            clearFilters();
+            if (filterMode === 'collection') {
+                clearFilters();
+            }
+
         }
         entityId = id;
     }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -43,8 +43,6 @@ function PostViewDataController(
     $scope.totalItems = $scope.itemsPerPage;
     $scope.posts = [];
     $scope.groupedPosts = {};
-    $scope.order = PostFilters.getDefaults().order;
-    $scope.orderby = PostFilters.getDefaults().orderby;
     $scope.showPost = showPost;
     $scope.loadMore = loadMore;
 


### PR DESCRIPTION
This pull request makes the following changes:
-  I can switch between views (Data & Map) without losing my active filter options
- Specifically this was added: 
    2091: Saved search filter remains active when switching between map and data views
    
    2091: post order options filter remains active when switching between map and data views
    
    2091: asc desc order filter remains active when switching between map and data views
    
    2091: unlocked on top remains active when switching between map and data views

Testing checklist:
- [ ] Add filters (one of each)
- [ ] When you switch between map and data views, you should have all your filters still enabled.

Pending for a different PR: Categories and Surveys cannot be filtered together, there is some logic that replaces them for some reason. I need to look into that and find out if it's an intended feature or a bug
Fixes ushahidi/platform# .

Ping @ushahidi/platform