### PR TITLE
Post edit pane WIP

### DIFF
--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -7,7 +7,8 @@ function CategorySelectorDirective() {
         restrict: 'E',
         scope: {
             available: '=',
-            selected: '='
+            selected: '=',
+            form: '='
         },
         controller: CategorySelectorController,
         template: require('./category-selector.html')
@@ -53,6 +54,11 @@ function CategorySelectorController($scope, _) {
     }
 
     function selectAll() {
+        if ($scope.form) {
+            // if used in a form, add the ng-dirty-class to categories.
+            $scope.form.$setDirty();
+        }
+
         if ($scope.available.length === $scope.selected.length) {
             $scope.selected.length = [];
         } else {

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -646,6 +646,7 @@
             "SMS": "SMS"
         },
         "valid" : {
+            "no_changes" : "You haven’t made any changes",
             "invalid_state" : "This post is currently in an invalid state. You'll need to complete all required tasks before you can re-publish this post. You can either complete the necessary tasks or give your post a different status, like \"under review.\"",
             "validation_fail" : "Required fields are missing, these fields are marked with an * below.",
             "title" : {
@@ -1055,7 +1056,8 @@
         "generic" : {
             "okay" : "Ok",
             "alerts": "Alerts",
-            "confirm": "Confirmation"
+            "confirm": "Confirmation",
+            "save" : "Save"
         },
         "login" : {
             "failed" : "Login failed, check your email and password."
@@ -1086,7 +1088,10 @@
             "bulk_destroy_confirm" : "Are you sure you want to delete {{count}} posts?",
             "stage_save_success" : "Updated {{stage}}",
             "export" : "This will export filtered posts. Are you sure you want to continue?",
-            "update_status_success_bulk" : "Status updated for {{count}} posts"
+            "update_status_success_bulk" : "Status updated for {{count}} posts",
+            "leave_without_save" : "Do you want to leave this report without saving?",
+            "leave_confirm_message" : "If you continue, all of your changes will be lost",
+            "leave_confirm" : "Continue without saving"
         },
         "category" : {
             "save_success" : "Saved category {{name}}",

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -17,7 +17,9 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         confirmDelete: confirmDelete,
         limit: limit,
         confirmTos: confirmTos,
-        adminUserSetupModal: adminUserSetupModal
+        adminUserSetupModal: adminUserSetupModal,
+        infoModal: infoModal,
+        confirmLeave: confirmLeave
     };
 
     function notify(message, translateValues) {
@@ -93,6 +95,8 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
 
         function showSlider(confirmText) {
             scope.confirmText = confirmText;
+            var scope = getScope();
+
             SliderService.openTemplate(
                 '<p>{{ confirmText }}</p>' +
                 '    <button class="button-flat" ng-click="$parent.cancel()" translate="message.button.cancel">Cancel</button>' +
@@ -131,6 +135,17 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         $translate(confirmText, translateValues).then(showSlider, showSlider);
 
         return deferred.promise;
+    }
+
+    function infoModal(confirmText, translate) {
+        var scope = getScope();
+        scope.cancel = function () {
+            ModalService.close();
+        };
+        ModalService.openTemplate(
+                '<div class="form-field">' +
+                '    <button class="button-alpha" ng-click="$parent.cancel()" translate="notify.generic.okay">Ok</button>' +
+                '</div>', confirmText, false, scope, false, false);
     }
 
     function adminUserSetupModal() {
@@ -198,14 +213,39 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 ModalService.openTemplate(
                 '<div class="form-field">' +
                 '<p><i translate="{{confirmWarningText}}"></i></p>' +
-                '    <button class="button-beta button-flat" ng-click="$parent.cancel()">Cancel</button>' +
-                '    <button class="button-destructive button-flat" ng-click="$parent.confirm()">' +
+                '    <button class="button-beta button-flat" ng-click="cancel()">Cancel</button>' +
+                '    <button class="button-destructive button-flat" ng-click="confirm()">' +
                 '    <svg class="iconic"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="' + iconicSprite + '#trash"></use></svg>' +
                 '    <span translate="app.delete">Delete</span>' +
                 '    </button>' +
                 '</div>', confirmText, false, scope, false, false);
             }
         }
+
+        return deferred.promise;
+    }
+
+    function confirmLeave(confirmText, translateValues) {
+        var deferred = $q.defer();
+        var scope = getScope();
+
+        scope.confirm = function () {
+            deferred.resolve();
+            ModalService.close();
+        };
+
+        scope.save = function () {
+            deferred.reject();
+            $rootScope.$broadcast('event:edit:post:data:mode:save');
+            ModalService.close();
+        };
+
+        ModalService.openTemplate(
+                '<div class="form-field">' +
+                '<p><i translate>notify.post.leave_confirm_message</i></p>' +
+                '    <button class="button button-flat" ng-click="confirm()" translate>notify.post.leave_confirm</button>' +
+                '    <button class="button-alpha button-flat" ng-click="save()" translate>notify.generic.save</button>' +
+                '</div>', confirmText, false, scope, false, false);
 
         return deferred.promise;
     }

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -42,7 +42,6 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         function showSlider(errorText) {
             SliderService.openTemplate('<p>' + errorText + '</p>', 'warning', 'error', null, false);
         }
-
         $translate(errorText, translateValues).then(showSlider, showSlider);
     }
 
@@ -64,7 +63,6 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
     function apiErrors(errorResponse) {
         var scope = getScope();
         scope.errors = _.pluck(errorResponse.data && errorResponse.data.errors, 'message');
-
         if (!scope.errors) {
             return;
         }
@@ -95,8 +93,6 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
 
         function showSlider(confirmText) {
             scope.confirmText = confirmText;
-            var scope = getScope();
-
             SliderService.openTemplate(
                 '<p>{{ confirmText }}</p>' +
                 '    <button class="button-flat" ng-click="$parent.cancel()" translate="message.button.cancel">Cancel</button>' +

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -18,7 +18,8 @@ function PostActionsDirective(
         restrict: 'E',
         replace: true,
         scope: {
-            post: '='
+            post: '=',
+            editMode: '='
         },
         template: require('./post-actions.html'),
         link: PostActionsLink
@@ -27,7 +28,7 @@ function PostActionsDirective(
     function PostActionsLink($scope) {
         $scope.deletePost = deletePost;
         $scope.updateStatus = updateStatus;
-
+        $scope.openEditMode = openEditMode;
         activate();
 
         function activate() {
@@ -46,6 +47,13 @@ function PostActionsDirective(
                     $route.reload();
                 }
             });
+        }
+        function openEditMode(id) {
+            if ($location.path() !== '/views/data') {
+                $location.path('/posts/' + id + '/edit');
+            } else {
+                $scope.editMode.editing = true;
+            }
         }
 
         function updateStatus(status) {

--- a/app/main/posts/common/post-actions.html
+++ b/app/main/posts/common/post-actions.html
@@ -9,7 +9,7 @@
     <ul>
 
         <li ng-show="post.allowed_privileges.indexOf('update') !== -1">
-          <a ng-show="post.allowed_privileges.indexOf('update') !== -1" ng-click="openEditMode()">
+          <a ng-show="post.allowed_privileges.indexOf('update') !== -1" ng-click="openEditMode(post.id)">
               <svg class="iconic">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#pencil"></use>
               </svg>

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -1,0 +1,310 @@
+module.exports = PostDataEditor;
+
+PostDataEditor.$inject = [];
+
+function PostDataEditor() {
+    return {
+        restrict: 'E',
+        scope: {
+            postToEdit: '=',
+            attributesToIgnore: '=',
+            postMode: '=',
+            editMode: '='
+        },
+        template: require('./post-data-editor.html'),
+        controller: PostDataEditorController
+    };
+}
+
+PostDataEditorController.$inject = [
+    '$scope',
+    '$rootScope',
+    '$q',
+    '$filter',
+    '$location',
+    '$translate',
+    '$timeout',
+    'moment',
+    'PostEntity',
+    'PostEndpoint',
+    'PostEditService',
+    'FormEndpoint',
+    'FormStageEndpoint',
+    'FormAttributeEndpoint',
+    'UserEndpoint',
+    'TagEndpoint',
+    'Notify',
+    '_',
+    'PostActionsService',
+    'MediaEditService'
+  ];
+
+function PostDataEditorController(
+    $scope,
+    $rootScope,
+    $q,
+    $filter,
+    $location,
+    $translate,
+    $timeout,
+    moment,
+    postEntity,
+    PostEndpoint,
+    PostEditService,
+    FormEndpoint,
+    FormStageEndpoint,
+    FormAttributeEndpoint,
+    UserEndpoint,
+    TagEndpoint,
+    Notify,
+    _,
+    PostActionsService,
+    MediaEditService
+  ) {
+
+    // Setup initial stages container
+    $scope.post = angular.copy($scope.postToEdit);
+    $scope.everyone = $filter('translate')('post.modify.everyone');
+    $scope.isEdit = !!$scope.post.id;
+    $scope.validationErrors = [];
+    $scope.visibleStage = 1;
+    $scope.enableTitle = true;
+    $scope.setVisibleStage = setVisibleStage;
+    $scope.fetchAttributesAndTasks = fetchAttributesAndTasks;
+    $scope.allowedChangeStatus = allowedChangeStatus;
+    $scope.deletePost = deletePost;
+    $scope.canSavePost = canSavePost;
+    $scope.savePost = savePost;
+    $scope.cancel = cancel;
+    $scope.postTitleLabel = 'Title';
+    $scope.postDescriptionLabel = 'Description';
+    $scope.tagKeys = [];
+    $scope.save = $translate.instant('app.save');
+    $scope.saving = $translate.instant('app.saving');
+    $scope.submit = $translate.instant('app.submit');
+    $scope.submitting = $translate.instant('app.submitting');
+
+    $rootScope.$on('event:edit:post:data:mode:save', function () {
+        $scope.savePost();
+    });
+    activate();
+
+    function activate() {
+        $scope.form = $scope.post.form;
+        $scope.fetchAttributesAndTasks($scope.post.form.id)
+        .then(function () {
+            // Use $timeout to delay this check till after form fields are rendered.
+            $timeout(() => {
+                // If the post in marked as 'Published' but it is not in
+                // a valid state to be saved as 'Published' warn the user
+                if ($scope.post.status === 'published' && !canSavePost()) {
+                    Notify.error('post.valid.invalid_state');
+                }
+            });
+        });
+
+        $scope.medias = {};
+        $scope.savingText = $translate.instant('app.saving');
+        $scope.submittingText = $translate.instant('app.submitting');
+    }
+
+    function setVisibleStage(stageId) {
+        $scope.visibleStage = stageId;
+    }
+
+    function fetchAttributesAndTasks(formId) {
+        return $q.all([
+            FormStageEndpoint.queryFresh({ formId: formId }).$promise,
+            FormAttributeEndpoint.queryFresh({ formId: formId }).$promise,
+            TagEndpoint.queryFresh().$promise
+        ]).then(function (results) {
+            var post = $scope.post;
+            var tasks = _.sortBy(results[0], 'priority');
+            var attrs = _.chain(results[1])
+                .sortBy('priority')
+                .value();
+            var categories = results[2];
+            // If attributesToIgnore is set, remove those attributes from set of fields to display
+            var attributes = [];
+            _.each(attrs, function (attr) {
+                if (attr.type === 'title' || attr.type === 'description') {
+                    if (attr.type === 'title') {
+                        $scope.postTitleLabel = attr.label;
+                        $scope.postTitleInstructions = attr.instructions;
+                    }
+                    if (attr.type === 'description') {
+                        $scope.postDescriptionLabel = attr.label;
+                        $scope.postDescriptionInstructions = attr.instructions;
+                    }
+                } else {
+                    attributes.push(attr);
+                }
+            });
+
+            // Initialize values on post (helps avoid madness in the template)
+            attributes.map(function (attr) {
+                // Create associated media entity
+                if (attr.input === 'upload') {
+                    var media = {};
+                    if ($scope.post.values[attr.key]) {
+                        media = $scope.post.values[attr.key][0];
+                    }
+                    $scope.medias[attr.key] = {};
+                }
+                if (attr.input === 'tags') {
+                    // adding category-objects attribute-options
+                    attr.options = _.chain(attr.options)
+                        .map(function (category) {
+                            return _.findWhere(categories, {id: category});
+                        })
+                        .filter()
+                        .value();
+                }
+                // @todo don't assign default when editing? or do something more sane
+                if (!$scope.post.values[attr.key]) {
+                    if (attr.input === 'location') {
+                        // Prepopulate location fields from message location
+                        if ($scope.post.values.message_location) {
+                            $scope.post.values[attr.key] = angular.copy($scope.post.values.message_location);
+                        } else {
+                            $scope.post.values[attr.key] = [null];
+                        }
+                    }  else if (attr.input === 'number') {
+                        $scope.post.values[attr.key] = [parseInt(attr.default)];
+                    } else if (attr.input === 'date' || attr.input === 'datetime') {
+                        $scope.post.values[attr.key] = attr.default ? [new Date(attr.default)] : [new Date()];
+                    } else {
+                        $scope.post.values[attr.key] = [attr.default];
+                    }
+                } else if (attr.input === 'date' || attr.input === 'datetime') {
+                    // Date picker requires date object
+                    // ensure that dates are preserved in UTC
+                    if ($scope.post.values[attr.key][0]) {
+                        $scope.post.values[attr.key][0] = moment($scope.post.values[attr.key][0]).toDate();
+                    }
+                } else if (attr.input === 'number') {
+                    // Number input requires a number
+                    if ($scope.post.values[attr.key][0]) {
+                        $scope.post.values[attr.key][0] = parseFloat($scope.post.values[attr.key][0]);
+                    }
+                } else if (attr.input === 'tags') {
+                    // tag.id needs to be a number
+                    if ($scope.post.values[attr.key]) {
+                        $scope.post.values[attr.key] = $scope.post.values[attr.key].map(function (id) {
+                            return parseInt(id);
+                        });
+                    }
+                }
+            });
+
+            _.each(tasks, function (task) {
+                task.attributes = _.filter(attributes, function (attribute) {
+                    return attribute.form_stage_id === task.id;
+                });
+            });
+
+            // If number of completed stages matches number of tasks - not including Post,
+            // assume they're all complete, and just show the first task
+            if (post.completed_stages.length === tasks.length - 1 && tasks.length > 1) {
+                $scope.setVisibleStage(tasks[1].id);
+            } else {
+                // Get incomplete stages
+                var incompleteStages = _.filter(tasks, function (task) {
+                    return !_.contains(post.completed_stages, task.id);
+                });
+
+                // Return lowest priority incomplete task - not including post
+                incompleteStages.length > 1 ? $scope.setVisibleStage(incompleteStages[1].id) : '';
+            }
+            $scope.tasks = tasks;
+        });
+
+    }
+
+    function canSavePost() {
+        return PostEditService.validatePost($scope.post, $scope.postForm, $scope.tasks);
+    }
+
+    function cancel() {
+
+        var path = $scope.post.id ? '/posts/' + $scope.post.id : '/';
+        $location.path(path);
+    }
+
+    function deletePost(post) {
+        PostActionsService.delete(post).then(function () {
+            $location.path('/');
+        });
+    }
+
+    function allowedChangeStatus() {
+        return $scope.post.allowed_privileges && $scope.post.allowed_privileges.indexOf('change_status') !== -1;
+    }
+
+    function resolveMedia() {
+        return MediaEditService.saveMedia($scope.medias, $scope.post);
+    }
+
+    function savePost() {
+        $scope.saving_post = true;
+        if (!$scope.canSavePost()) {
+            Notify.error('post.valid.validation_fail');
+            $scope.saving_post = false;
+            return;
+        }
+        // Create/update any associated media objects
+        // Media creation must be completed before we can progress with saving
+        resolveMedia().then(function () {
+
+            // Avoid messing with original object
+            // Clean up post values object
+            if ('message_location' in $scope.post.values) {
+                $scope.post.values.message_location = [];
+            }
+            var post = PostEditService.cleanPostValues(angular.copy($scope.post));
+            // adding neccessary tags to post.tags, needed for filtering
+            if ($scope.tagKeys.length > 0) {
+                post.tags = _.chain(post.values)
+                .pick($scope.tagKeys) // Grab just the 'tag' fields        { key1: [0,1], key2: [1,2], key3: undefined }
+                .values()             // then take their values            [ [0,1], [1,2], undefined ]
+                .flatten()            // flatten them into a single array  [0,1,1,2,undefined]
+                .filter()             // Remove nulls                      [0,1,1,2]
+                .uniq()               // Remove duplicates                 [0,1,2]
+                .value();             // and output
+            }
+            var request;
+            if (post.id) {
+                request = PostEndpoint.update(post);
+            } else {
+                request = PostEndpoint.save(post);
+            }
+            request.$promise.then(function (response) {
+                var success_message = (response.status && response.status === 'published') ? 'notify.post.save_success' : 'notify.post.save_success_review';
+
+                if (response.id && response.allowed_privileges.indexOf('read') !== -1) {
+                    $scope.saving_post = false;
+                    $scope.post.id = response.id;
+                    Notify.notify(success_message, { name: $scope.post.title });
+                    $scope.editMode.editing = false;
+                } else {
+                    Notify.notify(success_message, { name: $scope.post.title });
+                    $scope.editMode.editing = false;
+                }
+            }, function (errorResponse) { // errors
+                var validationErrors = [];
+                // @todo refactor limit handling
+                _.each(errorResponse.data.errors, function (value, key) {
+                    // Ultimately this should check individual status codes
+                    // for the moment just check for the message we expect
+                    if (value.title === 'limit::posts') {
+                        Notify.limit('limit.post_limit_reached');
+                    } else {
+                        validationErrors.push(value);
+                    }
+                });
+                Notify.errors(_.pluck(validationErrors, 'message'));
+                $scope.saving_post = false;
+            });
+        });
+    }
+}

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -72,7 +72,6 @@
         <!-- IF: User has permission to see other 'Tasks' -->
 
         <post-toolbox post="post"></post-toolbox>
-      </div>
        <post-tabs
            ng-show="tasks.length > 1"
            form="postForm"
@@ -83,11 +82,12 @@
            visible-stage="visibleStage">
         </post-tabs>
       </fieldset>
+    </div>
+
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
-          <button class="button-flat" data-modal="cancel-without-saving">Cancel</button>
-          <button class="button button-alpha" ng-click="savePost()">Save</a>
+          <button class="button-flat" ng-click="leavePost()">Cancel</button>
+          <button class="button button-alpha" ng-click="savePost()">Save</button>
         </div>
       </div>
-    </div>
   </form>

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -1,0 +1,93 @@
+<form name="postForm" novalidate>
+  <div class="form-sheet" role="article">
+    <div class="post-band" ng-style="{backgroundColor: form.color}"></div>
+      <fieldset>
+        <div 
+          class="form-field init required"
+          adaptive-form
+          ng-class="{'error': postForm.title.$invalid && postForm.title.$dirty, 'success': !postForm.title.$invalid && postForm.title.$dirty}"
+        >
+          <label>{{postTitleLabel}}</label>
+          <p>{{postTitleInstructions}}</p>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            ng-model="post.title"
+            ng-required="true"
+            ng-minlength=2
+            ng-maxlength=150
+            adaptive-input
+          >
+          <div
+            class="alert error"
+            ng-show="postForm.title.$dirty"
+            ng-repeat="(error, value) in postForm.title.$error"
+          >
+            <svg class="iconic">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+            </svg>
+            <span translate="{{'post.valid.title.' + error}}"></span>
+          </div>
+        </div>
+
+        <!-- Post stage default fields -->
+        <div
+          class="form-field init required"
+          ng-class="{'error': postForm.content.$invalid && postForm.content.$dirty, 'success': !postForm.content.$invalid && postForm.content.$dirty}"
+          adaptive-form
+        >
+          <label>{{postDescriptionLabel}}</label>
+          <p>{{postDescriptionInstructions}}</p>
+          <textarea id="content" name="content" data-min-rows="1" rows="1" ng-model="post.content" ng-required="true" adaptive-input msd-elastic></textarea>
+
+          <div class="alert error" ng-show="postForm.content.$dirty" ng-repeat="(error, value) in postForm.content.$error">
+            <svg class="iconic">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+            </svg>
+            <span translate="{{'post.valid.content.' + error}}"></span>
+          </div>
+        </div>
+
+        <!-- End post stage default fields -->
+
+        <!-- Start Post custom fields -->
+
+        <post-value-edit
+            ng-repeat="attribute in tasks[0].attributes | orderBy: 'priority' as filtered_result track by attribute.id"
+            post="post"
+            post-field=true
+            form="postForm"
+            medias="medias"
+            attribute="attribute"
+        ></post-value-edit>
+        <!-- End Post custom fields -->
+        <!-- IF: Editing an existing post -->
+
+        <!-- ELSE IF: Adding a new post w/o permission to manage who it's visible to
+        <div class="postcard-metadata">
+            <strong>This post will need to be moderated</strong> before it's visible to the public.
+        </div>
+        END: IF -->
+        <!-- IF: User has permission to see other 'Tasks' -->
+
+        <post-toolbox post="post"></post-toolbox>
+      </div>
+       <post-tabs
+           ng-show="tasks.length > 1"
+           form="postForm"
+           post="post"
+           stages="tasks"
+           attributes="attributes"
+           medias="medias"
+           visible-stage="visibleStage">
+        </post-tabs>
+      </fieldset>
+      <div class="toolbar toolbar-secondary">
+        <div class="button-group">
+          <button class="button-flat" data-modal="cancel-without-saving">Cancel</button>
+          <button class="button button-alpha" ng-click="savePost()">Save</a>
+        </div>
+      </div>
+    </div>
+  </form>

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -206,7 +206,8 @@
     <div ng-switch-when="tags">
         <category-selector
             available="attribute.options"
-            selected="post.values[attribute.key]"
+            selected="post.values[attribute.key]",
+            form="form"
         ></category-selector>
         <add-category
             form-id="post.form.id"

--- a/app/main/posts/posts-module.js
+++ b/app/main/posts/posts-module.js
@@ -35,6 +35,7 @@ angular.module('ushahidi.posts', [])
 .directive('filterPostOrderAscDesc', require('./views/filters/filter-post-order-asc-desc.directive.js'))
 .directive('filterUnlockedOnTop', require('./views/filters/filter-unlocked-on-top.directive.js'))
 .directive('postTimelineToolbox', require('./views/post-timeline-toolbox.directive.js'))
+.directive('postDataEditor', require('./modify/post-data-editor.directive.js'))
 
 // Timeline, data and Map screen
 .service('PostViewService', require('./views/post-view.service.js'))

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -8,7 +8,7 @@
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>
 
-        <post-actions post="post"></post-actions>
+        <post-actions edit-mode="editMode" post="post"></post-actions>
       </header>
       <div class="postcard-overflow">
         <div class="postcard-title">

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -11,10 +11,12 @@ function PostCardDirective(FormEndpoint) {
             selectedPosts: '=',
             inFocus: '=',
             shortContent: '@',
-            clickAction: '='
+            clickAction: '=',
+            editMode: '='
         },
         template: require('./card.html'),
         link: function ($scope) {
+
             activate();
 
             function activate() {

--- a/app/main/posts/views/post-toolbar.directive.js
+++ b/app/main/posts/views/post-toolbar.directive.js
@@ -16,15 +16,21 @@ function PostToolbarDirective() {
     };
 }
 
-PostToolbarController.$inject = ['$scope', '$rootScope'];
-function PostToolbarController($scope, $rootScope) {
+PostToolbarController.$inject = ['$scope', '$rootScope', 'Notify'];
+function PostToolbarController($scope, $rootScope, Notify) {
     $scope.setEditMode = setEditMode;
     $scope.savePost = savePost;
+    $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
+
     function savePost() {
         $rootScope.$broadcast('event:edit:post:data:mode:save');
     }
 
     function setEditMode() {
-        $scope.editMode.editing = !$scope.editMode.editing ? true : false;
+        if ($scope.editMode.editing) {
+            $rootScope.$broadcast('event:edit:leave:form');
+        } else {
+            $scope.editMode.editing = true;
+        }
     }
 }

--- a/app/main/posts/views/post-toolbar.directive.js
+++ b/app/main/posts/views/post-toolbar.directive.js
@@ -7,13 +7,24 @@ function PostToolbarDirective() {
         scope: {
             isLoading: '=',
             filters: '=',
-            currentView: '='
+            currentView: '=',
+            editMode: '=',
+            selectedPost: '='
         },
         controller: PostToolbarController,
         template: require('./post-toolbar.html')
     };
 }
 
-PostToolbarController.$inject = [];
-function PostToolbarController() {
+PostToolbarController.$inject = ['$scope', '$rootScope'];
+function PostToolbarController($scope, $rootScope) {
+    $scope.setEditMode = setEditMode;
+    $scope.savePost = savePost;
+    function savePost() {
+        $rootScope.$broadcast('event:edit:post:data:mode:save');
+    }
+
+    function setEditMode() {
+        $scope.editMode.editing = !$scope.editMode.editing ? true : false;
+    }
 }

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -2,18 +2,25 @@
     <!-- toolbar -->
 
     <!-- floating action button -->
-    <add-post-button></add-post-button>
+    <add-post-button ng-if="currentView !== 'data'"></add-post-button>
 
     <filter-posts current-view="currentView" filters="filters" embed-only="false"></filter-posts>
 
-    <div class="button-group" embed-only="false">
-      <post-share filters="filters" button="true"></post-share>
+    <div class="button-group" embed-only="false" ng-switch="editMode.editing">
+        <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
+        <button ng-switch-when="false" ng-if="selectedPost" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
+        <button ng-switch-when="true" class="button" ng-click="setEditMode()">CANCEL</button>
+        <button ng-switch-when="true" ng-click="savePost()" class=" button button-alpha">SAVE</button>
     </div>
 
+    
     <filter-by-survey></filter-by-survey>
 
-    <div class="button-group hide-until-medium" embed-only="true">
-      <post-share filters="filters" button="true"></post-share>
+    <div class="button-group hide-until-medium" ng-switch="editMode.editing" embed-only="true">
+        <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
+        <button ng-switch-when="false" ng-if="selectedPost" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
+        <button ng-switch-when="true" class="button" ng-click="setEditMode()">CANCEL</button>
+        <button ng-switch-when="true" class="button button-alpha"  ng-click="savePost()">SAVE</button>
     </div>
 
     <!-- toolbar -->

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -8,9 +8,9 @@
 
     <div class="button-group" embed-only="false" ng-switch="editMode.editing">
         <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
-        <button ng-switch-when="false" ng-if="selectedPost" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
-        <button ng-switch-when="true" class="button" ng-click="setEditMode()">CANCEL</button>
-        <button ng-switch-when="true" ng-click="savePost()" class=" button button-alpha">SAVE</button>
+        <button ng-switch-when="false" ng-if="selectedPost && hasPermission" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
+        <button ng-switch-when="true" ng-if="hasPermission" class="button" ng-click="setEditMode()">CANCEL</button>
+        <button ng-switch-when="true" ng-if="hasPermission" ng-click="savePost()" class=" button button-alpha">SAVE</button>
     </div>
 
     
@@ -18,9 +18,9 @@
 
     <div class="button-group hide-until-medium" ng-switch="editMode.editing" embed-only="true">
         <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
-        <button ng-switch-when="false" ng-if="selectedPost" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
-        <button ng-switch-when="true" class="button" ng-click="setEditMode()">CANCEL</button>
-        <button ng-switch-when="true" class="button button-alpha"  ng-click="savePost()">SAVE</button>
+        <button ng-switch-when="false" ng-if="selectedPost && hasPermission" class="button button-alpha" ng-click="setEditMode()">EDIT</button>
+        <button ng-switch-when="true" ng-if="hasPermission" class="button" ng-click="setEditMode()">CANCEL</button>
+        <button ng-switch-when="true" ng-if="hasPermission" ng-click="savePost()" class=" button button-alpha">SAVE</button>
     </div>
 
     <!-- toolbar -->

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,17 +1,19 @@
 <div>
-<div class="listing timeline">
-         <post-toolbar is-loading="isLoading" current-view="currentView" filters="filters"></post-toolbar>
-    <!-- @DEVNOTE: ANNA this was throwing an error . <ng-transclude></ng-transclude>-->
+    <post-toolbar is-loading="isLoading" current-view="currentView" selected-post="selectedPost" edit-mode="editMode" filters="filters"></post-toolbar>
+
     <div class="timeline-col">
-        <post-card
+        <div class="listing timeline init">
+            <h2 class="tool-heading">{{posts.length}} of {{total}} posts</h2>
+            <post-card
                 ng-repeat="post in posts"
                 can-select="false"
                 post="post"
                 selected-posts="selectedPosts"
                 click-action="showPost"
-                in-focus="selectedPostId === post.id"
+                in-focus="selectedPostId === post.id",
+                edit-mode="editMode"
             >
-        </post-card>
+            </post-card>
 
             <button class="button-gamma button-flat" ng-click="loadMore()">Load more</button>
             <div class="listing-toolbar">
@@ -22,7 +24,7 @@
             </div>
         </div>
     </div>
-      <div class="post-col" ng-if="selectedPost">
-        <post-detail-data filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
-    </div>
+    <div class="post-col">
+        <post-detail-data ng-if="selectedPost && !editMode.editing" filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
+        <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-to-edit="selectedPost"></post-editor>
 </div>

--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -25,7 +25,8 @@ PostListController.$inject = [
     'ConfigEndpoint',
     'moment',
     'PostFilters',
-    'PostActionsService'
+    'PostActionsService',
+    '$location'
 ];
 function PostListController(
     $scope,
@@ -38,7 +39,8 @@ function PostListController(
     ConfigEndpoint,
     moment,
     PostFilters,
-    PostActionsService
+    PostActionsService,
+    $location
 ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
@@ -61,6 +63,7 @@ function PostListController(
     $scope.clearPosts = false;
     $scope.clearSelectedPosts = clearSelectedPosts;
     $scope.changeOrder = changeOrder;
+    $scope.goToPost = goToPost;
     activate();
 
     // whenever the reactiveFilters var changes, do a dummy update of $scope.filters.reactiveFilters
@@ -140,7 +143,9 @@ function PostListController(
             }
         });
     }
-
+    function goToPost(id) {
+        $location.path('/posts/' + id);
+    }
     function groupPosts(posts) {
         var now = moment(),
             yesterday = moment().subtract(1, 'days');

--- a/app/main/posts/views/post-view-list.html
+++ b/app/main/posts/views/post-view-list.html
@@ -11,6 +11,7 @@
             can-select="userHasBulkActionPermissions()"
             post="post"
             selected-posts="selectedPosts"
+            click-action="goToPost(post.id)"
         >
         </post-card>
 

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -156,6 +156,10 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 return posts;
             });
         }
+        // This function should be sent to postcard
+        // function goToPost (id) {
+        //     $location.path('/posts/' + id);
+        // }
 
         function onEachFeature(feature, layer) {
             layer.on('click', function (e) {
@@ -173,8 +177,8 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                     getPostDetails(feature).then(function (details) {
                         var scope = $rootScope.$new();
                         scope.post = details;
-
-                        var el = $compile('<post-card post="post" short-content="true"></post-card>')(scope);
+                        // click-action does not work...
+                        var el = $compile('<post-card post="post" short-content="true" click-action="goToPost(post.id)"></post-card>')(scope);
 
                         layer.bindPopup(el[0], {
                             'minWidth': '300',

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -156,10 +156,10 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 return posts;
             });
         }
-        // This function should be sent to postcard
-        // function goToPost (id) {
-        //     $location.path('/posts/' + id);
-        // }
+
+        function goToPost(id) {
+            $location.path('/posts/' + id);
+        }
 
         function onEachFeature(feature, layer) {
             layer.on('click', function (e) {
@@ -177,7 +177,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                     getPostDetails(feature).then(function (details) {
                         var scope = $rootScope.$new();
                         scope.post = details;
-                        // click-action does not work...
+                        scope.goToPost = goToPost;
                         var el = $compile('<post-card post="post" short-content="true" click-action="goToPost(post.id)"></post-card>')(scope);
 
                         layer.bindPopup(el[0], {

--- a/app/main/posts/views/post-view.html
+++ b/app/main/posts/views/post-view.html
@@ -14,7 +14,7 @@
         <post-view-list ng-switch-when="list" is-loading="isLoading" filters="filters"></post-view-list>
 
         <!-- data view -->
-        <post-view-data ng-switch-when="data" is-loading="isLoading" filters="filters"></post-view-data>
+        <post-view-data ng-switch-when="data" current-view="currentView" is-loading="isLoading" filters="filters"></post-view-data>
         
         <!-- create view -->
         <post-view-create ng-switch-when="create"></post-view-create>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.1-rc.30"
+    "ushahidi-platform-pattern-library": "v3.7.2-rc.4"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Adds edit-functionality to split-view
- Shows correct toolbar-button based on where in application you are (based on currentView)
- Fixes edit-button in post-action dropdown
- Adds message with nb of posts out of total posts on top of post-list
LEFT TO DO!
~- Check error-messages~
~- Add message to user that a post is not changed when clicking save and no changes were made~
- Make edit-button in post-action-dropdown in detail-view work
- Display 'leave-form-warning' if clicking outside of the edit-form
- Update post-cards and detailed view with new details when a change has been saved
- When saving a post that doesn't match the current filtering, the post should be removed from the list and the detailed view of the next one should appear
- General style-fixes


Testing checklist:
- Go to data view and click on a post + edit-button
- [ ] Edit-view should appear
- Don't make a change and click save
- [ ] A modal with the text "You have not made any changes" should appear 
- Make a change and click save
- [ ] Changes should be saved and post-card to the left should update
- Make a change and click cancel, a warning should appear with the option to navigate away anyway or save
- [ ] Clicking 'navigate away' should leave the edit-mode and not save changes
- [ ] Clicking 'save' should save changes and leave the edit mode 
- Go to map-view and click on a post + select edit-post on the post-action-dropdown
- [ ] the 'old' edit-view should be visible




Fixes ushahidi/platform# .

Ping @ushahidi/platform