### PR TITLE
2091 - bufixing

### DIFF
--- a/app/common/directives/filter-system/filter-searchbar.html
+++ b/app/common/directives/filter-system/filter-searchbar.html
@@ -14,7 +14,7 @@
 
     <div class="searchbar-results dropdown-menu" ng-class="{active: (searchResultsVisible && form.q.$viewValue.length > 0) }">
         <div class="form-field">
-            <button type="submit" class="button-plain">
+            <button class="button-plain" ng-click="enableQuery()">
                 <span class="button-label">
                     <span translate-values="{ entity: entityType }" translate>
                         toolbar.searchbar.search_all_entities_for

--- a/app/common/directives/filter-system/filter-searchbar.js
+++ b/app/common/directives/filter-system/filter-searchbar.js
@@ -4,8 +4,8 @@
  * and selection of appropriate sub directive
  */
 
-module.exports = ['$timeout',
-function ($timeout) {
+module.exports = ['$timeout', 'PostFilters',
+function ($timeout, PostFilters) {
     var link =
         function (
             $scope, $elem, $attrs, formControl
@@ -21,6 +21,10 @@ function ($timeout) {
                 $timeout(function () {
                     $scope.searchResultsVisible = false;
                 }, 100);
+            };
+
+            $scope.enableQuery = function () {
+                PostFilters.qEnabled = true;
             };
         };
     return {

--- a/app/main/posts/views/filters/active-filters.directive.js
+++ b/app/main/posts/views/filters/active-filters.directive.js
@@ -16,10 +16,11 @@ function ActiveFilters($translate, $filter, PostFilters, _, FilterTransformers) 
         activate();
 
         function activate() {
-            $scope.$watch(function () {
-                return PostFilters.getActiveFilters(PostFilters.getFilters());
-            }, handleFiltersUpdate, true);
-            FilterTransformers.requestsFiltersData();
+            FilterTransformers.requestsFiltersData().then(function (all) {
+                $scope.$watch(function () {
+                    return PostFilters.getActiveFilters(PostFilters.getFilters());
+                }, handleFiltersUpdate, true);
+            });
         }
 
         function makeArray(value) {

--- a/app/main/posts/views/filters/active-search-filters.directive.js
+++ b/app/main/posts/views/filters/active-search-filters.directive.js
@@ -17,10 +17,11 @@ function ActiveSearchFilters($translate, $filter, PostFilters, _, FilterTransfor
         activate();
 
         function activate() {
-            $scope.$watch(function () {
-                return PostFilters.getActiveFilters(PostFilters.getFilters());
-            }, handleFiltersUpdate, true);
-            FilterTransformers.requestsFiltersData();
+            FilterTransformers.requestsFiltersData().then(function (all) {
+                $scope.$watch(function () {
+                    return PostFilters.getActiveFilters(PostFilters.getFilters());
+                }, handleFiltersUpdate, true);
+            });
         }
 
         function makeArray(value) {

--- a/app/main/posts/views/filters/filter-post-order-asc-desc.directive.js
+++ b/app/main/posts/views/filters/filter-post-order-asc-desc.directive.js
@@ -16,7 +16,7 @@ function FilterPostOrderAscDescDirective(moment, $rootScope, _) {
     function FilterPostOrderAscDescLink($scope, $element, $attrs, ngModel) {
         $scope.selectedValue = {
             value: 'desc',
-            labelTranslateKey: 'global_filter.sort.order.filter_type_tag'};
+            labelTranslateKey: 'global_filter.sort.order.desc'};
         $scope.activeOrderOptions = {
             labelTranslateKey: 'global_filter.sort.order.filter_type_tag',
             options: [
@@ -31,7 +31,17 @@ function FilterPostOrderAscDescDirective(moment, $rootScope, _) {
             ]
         };
         //$scope.$watch('activeOrderOptions', saveToView, true);
-        $scope.$watch('selectedValue', saveToViewSelected, true);
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('selectedValue', saveToViewSelected, true);
+        }
+        function renderModelValue() {
+            $scope.selectedValue = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.order.' + ngModel.$viewValue
+            };
+        }
+        activate();
         function saveToViewSelected(orderGroup) {
             ngModel.$setViewValue(angular.copy(orderGroup ? orderGroup.value.toString() : ''), 'radio');
         }

--- a/app/main/posts/views/filters/filter-post-sorting-options.directive.js
+++ b/app/main/posts/views/filters/filter-post-sorting-options.directive.js
@@ -16,7 +16,7 @@ function FilterPostSortingOptionsDirective(moment, $rootScope, _) {
     function PostSortingOptionsLink($scope, $element, $attrs, ngModel) {
         $scope.orderValue = {
             value: 'created',
-            labelTranslateKey: 'global_filter.sort.orderby.filter_type_tag'
+            labelTranslateKey: 'global_filter.sort.orderby.created'
         };
         $scope.orderByOptions = {
             value: 'created',
@@ -36,7 +36,17 @@ function FilterPostSortingOptionsDirective(moment, $rootScope, _) {
                 }
             ]
         };
-        $scope.$watch('orderValue', saveToView, true);
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('orderValue', saveToView, true);
+        }
+        function renderModelValue() {
+            $scope.orderValue = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.orderby.' + ngModel.$viewValue
+            };
+        }
+        activate();
         function saveToView(orderGroup) {
             /** @DEVNOTE  this is not something we should need.
              * We should be consistently getting the same type here. FIX FIX FIX before we merge

--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -22,6 +22,7 @@ function FilterPostsController($scope, $timeout, ModalService, PostFilters, $rou
     $scope.filtersDropdownToggle = false;
     $scope.searchDropdownToggle = $routeParams.view !== 'list';
     $scope.qFilter = '';
+    $scope.openSavedModal = openSavedModal;
     activate();
 
     function activate() {
@@ -41,5 +42,8 @@ function FilterPostsController($scope, $timeout, ModalService, PostFilters, $rou
 
     function rollbackForm() {
         PostFilters.clearFilters();
+    }
+    function openSavedModal() {
+        ModalService.openTemplate('<saved-search-modal></saved-search-modal>', 'nav.saved_searches', '/img/iconic-sprite.svg#star', $scope, true, true);
     }
 }

--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -21,7 +21,7 @@ function FilterPostsController($scope, $timeout, ModalService, PostFilters, $rou
     $scope.applyFilters = applyFilters;
     $scope.filtersDropdownToggle = false;
     $scope.searchDropdownToggle = $routeParams.view !== 'list';
-
+    $scope.qFilter = '';
     activate();
 
     function activate() {

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -11,6 +11,12 @@
     <filter-searchbar model="filters.q"></filter-searchbar>
     <!-- Toggle Filters show/hide -->
     <div class="searchbar-options">
+        <a class="button" ng-click="openSavedModal()">
+            <svg class="iconic">
+                <use xlink:href="/img/iconic-sprite.svg#star"></use>
+            </svg>
+            <span class="button-label hidden" translate>app.saved</span>
+        </a>
         <a class="button searchbar-options-filter" ng-click="filtersDropdownToggle = !filtersDropdownToggle" data-toggle="search-filters">
             <!-- DEVNOTE translate -->
             <sort-and-filter-counter></sort-and-filter-counter>

--- a/app/main/posts/views/filters/filter-saved-search.directive.js
+++ b/app/main/posts/views/filters/filter-saved-search.directive.js
@@ -12,26 +12,36 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope) {
     };
 
     function FilterSavedSearchLink(scope, element, attrs, ngModel) {
-        scope.selectedSavedSearch = '';
-
+        scope.selectedSavedSearch = null;
         function activate() {
+            ngModel.$render = renderModelValue;
+            if (ngModel.$viewValue.length > 0) {
+                scope.selectedSavedSearch = scope.searches[ngModel.$viewValue];
+            }
             scope.$watch('selectedSavedSearch', saveValueToView, true);
         }
         function saveValueToView(selectedSavedSearch) {
-            ngModel.$setViewValue(selectedSavedSearch ? selectedSavedSearch.toString() : '');
+            ngModel.$setViewValue(selectedSavedSearch && selectedSavedSearch.id ?
+                selectedSavedSearch.id.toString() : ngModel.$viewValue);
         }
 
-        activate();
+        function renderModelValue() {
+            scope.selectedSavedSearch = ngModel.$viewValue;
+            // Update savedSearch w/o breaking references used by selectedSavedSearch model
+        }
 
         // Load searches + users
-        (function loadSavedSearches(query) {
-            query = query || {};
-            SavedSearchEndpoint.query(query).$promise.then(function (searches) {
-                scope.searches = _.filter(searches, function (search) {
+        function loadSavedSearches() {
+            SavedSearchEndpoint.query({}).$promise.then(function (searches) {
+                var searchesTmp = _.filter(searches, function (search) {
                     var isOwner = (search.user && search.user.id === _.result($rootScope.currentUser, 'userId')) === true;
                     return search.featured || isOwner;
                 });
+                scope.searches = _.indexBy(searchesTmp, 'id');
+            }).then(function () {
+                activate();
             });
-        })();
+        }
+        loadSavedSearches();
     }
 }

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset ng-show="searches.length > 0">
     <label translate="app.saved_search"></label>
     <div class="custom-select" ng-model-options="{ updateOn: 'default' }">
         <select

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -3,11 +3,11 @@
     <div class="custom-select" ng-model-options="{ updateOn: 'default' }">
         <select
                 ng-model="selectedSavedSearch"
-                ng-options="search.id as search.name
-        for
-        search in searches"
+                ng-options="search.name
+                            for
+                            search in searches
+                            track by search.id"
         >
-            <option value="" selected translate="app.select_one"></option>
         </select>
     </div>
 </fieldset>

--- a/app/main/posts/views/filters/filter-transformers.service.js
+++ b/app/main/posts/views/filters/filter-transformers.service.js
@@ -5,72 +5,72 @@ FilterTransformersService.$inject = ['_', 'FormEndpoint', 'TagEndpoint', 'RoleEn
 function FilterTransformersService(_, FormEndpoint, TagEndpoint, RoleEndpoint,
                             UserEndpoint, SavedSearchEndpoint, PostMetadataService, $translate, $filter) {
     var roles, users, tags, forms, savedSearches = [];
-    return {
-        requestsFiltersData: function () {
-            RoleEndpoint.query().$promise.then(function (results) {
-                roles = _.indexBy(results, 'name');
-            });
-            UserEndpoint.query().$promise.then(function (results) {
-                users = _.indexBy(results.results, 'id');
-            });
-            TagEndpoint.query().$promise.then(function (results) {
-                tags = _.indexBy(results, 'id');
-            });
-            FormEndpoint.query().$promise.then(function (results) {
-                forms = _.indexBy(results, 'id');
-            });
-            SavedSearchEndpoint.query({}).$promise.then(function (searches) {
-                savedSearches = _.indexBy(searches, 'id');
-            });
-        },
-        transformers: {
-            order_unlocked_on_top: function (value) {
-                var boolText = value === 'true' ? 'yes' : 'no';
-                return $translate.instant('global_filter.filter_tabs.order_group.unlocked_on_top_' + boolText);
-            },
-            order: function (value) {
-                return $translate.instant('global_filter.filter_tabs.order_group.order.' + value.toLowerCase());
-            },
-            orderby: function (value) {
-                return $translate.instant('global_filter.filter_tabs.order_group.orderby.' + value);
-            },
-            tags : function (value) {
-                return tags[value] ? tags[value].tag : value;
-            },
-            user : function (value) {
-                return users[value] ? users[value].realname : value;
-            },
-            saved_search: function (value) {
-                return savedSearches[value] ? savedSearches[value].name : value;
-            },
-            center_point : function (value) {
-                return $translate.instant('global_filter.filter_tabs.location_value', {
-                    value: this.rawFilters.location_text ? this.rawFilters.location_text : value,
-                    km: this.rawFilters.within_km
-                });
-            },
-            created_before : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            created_after : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            date_before : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            date_after : function (value) {
-                return $filter('date', 'longdate')(value);
-            },
-            status : function (value) {
-                return $translate.instant('post.' + value);
-            },
-            source : function (value) {
-                return PostMetadataService.formatSource(value);
-            },
-            form: function (value) {
-                return forms[value] ? forms[value].name : value;
-            }
-        },
-        rawFilters: {}
+    var self = this;
+    this.rawFilters = {};
+    this.requestsFiltersData = function () {
+        RoleEndpoint.query().$promise.then(function (results) {
+            roles = _.indexBy(results, 'name');
+        });
+        UserEndpoint.query().$promise.then(function (results) {
+            users = _.indexBy(results.results, 'id');
+        });
+        TagEndpoint.query().$promise.then(function (results) {
+            tags = _.indexBy(results, 'id');
+        });
+        FormEndpoint.query().$promise.then(function (results) {
+            forms = _.indexBy(results, 'id');
+        });
+        SavedSearchEndpoint.query({}).$promise.then(function (searches) {
+            savedSearches = _.indexBy(searches, 'id');
+        });
     };
+    this.transformers = {
+        order_unlocked_on_top: function (value) {
+            var boolText = value === 'true' ? 'yes' : 'no';
+            return $translate.instant('global_filter.filter_tabs.order_group.unlocked_on_top_' + boolText);
+        },
+        order: function (value) {
+            return $translate.instant('global_filter.filter_tabs.order_group.order.' + value.toLowerCase());
+        },
+        orderby: function (value) {
+            return $translate.instant('global_filter.filter_tabs.order_group.orderby.' + value);
+        },
+        tags : function (value) {
+            return tags[value] ? tags[value].tag : value;
+        },
+        user : function (value) {
+            return users[value] ? users[value].realname : value;
+        },
+        saved_search: function (value) {
+            return savedSearches[value] ? savedSearches[value].name : value;
+        },
+        center_point : function (value) {
+            return $translate.instant('global_filter.filter_tabs.location_value', {
+                value: self.rawFilters.location_text ? this.rawFilters.location_text : value,
+                km: self.rawFilters.within_km
+            });
+        },
+        created_before : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        created_after : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        date_before : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        date_after : function (value) {
+            return $filter('date', 'longdate')(value);
+        },
+        status : function (value) {
+            return $translate.instant('post.' + value);
+        },
+        source : function (value) {
+            return PostMetadataService.formatSource(value);
+        },
+        form: function (value) {
+            return forms[value] ? forms[value].name : value;
+        }
+    };
+    return self;
 }

--- a/app/main/posts/views/filters/filter-transformers.service.js
+++ b/app/main/posts/views/filters/filter-transformers.service.js
@@ -1,27 +1,20 @@
 module.exports = FilterTransformersService;
 
 FilterTransformersService.$inject = ['_', 'FormEndpoint', 'TagEndpoint', 'RoleEndpoint',
-    'UserEndpoint', 'SavedSearchEndpoint', 'PostMetadataService', '$translate', '$filter'];
+    'UserEndpoint', 'SavedSearchEndpoint', 'PostMetadataService', '$translate', '$filter', '$q'];
 function FilterTransformersService(_, FormEndpoint, TagEndpoint, RoleEndpoint,
-                            UserEndpoint, SavedSearchEndpoint, PostMetadataService, $translate, $filter) {
+                            UserEndpoint, SavedSearchEndpoint, PostMetadataService, $translate, $filter, $q) {
     var roles, users, tags, forms, savedSearches = [];
     var self = this;
     this.rawFilters = {};
     this.requestsFiltersData = function () {
-        RoleEndpoint.query().$promise.then(function (results) {
-            roles = _.indexBy(results, 'name');
-        });
-        UserEndpoint.query().$promise.then(function (results) {
-            users = _.indexBy(results.results, 'id');
-        });
-        TagEndpoint.query().$promise.then(function (results) {
-            tags = _.indexBy(results, 'id');
-        });
-        FormEndpoint.query().$promise.then(function (results) {
-            forms = _.indexBy(results, 'id');
-        });
-        SavedSearchEndpoint.query({}).$promise.then(function (searches) {
-            savedSearches = _.indexBy(searches, 'id');
+        return $q.all([RoleEndpoint.query().$promise, UserEndpoint.query().$promise,
+            TagEndpoint.query().$promise, FormEndpoint.query().$promise, SavedSearchEndpoint.query({}).$promise]).then(function (results) {
+            roles = results[0];
+            users = results[1];
+            tags = results[2];
+            forms = results[3];
+            savedSearches = results[4];
         });
     };
     this.transformers = {

--- a/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
+++ b/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
@@ -18,7 +18,19 @@ function FilterUnlockedOnTopDirective(moment, $rootScope, _) {
             value: 'true',
             labelTranslateKey: 'global_filter.sort.unlockedOnTop.filter_type_tag'
         };
-        $scope.$watch('unlockedOnTop', saveToView, true);
+
+        function activate() {
+            ngModel.$render = renderModelValue;
+            $scope.$watch('unlockedOnTop', saveToView, true);
+        }
+
+        function renderModelValue() {
+            $scope.unlockedOnTop = {
+                value: ngModel.$viewValue,
+                labelTranslateKey: 'global_filter.sort.unlockedOnTop.filter_type_tag'
+            };
+        }
+        activate();
         function saveToView(unlockedOnTop) {
             ngModel.$setViewValue(angular.copy(unlockedOnTop ? unlockedOnTop.value.toString() : ''));
         }

--- a/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
+++ b/app/main/posts/views/filters/filter-unlocked-on-top.directive.js
@@ -1,11 +1,9 @@
 module.exports = FilterUnlockedOnTopDirective;
 
 FilterUnlockedOnTopDirective.$inject = [
-    'moment',
-    '$rootScope',
     '_'
 ];
-function FilterUnlockedOnTopDirective(moment, $rootScope, _) {
+function FilterUnlockedOnTopDirective(_) {
     return {
         restrict: 'E',
         require: 'ngModel',

--- a/app/main/posts/views/filters/filter-unlocked-on-top.html
+++ b/app/main/posts/views/filters/filter-unlocked-on-top.html
@@ -1,7 +1,7 @@
 <div class="form-field checkbox" ng-model-options="{ updateOn: 'default' }">
     <label>
         <input type="checkbox" id="unlockedOnTop" value="unlockedOnTop"
-               name="unlockedOnTop" ng-model="unlockedOnTop.value" ng-change="change()"
+               name="unlockedOnTop" ng-model="unlockedOnTop.value"
                ng-true-value="'true'" ng-false-value="'false'"
                ng-model-options="{updateOn: 'default'}">
         {{unlockedOnTop.labelTranslateKey|translate}}

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -28,7 +28,6 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope) {
         $scope.clearFilters = function () {
             $scope.filtersVar = PostFilters.clearFilters();
         };
-
         $scope.enableQuery = function () {
             PostFilters.qEnabled = true;
         };

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -22,12 +22,15 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope) {
             view : 'map',
             role : []
         };
-
         $scope.applyFiltersLocked = function () {
             PostFilters.reactiveFilters = 'enabled';
         };
         $scope.clearFilters = function () {
             $scope.filtersVar = PostFilters.clearFilters();
+        };
+
+        $scope.enableQuery = function () {
+            PostFilters.qEnabled = true;
         };
         $scope.openSavedModal = function () {
             $scope.savedSearch.filter = $scope.filtersVar;

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -31,7 +31,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope) {
         $scope.enableQuery = function () {
             PostFilters.qEnabled = true;
         };
-        $scope.openSavedModal = function () {
+        $scope.saveSavedSearchModal = function () {
             $scope.savedSearch.filter = $scope.filtersVar;
             // @TODO Prevent the user from creating one if they somehow manage to get to this point without being logged in
             $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -24,9 +24,11 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope) {
         };
         $scope.applyFiltersLocked = function () {
             PostFilters.reactiveFilters = 'enabled';
+            $scope.filtersDropdownToggle = false;
         };
         $scope.clearFilters = function () {
             $scope.filtersVar = PostFilters.clearFilters();
+            $scope.filtersDropdownToggle = false;
         };
         $scope.enableQuery = function () {
             PostFilters.qEnabled = true;

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -18,7 +18,7 @@
             <post-active-search-filters ng-model="filtersVar" filters-var="filtersVar"></post-active-search-filters>
         </div>
         <div class="form-field">
-            <button type="button" class="button button-alpha button-right" ng-click="openSavedModal()">Save search</button>
+            <button type="button" class="button button-alpha button-right" ng-click="saveSavedSearchModal()">Save search</button>
         </div>
         <div class="divider"></div>
         <!-- sorting options -->

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -3,7 +3,7 @@
         <div class="form-field filter-buttons">
             <div ng-show="filtersVar.q.length > 0" ng-class="{active: (filtersVar.q.length > 0) }">
                 <div ng-class="{active: (filtersVar.q.length > 0) , 'form-field': 'form-field'}">
-                    <button type="submit" class="button-plain">
+                    <button class="button-plain" ng-click="enableQuery()">
                         <span class="button-label">
                             <span translate-values="{ entity: entityType }" translate>
                                 toolbar.searchbar.search_all_entities_for

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -25,7 +25,8 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         getMode: getMode,
         getModeId: getModeId,
         countFilters: countFilters,
-        reactiveFilters: 'enabled'
+        reactiveFilters: 'enabled',
+        qEnabled: false
     };
 
 

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -193,7 +193,10 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         // If mode changes, reset filters
         if (newMode !== filterMode) {
             filterMode = newMode;
-            clearFilters();
+            if (filterMode === 'collection') {
+                clearFilters();
+            }
+
         }
         entityId = id;
     }

--- a/app/main/posts/views/post-timeline-toolbox.directive.js
+++ b/app/main/posts/views/post-timeline-toolbox.directive.js
@@ -11,25 +11,17 @@ function PostTimelineToolboxDirective(
     return {
         restrict: 'E',
         scope: {
-            orderBy: '<',
-            order: '<',
-            onChange: '&'
+            filters: '='
         },
         template: require('./post-timeline-toolbox.html'),
         link: PostTimelineToolboxLink
     };
 
     function PostTimelineToolboxLink($scope) {
-        $scope.change = change;
-
         activate();
 
         function activate() {
 
-        }
-
-        function change() {
-            $scope.onChange({order: $scope.order, orderBy: $scope.orderBy});
         }
     }
 }

--- a/app/main/posts/views/post-timeline-toolbox.html
+++ b/app/main/posts/views/post-timeline-toolbox.html
@@ -11,30 +11,8 @@
       </span>
 
       <div class="toggle-content init" dropdown-menu>
-          <fieldset>
-              <div class="custom-select">
-                  <select ng-model="orderBy" ng-change="change()">
-                      <option value="post_date" translate="post.post_date">Post Date</option>
-                      <option value="created" translate="app.date_created">Date created</option>
-                      <option value="updated" translate="app.date_updated">Date updated</option>
-                  </select>
-              </div>
-        </fieldset>
-
-          <fieldset>
-              <div class="form-field radio">
-                  <label>
-                    <input type="radio" id="asc" value="asc" name="order" ng-model="order" ng-change="change()">
-                    <span translate="app.oldest_first">Oldest first</span>
-                  </label>
-              </div>
-              <div class="form-field radio">
-                  <label>
-                    <input type="radio" id="desc" value="desc" name="order" ng-model="order" ng-change="change()">
-                    <span translate="app.newest_first">Newest first</span>
-                  </label>
-              </div>
-          </fieldset>
+          <filter-post-sorting-options ng-model="filters.orderby"></filter-post-sorting-options>
+          <filter-post-order-asc-desc ng-model="filters.order"></filter-post-order-asc-desc>
       </div>
   </div>
 </div>

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -48,7 +48,10 @@ function PostViewDataController(
     $scope.loadMore = loadMore;
     $scope.editMode = {editing: false};
 
-    $rootScope.setLayout('layout-d');
+    if (PostFilters.getMode() !== 'collection' && PostFilters.getMode() !== 'savedsearch') {
+        $rootScope.setLayout('layout-d');
+    }
+
     activate();
     function activate() {
         getPosts();

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -43,8 +43,6 @@ function PostViewDataController(
     $scope.totalItems = $scope.itemsPerPage;
     $scope.posts = [];
     $scope.groupedPosts = {};
-    $scope.order = PostFilters.getDefaults().order;
-    $scope.orderby = PostFilters.getDefaults().orderby;
     $scope.showPost = showPost;
     $scope.loadMore = loadMore;
 

--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -115,9 +115,7 @@ function PostListController(
         query = query || PostFilters.getQueryParams($scope.filters);
         var postQuery = _.extend({}, query, {
             offset: ($scope.currentPage - 1) * $scope.itemsPerPage,
-            limit: $scope.itemsPerPage,
-            order: $scope.order,
-            orderby: $scope.orderby
+            limit: $scope.itemsPerPage
         });
         $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {

--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -104,6 +104,10 @@ function PostListController(
         $scope.order = order;
         $scope.orderby = orderBy;
         $scope.clearPosts = true;
+
+        $scope.filters.order = order;
+        $scope.filters.orderby = orderBy;
+
         getPosts();
     }
 

--- a/app/main/posts/views/post-view-list.html
+++ b/app/main/posts/views/post-view-list.html
@@ -65,7 +65,11 @@
 
         </listing-toolbar>
 
-        <post-timeline-toolbox order="order" order-by="orderBy" on-change="changeOrder(order, orderBy)"></post-timeline-toolbox>
+        <!--Leaving here as a reference of when the post-timeline-toolbox can be added and how
+        <post-timeline-toolbox filters="filters"></post-timeline-toolbox>
+        this was discussed with Jess about removing it to avoid confusion with filters being applied in
+        non reactive ways + reactive ways in the same screen
+        -->
 
         <div class="listing-item" ng-if="posts.length == 0 && hasFilters() && !isLoading.state">
             <h4 translate>post.no_search_results</h4>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.1-rc.30"
+    "ushahidi-platform-pattern-library": "v3.7.2-rc.3"
   },
   "engines": {
     "node": ">=4.0"

--- a/test/unit/main/post/views/filters/active-filters.directive.spec.js
+++ b/test/unit/main/post/views/filters/active-filters.directive.spec.js
@@ -15,6 +15,7 @@ describe('post active filters directive', function () {
         var testApp = makeTestApp();
 
         testApp.directive('postActiveFilters', require('app/main/posts/views/filters/active-filters.directive'))
+        .service('FilterTransformers', require('app/main/posts/views/filters/filter-transformers.service.js'))
         .value('$filter', function () {
             return function () {
                 return 'Feb 17, 2016';
@@ -23,8 +24,6 @@ describe('post active filters directive', function () {
 
         angular.mock.module('testApp');
     });
-
-
 
     beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _Notify_, _PostFilters_, _SavedSearchEndpoint_) {
         $rootScope = _$rootScope_;

--- a/test/unit/main/post/views/filters/active-search-filters.directive.spec.js
+++ b/test/unit/main/post/views/filters/active-search-filters.directive.spec.js
@@ -6,8 +6,8 @@ describe('post active search filters directive', function () {
         PostFilters,
         Notify,
         SavedSearchEndpoint,
-        element;
-
+        element,
+        $compile;
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
 
@@ -16,6 +16,7 @@ describe('post active search filters directive', function () {
 
         testApp.directive('postActiveSearchFilters', require('app/main/posts/views/filters/active-search-filters.directive'))
         .service('FilterTransformers', require('app/main/posts/views/filters/filter-transformers.service.js'))
+        .service('PostFilters', require('app/main/posts/views/post-filters.service.js'))
         .value('$filter', function () {
             return function () {
                 return 'Feb 17, 2016';
@@ -24,19 +25,35 @@ describe('post active search filters directive', function () {
 
         angular.mock.module('testApp');
     });
-
-    beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _Notify_, _PostFilters_, _SavedSearchEndpoint_) {
+    var defaults = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [1, 2, 3, 4],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _Notify_, _PostFilters_, _SavedSearchEndpoint_) {
+        $compile = _$compile_;
         $rootScope = _$rootScope_;
         $scope = _$rootScope_.$new();
         SavedSearchEndpoint = _SavedSearchEndpoint_;
         PostFilters = _PostFilters_;
         Notify = _Notify_;
-
-        $scope.filters = {
-            status: 'published',
-            published_to: ''
-        };
-
+        $rootScope.filters = defaults;
+        $scope.filters = defaults;
         element = '<post-active-search-filters ng-model="$scope.filters"></post-active-search-filters>';
         element = $compile(element)($scope);
         $scope.$digest();
@@ -76,6 +93,20 @@ describe('post active search filters directive', function () {
 
             expect(PostFilters.clearFilter).toHaveBeenCalled();
         });
-
+    });
+    describe('test clean filters', function () {
+        it ('should show the clean active search filters, which are different from their default value', function () {
+            spyOn(PostFilters, 'getActiveFilters').and.callThrough();
+            spyOn(PostFilters, 'getCleanActiveFilters').and.callThrough();
+            var elementDir = '<post-active-search-filters ng-model="$scope.filters"></post-active-search-filters>';
+            elementDir = $compile(elementDir)($scope);
+            var directiveScopeTest = elementDir.scope();
+            var newDefaults = defaults;
+            newDefaults.source = ['sms'];
+            PostFilters.setFilters(newDefaults);
+            $scope.$digest();
+            expect(PostFilters.getCleanActiveFilters).toHaveBeenCalled();
+            expect(directiveScopeTest.activeFilters).toEqual({source: ['sms'], form: [1,2,3,4]});
+        });
     });
 });

--- a/test/unit/main/post/views/filters/filter-post-order-asc-desc.spec.js
+++ b/test/unit/main/post/views/filters/filter-post-order-asc-desc.spec.js
@@ -1,0 +1,65 @@
+describe('filter post order ASC/DESC  directive', function () {
+
+    var
+        $scope,
+        element,
+        $rootScope,
+        isolateScope,
+        PostFilters;
+    var defaultFilters = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+        var testApp = makeTestApp();
+        testApp.directive('filterPostOrderAscDesc', require('app/main/posts/views/filters/filter-post-order-asc-desc.directive'))
+            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
+        angular.mock.module('testApp');
+    });
+    beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _PostFilters_) {
+        $rootScope = _$rootScope_;
+        PostFilters = _PostFilters_;
+        $scope = $rootScope.$new();
+        $scope.filters = defaultFilters;
+        element = '<filter-post-order-asc-desc ng-model="filters.order"></filter-post-order-asc-desc>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.isolateScope();
+    }));
+
+    describe('test order values', function () {
+        it('should be desc when we initialize the directive with default filters', function () {
+            expect(isolateScope.selectedValue.value).toEqual('desc');
+        });
+        it('$scope.filters and cleanActive filters should change when order changes', function () {
+            isolateScope.selectedValue.value = 'asc';
+            $rootScope.$digest();
+            /**
+             * Checks that order (which we send as ngModel) was updated on setViewValue
+             * this is pretty much all this directive does.
+             */
+            expect($scope.filters.order).toEqual('asc');
+            /**
+             * Checks that no other filters changed because of changing orderby
+             */
+            expect(PostFilters.getCleanActiveFilters($scope.filters)).toEqual({order: 'asc'});
+        });
+    });
+});

--- a/test/unit/main/post/views/filters/filter-post-sorting-options.directive.spec.js
+++ b/test/unit/main/post/views/filters/filter-post-sorting-options.directive.spec.js
@@ -1,0 +1,65 @@
+describe('filter post sorting options on top directive', function () {
+
+    var
+        $scope,
+        element,
+        $rootScope,
+        isolateScope,
+        PostFilters;
+    var defaultFilters = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+        var testApp = makeTestApp();
+        testApp.directive('filterPostSortingOptions', require('app/main/posts/views/filters/filter-post-sorting-options.directive'))
+            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
+        angular.mock.module('testApp');
+    });
+    beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _PostFilters_) {
+        $rootScope = _$rootScope_;
+        PostFilters = _PostFilters_;
+        $scope = $rootScope.$new();
+        $scope.filters = defaultFilters;
+        element = '<filter-post-sorting-options ng-model="filters.orderby"></filter-post-sorting-options>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.isolateScope();
+    }));
+
+    describe('test orderby values', function () {
+        it('should be 0 when we initialize the directive with default filters', function () {
+            expect(isolateScope.orderValue.value).toEqual('created');
+        });
+        it('$scope.filters and cleanActive filters should change when orderby changes', function () {
+            isolateScope.orderValue.value = 'updated';
+            $rootScope.$digest();
+            /**
+             * Checks that orderby (which we send as ngModel) was updated on setViewValue
+             * this is pretty much all this directive does.
+             */
+            expect($scope.filters.orderby).toEqual('updated');
+            /**
+             * Checks that no other filters changed because of changing orderby
+             */
+            expect(PostFilters.getCleanActiveFilters($scope.filters)).toEqual({orderby: 'updated'});
+        });
+    });
+});

--- a/test/unit/main/post/views/filters/filter-unlocked-on-top.directive.spec.js
+++ b/test/unit/main/post/views/filters/filter-unlocked-on-top.directive.spec.js
@@ -1,0 +1,73 @@
+describe('filter unlocked on top directive', function () {
+
+    var
+        $scope,
+        element,
+        $rootScope,
+        isolateScope,
+        FilterTransformers,
+        PostFilters;
+
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+        var testApp = makeTestApp();
+        testApp.directive('filterUnlockedOnTop', require('app/main/posts/views/filters/filter-unlocked-on-top.directive'))
+                .service('FilterTransformers', require('app/main/posts/views/filters/filter-transformers.service.js'))
+                .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
+        angular.mock.module('testApp');
+    });
+    beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _FilterTransformers_, _PostFilters_) {
+        $rootScope = _$rootScope_;
+        FilterTransformers = _FilterTransformers_;
+        PostFilters = _PostFilters_;
+        spyOn(FilterTransformers.transformers, 'order_unlocked_on_top');
+        $scope = $rootScope.$new();
+        $scope.filters = {
+            q: '',
+            date_after: '',
+            date_before: '',
+            status: ['published', 'draft'],
+            published_to: '',
+            center_point: '',
+            has_location: 'all',
+            within_km: '1',
+            current_stage: [],
+            tags: [],
+            saved_search: '',
+            orderby: 'created',
+            order: 'desc',
+            order_unlocked_on_top: 'true',
+            form: [],
+            set: [],
+            user: false,
+            source: ['sms', 'twitter','web', 'email']
+        };
+        // $scope.models = {};
+        // $scope.models.modelUnlocked = 'true';
+        element = '<filter-unlocked-on-top ng-model="filters.order_unlocked_on_top"></filter-unlocked-on-top>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.isolateScope();
+        spyOn(PostFilters, 'getCleanActiveFilters').and.callThrough();
+        spyOn(PostFilters, 'getFilters').and.callThrough();
+    }));
+
+    describe('test directive functions', function () {
+        it('unlockedOnTop value should be true by default', function () {
+            expect(isolateScope.unlockedOnTop.value).toEqual('true');
+        });
+        it('$scope.filters and cleanActive filters should change when unlockedOnTop changes', function () {
+            isolateScope.unlockedOnTop.value = 'false';
+            $rootScope.$digest();
+            /**
+             * Checks that order_unlocked_on_top (which we send as ngModel) was updated on setViewValue
+             * this is pretty much all this directive does.
+             */
+            expect($scope.filters.order_unlocked_on_top).toEqual('false');
+            /**
+             * Checks that no other filters changed because of changing order_unlocked_on_top
+             */
+            expect(PostFilters.getCleanActiveFilters($scope.filters)).toEqual({order_unlocked_on_top: 'false'});
+        });
+    });
+});

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -1,0 +1,86 @@
+describe('post active search filters directive', function () {
+
+    var $rootScope,
+        $scope,
+        PostFilters,
+        ModalService,
+        SavedSearchEndpoint,
+        element,
+        isolateScope,
+        $compile;
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+
+
+        var testApp = makeTestApp();
+
+        testApp.directive('filtersDropdown', require('app/main/posts/views/filters/filters-dropdown.directive'))
+            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'))
+            .value('$filter', function () {
+                return function () {
+                    return 'Feb 17, 2016';
+                };
+            });
+
+        angular.mock.module('testApp');
+    });
+    var defaults = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [1, 2, 3, 4],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _ModalService_, _PostFilters_, _SavedSearchEndpoint_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $scope = _$rootScope_.$new();
+        SavedSearchEndpoint = _SavedSearchEndpoint_;
+        PostFilters = _PostFilters_;
+        ModalService = _ModalService_;
+        $rootScope.filters = defaults;
+        $scope.filters = defaults;
+        element = '<filters-dropdown filters-var="$scope.filters" ng-model="$scope.filters"></filters-dropdown>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.isolateScope();
+
+    }));
+
+    describe('test directive functions', function () {
+        it('reactiveFilters should be false', function () {
+            expect(PostFilters.reactiveFilters).toEqual('disabled');
+        });
+        it('should enable reactiveFilters when I call applyFiltersLocked', function () {
+            expect(PostFilters.reactiveFilters).toEqual('disabled');
+            isolateScope.applyFiltersLocked();
+            expect(PostFilters.reactiveFilters).toEqual('enabled');
+        });
+        it('should clear PostFilters when calling clearFilters', function () {
+            isolateScope.clearFilters();
+            expect(isolateScope.filtersVar).toEqual(PostFilters.getDefaults());
+        });
+        it('should set qEnabled true when I call enableQuery', function () {
+            isolateScope.enableQuery();
+            expect(PostFilters.qEnabled).toEqual(true);
+        });
+        it('should call saved-search-modal once when I call openSavedModal', function () {
+            spyOn(ModalService, 'openTemplate');
+            isolateScope.openSavedModal();
+            expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -7,21 +7,15 @@ describe('post active search filters directive', function () {
         SavedSearchEndpoint,
         element,
         isolateScope,
+        FilterTransformers,
         $compile;
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
-
-
         var testApp = makeTestApp();
-
-        testApp.directive('filtersDropdown', require('app/main/posts/views/filters/filters-dropdown.directive'))
-            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'))
-            .value('$filter', function () {
-                return function () {
-                    return 'Feb 17, 2016';
-                };
-            });
-
+        testApp.directive('postActiveSearchFilters', require('app/main/posts/views/filters/active-search-filters.directive'))
+        .directive('filtersDropdown', require('app/main/posts/views/filters/filters-dropdown.directive'))
+        .service('FilterTransformers', require('app/main/posts/views/filters/filter-transformers.service.js'))
+        .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
         angular.mock.module('testApp');
     });
     var defaults = {
@@ -44,13 +38,14 @@ describe('post active search filters directive', function () {
         user: false,
         source: ['sms', 'twitter','web', 'email']
     };
-    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _ModalService_, _PostFilters_, _SavedSearchEndpoint_) {
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _ModalService_, _PostFilters_, _SavedSearchEndpoint_, _FilterTransformers_) {
         $compile = _$compile_;
         $rootScope = _$rootScope_;
         $scope = _$rootScope_.$new();
         SavedSearchEndpoint = _SavedSearchEndpoint_;
         PostFilters = _PostFilters_;
         ModalService = _ModalService_;
+        FilterTransformers = _FilterTransformers_;
         $rootScope.filters = defaults;
         $scope.filters = defaults;
         element = '<filters-dropdown filters-var="$scope.filters" ng-model="$scope.filters"></filters-dropdown>';
@@ -81,6 +76,20 @@ describe('post active search filters directive', function () {
             spyOn(ModalService, 'openTemplate');
             isolateScope.openSavedModal();
             expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('test children', function () {
+        it('should have a filter-post-order-asc-desc directive child', function () {
+            expect(element.find('filter-post-sorting-options').length).toEqual(1);
+            expect(element.find('filter-post-order-asc-desc').length).toEqual(1);
+            expect(element.find('filter-unlocked-on-top').length).toEqual(1);
+            expect(element.find('filter-saved-search').length).toEqual(1);
+            expect(element.find('filter-status').length).toEqual(1);
+            expect(element.find('filter-category').length).toEqual(1);
+            expect(element.find('filter-form').length).toEqual(1);
+            expect(element.find('filter-source').length).toEqual(1);
+            expect(element.find('filter-date').length).toEqual(1);
+            expect(element.find('filter-location').length).toEqual(1);
         });
     });
 });

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -72,9 +72,9 @@ describe('post active search filters directive', function () {
             isolateScope.enableQuery();
             expect(PostFilters.qEnabled).toEqual(true);
         });
-        it('should call saved-search-modal once when I call openSavedModal', function () {
+        it('should call saved-search-modal once when I call saveSavedSearchModal', function () {
             spyOn(ModalService, 'openTemplate');
-            isolateScope.openSavedModal();
+            isolateScope.saveSavedSearchModal();
             expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
         });
     });

--- a/test/unit/main/post/views/filters/post-filters.service.spec.js
+++ b/test/unit/main/post/views/filters/post-filters.service.spec.js
@@ -35,7 +35,11 @@ describe('Post Filters Service', function () {
             var filters = PostFilters.getActiveFilters(PostFilters.getFilters());
             expect(filters.tags).toEqual(['test']);
         });
-
+        it('getCleanActiveFilters should return only the difference between the default filters and the currently set filters', function () {
+            PostFilters.setFilters({ tags : ['test']});
+            var filters = PostFilters.getCleanActiveFilters(PostFilters.getFilters());
+            expect(filters).toEqual({tags: ['test']});
+        });
         it('should return status filter if different from defaults', function () {
             var filters = PostFilters.getActiveFilters({ status: ['draft'] });
             expect(filters.status).toEqual(['draft']);

--- a/test/unit/main/post/views/filters/sort-and-filter-counter.directive.spec.js
+++ b/test/unit/main/post/views/filters/sort-and-filter-counter.directive.spec.js
@@ -1,0 +1,73 @@
+describe('filter unlocked on top directive', function () {
+
+    var
+        $scope,
+        element,
+        $rootScope,
+        isolateScope,
+        PostFilters;
+    var defaultFilters = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+        var testApp = makeTestApp();
+        testApp.directive('sortAndFilterCounter', require('app/main/posts/views/filters/sort-and-filter-counter.directive'))
+            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
+        angular.mock.module('testApp');
+    });
+    beforeEach(angular.mock.inject(function (_$rootScope_, $compile, _PostFilters_) {
+        $rootScope = _$rootScope_;
+        PostFilters = _PostFilters_;
+        $scope = $rootScope.$new();
+        PostFilters.setFilters(defaultFilters);
+        // $scope.models = {};
+        // $scope.models.modelUnlocked = 'true';
+        element = '<sort-and-filter-counter></sort-and-filter-counter>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        isolateScope = element.isolateScope();
+    }));
+
+    describe('filtersCount value', function () {
+        it('should be 0 when we initialize the directive with default filters', function () {
+            expect(isolateScope.filtersCount).toEqual(0);
+        });
+        it('should be 1 when we change a filter to a non default value', function () {
+            defaultFilters.order_unlocked_on_top = 'false';
+            PostFilters.setFilters(defaultFilters);
+            $scope.$digest();
+            /**
+             * Checks that no other filters changed because of changing order_unlocked_on_top
+             */
+            expect(isolateScope.filtersCount).toEqual(1);
+
+        });
+        it('should be 0 when we change a filter back to the default value', function () {
+            defaultFilters.order_unlocked_on_top = 'true';
+            PostFilters.setFilters(defaultFilters);
+            $scope.$digest();
+            /**
+             * Checks that no other filters changed because of changing order_unlocked_on_top
+             */
+            expect(isolateScope.filtersCount).toEqual(0);
+        });
+    });
+});

--- a/test/unit/main/post/views/post-view-map.directive.spec.js
+++ b/test/unit/main/post/views/post-view-map.directive.spec.js
@@ -11,7 +11,8 @@ describe('post view map directive', function () {
         map,
         geojson,
         markers,
-        element;
+        element,
+        PostFilters;
 
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
@@ -26,12 +27,13 @@ describe('post view map directive', function () {
         angular.mock.module('testApp');
     });
 
-    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _Notify_, _Maps_, _PostEndpoint_, $q) {
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _Notify_, _Maps_, _PostEndpoint_, $q, _PostFilters_) {
         $rootScope = _$rootScope_;
         $compile = _$compile_;
         Notify = _Notify_;
         Maps = _Maps_;
         PostEndpoint = _PostEndpoint_;
+        PostFilters = _PostFilters_;
 
         map = L.map(document.createElement('div'), {
             center: [0,1],
@@ -144,5 +146,94 @@ describe('post view map directive', function () {
             layer: child
         });
         expect(child.openPopup.calls.count()).toEqual(2);
+    });
+    it('does not call PostEndpoint.geojson when filter.q changes and qEnabled is false', function () {
+        /**
+         * create directive with isolate scope
+         */
+        element = $compile(element)($scope);
+        $rootScope.$digest();
+        isolateScope = element.isolateScope();
+        spyOn(isolateScope, 'loadPosts').and.callThrough();
+        /**
+         * Set default qEnabled value to ensure we are dealing
+         * with the directive's logic and not the postFilters defaults
+         * @type {boolean}
+         */
+        isolateScope.$apply(function () {
+            isolateScope.filters = {
+                q : 'U'
+            };
+        });
+        /**
+         * When we initially setup the directive Postendpoint's geojson should
+         * only be called once.
+         */
+        expect(L.geoJson.calls.count()).toEqual(1);
+
+        expect(PostEndpoint.geojson).toHaveBeenCalledTimes(1);
+        /**
+         * Apply q filter to scope. Don't change qEnabled to true.
+         * This should not call PostEndpoint.geojson because the app doesn't
+         * care for changes in the input until the qEnabled property is true
+         */
+        isolateScope.$apply(function () {
+            isolateScope.filters = {
+                q : 'U'
+            };
+        });
+        $rootScope.$digest();
+        expect(PostEndpoint.geojson).toHaveBeenCalledTimes(1);
+        /**
+         * Enable q so that loadPosts is called.
+         * @type {boolean}
+         */
+        PostFilters.qEnabled = true;
+        $rootScope.$digest();
+        expect(isolateScope.loadPosts.calls.count()).toEqual(2);
+
+        /**
+         * Change q twice. qEnabled is now false because we already 'clicked'and set it back to false.
+         * This means loadPosts should be called zero times when we apply our q filter changes at the
+         * moment.
+         */
+        isolateScope.$apply(function () {
+            isolateScope.filters = {
+                q : 'Us'
+            };
+        });
+        $rootScope.$digest();
+        isolateScope.$apply(function () {
+            isolateScope.filters = {
+                q : 'Ushahidi'
+            };
+        });
+        $rootScope.$digest();
+        /**
+         * qEnabled is set to false successfuly if this equals 2
+         */
+        expect(isolateScope.loadPosts.calls.count()).toEqual(2);
+
+        /**
+         * Set qEnabled to true. This should generate 2 more call to loadPosts,
+         * because of how the basic setup is done, within_km generates a second
+         * watch being triggered when we call getQueryParams
+         *
+         *
+         */
+        PostFilters.qEnabled = true;
+        $rootScope.$digest();
+        expect(isolateScope.loadPosts.calls.count()).toEqual(4);
+        /**
+         * If I (for whatever reason) enable qEnabled with no changes,
+         * loadPosts is still called. This is because we are actually changing
+         * the filters and cannot avoid it without impacting the feature, so it's
+         * the expected behavior.
+         * @type {boolean}
+         */
+        PostFilters.qEnabled = true;
+        $rootScope.$digest();
+        expect(isolateScope.loadPosts.calls.count()).toEqual(5);
+
     });
 });

--- a/test/unit/mock/services/post-filters.js
+++ b/test/unit/mock/services/post-filters.js
@@ -33,6 +33,7 @@ module.exports = [function () {
     var filterMode = 'all';
 
     return {
+        qEnabled: false,
         filterState: filterState,
         getDefaults: function () {
             return defaultFilters;

--- a/test/unit/mock/services/post-filters.js
+++ b/test/unit/mock/services/post-filters.js
@@ -47,6 +47,9 @@ module.exports = [function () {
         clearFilters: function () {},
         clearFilter: function () {},
         hasFilters: function () {},
+        getCleanActiveFilters: function (filters) {
+            return filters;
+        },
         getActiveFilters: function (filters) {
             return filters;
         },


### PR DESCRIPTION

This pull request makes the following changes:

- I can switch between views (Data & Map) without losing my active filter options
    - 2091: Saved search filter remains active when switching between map and data views
    - 2091: post order options filter remains active when switching between map and data views
    - 2091: asc desc order filter remains active when switching between map and data views
    - 2091: unlocked on top remains active when switching between map and data views

- I can write a search query witouth it generating a .get request for each key change while I type. When I click the "Search all " button in the dropdown the search query is enabled once. 
- Adds some basic tests for dropdown directive
- Moves filtertransformers out of active filters directive
- Adds basic tests for active clean filters (diff only)


Testing checklist:

 Add filters (one of each)
- [x] When you switch between map and data views, you should have all your filters still enabled.
- [x] When you write a query in the searchbar, you should only see the loading bar change after clicking the Search all button .

Pending for a different PR: Categories and Surveys cannot be filtered together, there is some logic that replaces them for some reason. I need to look into that and find out if it's an intended feature or a bug

Fixes ushahidi/platform# .

Ping @ushahidi/platform#2091