### PR TITLE
Post pane structuring

### DIFF
--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -8,7 +8,8 @@ function PostDetailData() {
         scope: {
             filters: '=',
             isLoading: '=',
-            post: '='
+            post: '=',
+            editMode: '='
         },
         controller: PostDetailDataController,
         template: require('./post-detail-data.html')

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -3,13 +3,12 @@
 
         <div class="postcard-body"> 
             <div ng-if="post.form">
-            <h1 class="form-sheet-title survey-title">{{post.form.name}}</h1>
-            <p>{{post.form.description}}</p>
-                    </div>
+              <h1 class="form-sheet-title survey-title">{{post.title}}</h1>
+            </div>
 
             <div class="postcard-header">
                 <post-metadata post="post" hide-date-this-week="true"></post-metadata>
-                <post-actions post="post"></post-actions>
+                <post-actions  edit-mode="editMode" post="post"></post-actions>
             </div>
             <div
           ng-repeat="(key,value) in post.values"

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -4,6 +4,7 @@
         <div class="postcard-body"> 
             <div ng-if="post.form">
               <h1 class="form-sheet-title survey-title">{{post.title}}</h1>
+              <p>{{post.content}}</p>
             </div>
 
             <div class="postcard-header">

--- a/app/main/posts/detail/post-value.html
+++ b/app/main/posts/detail/post-value.html
@@ -14,11 +14,10 @@
         </p>
       </div>
 
-      
-      <div ng-repeat="entry in value" ng-if="attribute.type === 'relation'">
+      <div ng-repeat="entry in value track by $index" ng-if="attribute.type === 'relation'">
           <a ng-href="/posts/{{entry.id}}">{{entry.title}}</a>
       </div>
-      <div ng-repeat="entry in value" ng-if="attribute.type !== 'relation' && attribute.input !== 'tags'">
+     <div ng-repeat="entry in value track by $index" ng-if="attribute.type !== 'relation' && attribute.input !== 'tags'">
           <p ng-if="attribute.type !== 'markdown'">{{entry}}</p>
           <p ng-if="attribute.type === 'markdown'" markdown-to-html="entry"></p>
       </div>

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -108,8 +108,8 @@ function PostDataEditorController(
         if ($scope.post.form) {
             $scope.selectForm();
         } else {
-            FormEndpoint.get().$promise.then(function (results) {
-                $scope.forms = results.results;
+            FormEndpoint.queryFresh().$promise.then(function (results) {
+                $scope.forms = results;
             });
         }
 

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -96,6 +96,11 @@ function PostDataEditorController(
         }
     });
 
+    $scope.$on('$locationChangeStart', function (e) {
+        e.preventDefault();
+        $scope.leavePost();
+    });
+
     activate();
 
     function activate() {

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -6,7 +6,7 @@ function PostDataEditor() {
     return {
         restrict: 'E',
         scope: {
-            postToEdit: '=',
+            postContainer: '=',
             attributesToIgnore: '=',
             postMode: '=',
             editMode: '='
@@ -63,7 +63,7 @@ function PostDataEditorController(
   ) {
 
     // Setup initial stages container
-    $scope.post = angular.copy($scope.postToEdit);
+    $scope.post = angular.copy($scope.postContainer.post);
     $scope.everyone = $filter('translate')('post.modify.everyone');
     $scope.isEdit = !!$scope.post.id;
     $scope.validationErrors = [];
@@ -318,7 +318,7 @@ function PostDataEditorController(
             }
             request.$promise.then(function (response) {
                 var success_message = (response.status && response.status === 'published') ? 'notify.post.save_success' : 'notify.post.save_success_review';
-                $scope.postToEdit = post;
+                $scope.postContainer.post = $scope.post;
                 if (response.id && response.allowed_privileges.indexOf('read') !== -1) {
                     $scope.saving_post = false;
                     $scope.post.id = response.id;

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -85,6 +85,7 @@ function PostDataEditorController(
     $scope.submitting = $translate.instant('app.submitting');
     $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
     $scope.leavePost = leavePost;
+    $scope.selectForm = selectForm;
     $rootScope.$on('event:edit:post:data:mode:save', function () {
         $scope.savePost();
     });
@@ -104,6 +105,23 @@ function PostDataEditorController(
     activate();
 
     function activate() {
+        if ($scope.post.form) {
+            $scope.selectForm();
+        } else {
+            FormEndpoint.get().$promise.then(function (results) {
+                $scope.forms = results.results;
+            });
+        }
+
+        $scope.medias = {};
+        $scope.savingText = $translate.instant('app.saving');
+        $scope.submittingText = $translate.instant('app.submitting');
+    }
+
+    function setVisibleStage(stageId) {
+        $scope.visibleStage = stageId;
+    }
+    function selectForm() {
         $scope.form = $scope.post.form;
         $scope.fetchAttributesAndTasks($scope.post.form.id)
         .then(function () {
@@ -116,14 +134,6 @@ function PostDataEditorController(
                 }
             });
         });
-
-        $scope.medias = {};
-        $scope.savingText = $translate.instant('app.saving');
-        $scope.submittingText = $translate.instant('app.submitting');
-    }
-
-    function setVisibleStage(stageId) {
-        $scope.visibleStage = stageId;
     }
 
     function fetchAttributesAndTasks(formId) {

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -53,16 +53,16 @@
             class="form-field init required"
             ng-class="{'error': postForm.form.$invalid && postForm.form.$dirty, 'success': !postForm.form.$invalid && postForm.form.$dirty}"
           >
-          <label translate>app.surveys</label>
-            <select
+          <p translate="post.unstructured.add_survey.info" translate-values="{source:post.source}"></p>
+          <label translate>post.unstructured.add_survey.title</label>
+              <select
               class="custom-select"
               ng-change="selectForm(form)"
               ng-model="post.form"
             >
-              <option disabled>Select a form</option>
+              <option selected disabled translate>post.unstructured.add_survey.choose</option>
               <option ng-repeat="form in forms" ng-value="form">{{form.name}}</option>
             </select>
-
           <div class="alert error" ng-show="postForm.form.$dirty" ng-repeat="(error, value) in postForm.form.$error">
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -112,5 +112,4 @@
           <button class="button button-alpha" ng-click="savePost()">Save</button>
         </div>
       </div>
-    </div>
   </form>

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -30,7 +30,6 @@
             <span translate="{{'post.valid.title.' + error}}"></span>
           </div>
         </div>
-
         <!-- Post stage default fields -->
         <div
           class="form-field init required"
@@ -48,8 +47,29 @@
             <span translate="{{'post.valid.content.' + error}}"></span>
           </div>
         </div>
-
         <!-- End post stage default fields -->
+          <div
+            ng-if="!form"
+            class="form-field init required"
+            ng-class="{'error': postForm.form.$invalid && postForm.form.$dirty, 'success': !postForm.form.$invalid && postForm.form.$dirty}"
+          >
+          <label translate>app.surveys</label>
+            <select
+              class="custom-select"
+              ng-change="selectForm(form)"
+              ng-model="post.form"
+            >
+              <option disabled>Select a form</option>
+              <option ng-repeat="form in forms" ng-value="form">{{form.name}}</option>
+            </select>
+
+          <div class="alert error" ng-show="postForm.form.$dirty" ng-repeat="(error, value) in postForm.form.$error">
+            <svg class="iconic">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+            </svg>
+            <span translate="{{'post.valid.content.' + error}}"></span>
+          </div>
+          </div>
 
         <!-- Start Post custom fields -->
 
@@ -60,6 +80,7 @@
             form="postForm"
             medias="medias"
             attribute="attribute"
+            ng-if="form"
         ></post-value-edit>
         <!-- End Post custom fields -->
         <!-- IF: Editing an existing post -->
@@ -71,7 +92,7 @@
         END: IF -->
         <!-- IF: User has permission to see other 'Tasks' -->
 
-        <post-toolbox post="post"></post-toolbox>
+        <post-toolbox post="post" ng-if="form"></post-toolbox>
        <post-tabs
            ng-show="tasks.length > 1"
            form="postForm"
@@ -79,7 +100,8 @@
            stages="tasks"
            attributes="attributes"
            medias="medias"
-           visible-stage="visibleStage">
+           visible-stage="visibleStage"
+          ng-if="form"        >
         </post-tabs>
       </fieldset>
     </div>
@@ -90,4 +112,5 @@
           <button class="button button-alpha" ng-click="savePost()">Save</button>
         </div>
       </div>
+    </div>
   </form>

--- a/app/main/posts/modify/post-edit.service.js
+++ b/app/main/posts/modify/post-edit.service.js
@@ -25,7 +25,6 @@ function (
             // First get tasks to be validated
             // The post task is always validated
             // Other tasks are only validated if marked completed
-
             var isPostValid = true;
             var tasks_to_validate = [];
 
@@ -37,6 +36,10 @@ function (
 
             // Validate Post default fields
             if (!form) {
+                return false;
+            }
+
+            if (!post.form) {
                 return false;
             }
 

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -83,14 +83,14 @@ function PostViewDataController(
         if ($scope.editMode.editing) {
             Notify.confirmLeave('notify.post.leave_without_save').then(function () {
                 $scope.editMode.editing = false;
-                $scope.selectedPost = post;
+                $scope.selectedPost = {post: post};
                 $scope.selectedPostId = post.id;
             });
         } else if (post.id !== $scope.selectedPostId) {
-            $scope.selectedPost = post;
+            $scope.selectedPost = {post: post};
             $scope.selectedPostId = post.id;
         } else {
-            $scope.selectedPost = null;
+            $scope.selectedPost = {post: null};
             $scope.selectedPostId = null;
         }
     }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -23,7 +23,8 @@ PostViewDataController.$inject = [
 'PostEndpoint',
 'PostViewService',
 'moment',
-'$translate'
+'$translate',
+'Notify'
 ];
 
 function PostViewDataController(
@@ -34,7 +35,8 @@ function PostViewDataController(
     PostEndpoint,
     PostViewService,
     moment,
-    $translate
+    $translate,
+    Notify
 ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
@@ -76,7 +78,14 @@ function PostViewDataController(
     }
 
     function showPost(post) {
-        if (post.id !== $scope.selectedPostId) {
+        // displaying warning if user is in editmode when trying to change post
+        if ($scope.editMode.editing) {
+            Notify.confirmLeave('notify.post.leave_without_save').then(function () {
+                $scope.editMode.editing = false;
+                $scope.selectedPost = post;
+                $scope.selectedPostId = post.id;
+            });
+        } else if (post.id !== $scope.selectedPostId) {
             $scope.selectedPost = post;
             $scope.selectedPostId = post.id;
         } else {

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,5 +1,5 @@
 <div class="flex-container">
-    <post-toolbar is-loading="isLoading" current-view="currentView" selected-post="selectedPost" edit-mode="editMode" filters="filters"></post-toolbar>
+    <post-toolbar is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
 
     <div class="timeline-col">
         <div class="listing timeline init">
@@ -7,7 +7,7 @@
             <post-card
                 ng-repeat="post in posts"
                 can-select="false"
-                post="post"
+                post="post.id === selectedPostId ? selectedPost.post : post"
                 selected-posts="selectedPosts"
                 click-action="showPost"
                 in-focus="selectedPostId === post.id",
@@ -25,6 +25,6 @@
         </div>
     </div>
     <div class="post-col">
-        <post-detail-data ng-if="selectedPost && !editMode.editing" edit-mode="editMode" filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
-        <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-to-edit="selectedPost"></post-data-editor>
+        <post-detail-data ng-if="selectedPost.post && !editMode.editing" edit-mode="editMode" filters="filters" is-loading="isLoading" post="selectedPost.post"></post-detail-data>
+        <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-container="selectedPost"></post-data-editor>
 </div>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -25,6 +25,6 @@
         </div>
     </div>
     <div class="post-col">
-        <post-detail-data ng-if="selectedPost && !editMode.editing" filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
+        <post-detail-data ng-if="selectedPost && !editMode.editing" edit-mode="editMode" filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
         <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-to-edit="selectedPost"></post-editor>
 </div>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -26,5 +26,5 @@
     </div>
     <div class="post-col">
         <post-detail-data ng-if="selectedPost && !editMode.editing" edit-mode="editMode" filters="filters" is-loading="isLoading" post="selectedPost"></post-detail-data>
-        <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-to-edit="selectedPost"></post-editor>
+        <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-to-edit="selectedPost"></post-data-editor>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- displaying warning if user tries to navigate away from edit-screen without saving
- makes edit-button on post-detail work
- adds form-selection to unstructured posts in edit-mode

Testing checklist:
- [ ] Go to edit-mode, make a change and try navigate away, a warning should appear
- [ ] Click on ... on post-detail-pane, choose edit --> edit-screen should appear
- [ ] Choose an unstructured post, a dropdown should appear with forms to select
- [ ] Select a form, the form-attributes should appear.

Fixes ushahidi/platform# .

Ping @ushahidi/platform
