### PR TITLE
2102 bulk actions

### DIFF
--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -1,7 +1,7 @@
 <article ng-class="['postcard', {selected: inFocus}]" ng-click="clickAction(post)">
     <div class="post-band" ng-style="{backgroundColor: post.form.color}"></div>
     <div class="listing-item-select">
-        <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
+        <input ng-if="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
     </div>
     <div class="postcard-body">
       <header class="postcard-header">

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -1,7 +1,7 @@
 <article ng-class="['postcard', {selected: inFocus}]" ng-click="clickAction(post)">
     <div class="post-band" ng-style="{backgroundColor: post.form.color}"></div>
     <div class="listing-item-select">
-        <input ng-if="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
+        <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
     </div>
     <div class="postcard-body">
       <header class="postcard-header">

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -19,6 +19,9 @@ function PostCardDirective(FormEndpoint, $rootScope) {
             $rootScope.$on('bulkActionsSelected:true', function () {
                 $scope.canSelect = true;
             });
+            $rootScope.$on('bulkActionsSelected:false', function () {
+                $scope.canSelect = false;
+            });
             activate();
 
             function activate() {

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -1,7 +1,7 @@
 module.exports = PostCardDirective;
 
-PostCardDirective.$inject = ['FormEndpoint'];
-function PostCardDirective(FormEndpoint) {
+PostCardDirective.$inject = ['FormEndpoint', '$rootScope'];
+function PostCardDirective(FormEndpoint, $rootScope) {
     return {
         restrict: 'E',
         replace: true,
@@ -16,7 +16,9 @@ function PostCardDirective(FormEndpoint) {
         },
         template: require('./card.html'),
         link: function ($scope) {
-
+            $rootScope.$on('bulkActionsSelected:true', function () {
+                $scope.canSelect = true;
+            });
             activate();
 
             function activate() {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -25,7 +25,7 @@ PostViewDataController.$inject = [
 'moment',
 '$translate',
 '$q',
-'PostActionsService'
+'PostActionsService',
 '$timeout',
 '$location',
 '$anchorScroll',
@@ -213,7 +213,7 @@ function PostViewDataController(
         })
         ;
     }
- 
+
     function createPostGroups(posts) {
         var now = moment(),
             yesterday = moment().subtract(1, 'days');
@@ -274,7 +274,8 @@ function PostViewDataController(
         return _.any($scope.posts, function (post) {
             return _.intersection(post.allowed_privileges, ['update', 'delete', 'change_status']).length > 0;
         });
-      
+    }
+
     function getNewPosts() {
         var existingFilters = PostFilters.getQueryParams($scope.filters);
         var filterDate = moment(existingFilters.date_before).format('MMM Do YY');

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -37,7 +37,7 @@ function PostViewDataController(
     moment,
     $translate,
     Notify
-) {
+ ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
     $scope.itemsPerPageOptions = [10, 20, 50];

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -145,7 +145,6 @@ function PostViewDataController(
     }
 
     function loadMore() {
-        console.log("loading?")
         // Increment page
         $scope.currentPage++;
         $scope.clearPosts = false;
@@ -153,7 +152,6 @@ function PostViewDataController(
     }
 
     function selectBulkActions() {
-        console.log("clicking bulk acitions")
         $scope.bulkActionsSelected = true;
     }
 }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -26,7 +26,7 @@ PostViewDataController.$inject = [
 '$translate',
 'Notify',
 '$q',
-'PostActionsService',
+'PostActionsService'
 ];
 
 function PostViewDataController(
@@ -41,7 +41,6 @@ function PostViewDataController(
     Notify,
     $q,
     PostActionsService
-
  ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
@@ -64,9 +63,6 @@ function PostViewDataController(
     $scope.selectBulkActions = selectBulkActions;
     $scope.bulkActionsSelected = '';
     $scope.closeBulkActions = closeBulkActions;
-    
-    
-
 
     if (PostFilters.getMode() !== 'collection' && PostFilters.getMode() !== 'savedsearch') {
         $rootScope.setLayout('layout-d');

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -24,7 +24,9 @@ PostViewDataController.$inject = [
 'PostViewService',
 'moment',
 '$translate',
-'Notify'
+'Notify',
+'$q',
+'PostActionsService',
 ];
 
 function PostViewDataController(
@@ -36,7 +38,10 @@ function PostViewDataController(
     PostViewService,
     moment,
     $translate,
-    Notify
+    Notify,
+    $q,
+    PostActionsService
+
  ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
@@ -46,11 +51,21 @@ function PostViewDataController(
     $scope.totalItems = $scope.itemsPerPage;
     $scope.posts = [];
     $scope.groupedPosts = {};
+    $scope.deletePosts = deletePosts;
+    $scope.userHasBulkActionPermissions = userHasBulkActionPermissions;
+    $scope.statuses = PostActionsService.getStatuses();
+    $scope.changeStatus = changeStatus;
     $scope.showPost = showPost;
     $scope.loadMore = loadMore;
+    $scope.resetPosts = resetPosts;
+    $scope.clearPosts = false;
+    $scope.clearSelectedPosts = clearSelectedPosts;
     $scope.editMode = {editing: false};
     $scope.selectBulkActions = selectBulkActions;
-    $scope.bulkActionsSelected = false;
+    $scope.bulkActionsSelected = '';
+    $scope.closeBulkActions = closeBulkActions;
+    
+    
 
 
     if (PostFilters.getMode() !== 'collection' && PostFilters.getMode() !== 'savedsearch') {
@@ -79,6 +94,10 @@ function PostViewDataController(
                 PostFilters.reactiveFilters = 'disabled';
             }
         }, true);
+
+        $scope.$watch('selectedPosts.length', function () {
+            $scope.$emit('post:list:selected', $scope.selectedPosts);
+        });
     }
 
     function showPost(post) {
@@ -130,6 +149,70 @@ function PostViewDataController(
         });
     }
 
+    function deletePosts() {
+        Notify.confirmDelete('notify.post.bulk_destroy_confirm', { count: $scope.selectedPosts.length }).then(function () {
+            // ask server to delete selected posts
+            // and refetch posts from server
+            $scope.isLoading.state = true;
+            var deletePostsPromises = _.map(
+                $scope.selectedPosts,
+                function (postId) {
+                    $scope.selectedPosts = _.without($scope.selectedPosts, postId);
+                    return PostEndpoint.delete({ id: postId }).$promise;
+                });
+            $q.all(deletePostsPromises).then(handleDeleteSuccess, handleDeleteErrors)
+            ;
+
+            function handleDeleteErrors(errorResponse) {
+                $scope.isLoading.state = false;
+                Notify.apiErrors(errorResponse);
+            }
+            function handleDeleteSuccess(deleted) {
+                $scope.isLoading.state = false;
+                Notify.notify('notify.post.destroy_success_bulk');
+                // Remove deleted posts from state
+                var deletedIds = _.pluck(deleted, 'id');
+                angular.forEach($scope.groupedPosts, function (posts, group) {
+                    $scope.groupedPosts[group] = _.reject(posts, function (post) {
+                        return _.contains(deletedIds, post.id);
+                    });
+                });
+                $scope.posts = _.reject($scope.posts, function (post) {
+                    return _.contains(deletedIds, post.id);
+                });
+                clearSelectedPosts();
+
+                if (!$scope.posts.length) {
+                    $scope.clearPosts = true;
+                    getPosts();
+                }
+            }
+        });
+    }
+
+    function changeStatus(status) {
+        var selectedPosts = _.filter($scope.posts, function (post) {
+            return _.contains($scope.selectedPosts, post.id);
+        });
+
+        var count = $scope.selectedPosts.length;
+
+        var updateStatusPromises = _.map(selectedPosts, function (post) {
+            post.status = status;
+            // $scope.selectedPosts = _.without($scope.selectedPosts, post.id);
+            return PostEndpoint.update(post).$promise;
+        });
+
+        $q.all(updateStatusPromises).then(function () {
+            Notify.notify('notify.post.update_status_success_bulk', {count: count});
+            clearSelectedPosts();
+        }, function (errorResponse) {
+            Notify.apiErrors(errorResponse);
+        })
+        ;
+    }
+
+
     function groupPosts(posts) {
         var now = moment(),
             yesterday = moment().subtract(1, 'days');
@@ -162,7 +245,23 @@ function PostViewDataController(
     }
 
     function selectBulkActions() {
-        $scope.bulkActionsSelected = true;
+        $scope.bulkActionsSelected = 'toolbar-active';
         $rootScope.$broadcast('bulkActionsSelected:true');
+    }
+
+    function closeBulkActions() {
+        $scope.bulkActionsSelected = '';
+        $rootScope.$broadcast('bulkActionsSelected:false');
+    }
+
+    function clearSelectedPosts() {
+        // Clear selected posts
+        $scope.selectedPosts.splice(0);
+    }
+
+    function userHasBulkActionPermissions() {
+        return _.any($scope.posts, function (post) {
+            return _.intersection(post.allowed_privileges, ['update', 'delete', 'change_status']).length > 0;
+        });
     }
 }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -49,6 +49,9 @@ function PostViewDataController(
     $scope.showPost = showPost;
     $scope.loadMore = loadMore;
     $scope.editMode = {editing: false};
+    $scope.selectBulkActions = selectBulkActions;
+    $scope.bulkActionsSelected = false;
+
 
     $rootScope.setLayout('layout-d');
     activate();
@@ -142,9 +145,15 @@ function PostViewDataController(
     }
 
     function loadMore() {
+        console.log("loading?")
         // Increment page
         $scope.currentPage++;
         $scope.clearPosts = false;
         getPosts();
+    }
+
+    function selectBulkActions() {
+        console.log("clicking bulk acitions")
+        $scope.bulkActionsSelected = true;
     }
 }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -23,7 +23,7 @@ PostViewDataController.$inject = [
 'PostEndpoint',
 'PostViewService',
 'moment',
-'$translate'
+'$translate',
 ];
 
 function PostViewDataController(
@@ -34,7 +34,7 @@ function PostViewDataController(
     PostEndpoint,
     PostViewService,
     moment,
-    $translate
+    $translate,
 ) {
     $scope.currentPage = 1;
     $scope.selectedPosts = [];
@@ -153,5 +153,6 @@ function PostViewDataController(
 
     function selectBulkActions() {
         $scope.bulkActionsSelected = true;
+        $rootScope.$broadcast('bulkActionsSelected:true');
     }
 }

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -3,7 +3,10 @@
 
     <div class="timeline-col">
         <div class="listing timeline init">
-            <h2 class="tool-heading">{{posts.length}} of {{total}} posts</h2>
+        <div class="bulk-action">
+            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">BulkYYYYY Actions</button>
+            <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
+        </div>
             <post-card
                 ng-repeat="post in posts"
                 can-select="false"
@@ -14,6 +17,7 @@
                 edit-mode="editMode"
             >
             </post-card>
+            <listing-toolbar ng-show="bulkActionsSelected"></listing-toolbar>
 
             <button class="button-gamma button-flat" ng-click="loadMore()">Load more</button>
             <div class="listing-toolbar">

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -4,7 +4,7 @@
     <div class="timeline-col">
         <div class="listing timeline init">
         <div class="bulk-action">
-            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">BulkYYYYY Actions</button>
+            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">Bulk Actions</button>
             <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
         </div>
             <post-card

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -5,7 +5,7 @@
         <div class="listing timeline init">
         <div class="bulk-action">
             <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
-            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">Bulk Actions</button>
+            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin">Bulk Actions</button>
         </div>
             <post-card
                 ng-repeat="post in posts"
@@ -48,14 +48,14 @@
               </span>
 
               <collection-toggle-button selected-posts="selectedPosts" posts="posts" on-done="clearSelectedPosts()"></collection-toggle-button>
-              <button type="button" class="button-destructive" ng-click="deletePosts()">
+              <button type="button" class="button-destructive" ng-click="deletePosts()" ng-if="userHasBulkActionPermissions()">
                 <svg class="iconic">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
                 </svg>
                 <span class="button-label hidden">nav.delete</span>
               </button>
 
-              <button href="" ng-click="closeBulkActions()" class="button-beta button-flat listing-item-secondary">
+              <button href="" ng-click="closeBulkActions()" class="button-beta button-flat toolbar-close-button">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
                 </svg>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,11 +1,11 @@
 <div class="flex-container">
     <post-toolbar is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
 
-    <div class="timeline-col">
+    <div class="timeline-col" ng-class="bulkActionsSelected">
         <div class="listing timeline init">
         <div class="bulk-action">
-            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">Bulk Actions</button>
             <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
+            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()">Bulk Actions</button>
         </div>
             <post-card
                 ng-repeat="post in posts"
@@ -17,15 +17,141 @@
                 edit-mode="editMode"
             >
             </post-card>
-            <listing-toolbar ng-show="bulkActionsSelected"></listing-toolbar>
+
+
+            <listing-toolbar
+            entities="posts"
+            selected-set="selectedPosts"
+          >
+              <!-- status bulk actions -->
+              <span dropdown ng-if="userHasBulkActionPermissions()">
+                <button class="button-beta init" data-toggle="toggle-content" dropdown-toggle>
+                  <span class="button-label" translate="app.mark_as">Mark as</span>
+                  <svg class="iconic">
+                    <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
+                  </svg>
+                </button>
+                <ul class="dropdown-menu toggle-content init" dropdown-menu unpositioned="true">
+                  <li ng-repeat="status in statuses">
+                    <a ng-click="changeStatus(status)">
+                      <svg class="iconic">
+                        <use xlink:href="/img/iconic-sprite.svg#globe" ng-if="status=='published'"></use>
+                        <use xlink:href="/img/iconic-sprite.svg#lock-locked" ng-if="status=='draft'"></use>
+                        <use xlink:href="/img/iconic-sprite.svg#box" ng-if="status=='archived'"></use>
+                      </svg>
+                      <span class="label" translate="post.published" ng-if="status == 'published'">Published</span>
+                      <span class="label" translate="post.draft" ng-if="status == 'draft'">Under review</span>
+                      <span class="label" translate="post.archived" ng-if="status == 'archived'">Archive</span>
+                    </a>
+                  </li>
+                </ul>
+              </span>
+
+              <collection-toggle-button selected-posts="selectedPosts" posts="posts" on-done="clearSelectedPosts()"></collection-toggle-button>
+              <button type="button" class="button-destructive" ng-click="deletePosts()">
+                <svg class="iconic">
+                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
+                </svg>
+                <span class="button-label hidden">nav.delete</span>
+              </button>
+
+              <button href="" ng-click="closeBulkActions()" class="button-beta button-flat listing-item-secondary">
+                <svg class="iconic">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
+                </svg>
+                <span class="hidden">Close</span>
+            </button>
+
+        </listing-toolbar>
+
+            <!-- <listing-toolbar></listing-toolbar> -->
+            <!-- <div class="listing-toolbar">
+                <div class="listing-item">
+                    <button href="" ng-click="closeBulkActions()" class="button-beta button-flat listing-item-secondary">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
+                        </svg>
+                        <span class="hidden">Close</span>
+                    </button>
+                    <div class="listing-toolbar-summary listing-item-primary">
+                        <strong><span class="total"></span> selected</strong>
+                        <button class="button-link">Deselect</button>
+                    </div>
+                </div>
+
+                <div class="listing-toolbar-actions">
+                    <button class="button-beta" data-toggle="toggle-content">
+                        <span class="button-label">Mark as</span>
+                        <svg class="iconic">
+                            <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
+                        </svg>
+                    </button>
+
+                    <ul class="dropdown-menu toggle-content">
+                        <li>
+                            <a href="" data-message="publish-success">
+                                <svg class="iconic">
+                                    <use xlink:href="/img/iconic-sprite.svg#globe"></use>
+                                </svg>
+                                <span class="label">Published</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="" data-message="under_review-success">
+                                <svg class="iconic">
+                                    <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
+                                </svg>
+                                <span class="label">Under Review</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="" data-message="archive-success">
+                                <svg class="iconic">
+                                    <use xlink:href="/img/iconic-sprite.svg#box"></use>
+                                </svg>
+                                <span class="label">Archived</span>
+                            </a>
+                        </li>
+                    </ul>
+
+                    <button class="button-beta" data-modal="add-to-collection">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#grid-three-up"></use>
+                        </svg>
+                        <span class="button-label hidden">Add to Collection</span>
+                    </button>
+
+                    <button class="button-beta">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#pencil"></use>
+                        </svg>
+                        <span class="button-label hidden">Edit</span>
+                    </button>
+
+                    <button class="button-destructive" data-modal="delete-post">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
+                        </svg>
+                        <span class="button-label hidden">Delete</span>
+                    </button>
+
+                    <button class="listing-toolbar-toggle more">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#ellipses"></use>
+                        </svg>
+                        <span class="button-label hidden">Edit</span>
+                    </button>
+
+                    <button class="listing-toolbar-toggle less">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>
+                        </svg>
+                        <span class="button-label hidden">Delete</span>
+                    </button>
+                </div>
+        </div> -->
 
             <button class="button-gamma button-flat" ng-click="loadMore()">Load more</button>
-            <div class="listing-toolbar">
-                <div class="listing-toolbar-summary">
-                    <strong><span class="total"></span> selected</strong>
-                    <button class="button-link">Deselect</button>
-                </div>
-            </div>
         </div>
     </div>
     <div class="post-col">

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.2-rc.5"
+    "ushahidi-platform-pattern-library": "v3.7.2-rc.6"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Adds bulk actions toolbar drop and functionality to data view

Testing checklist:
- [x] While not logged in, navigate to data view; confirm you do not see "BULK ACTION" button.
- [x] select 'x' button and confirm dropdown goes away and checkboxes are removed from post cards

While logged in with bulk actions permissions (e.g. Admin)
- [x] Navigate to data view; confirm you do see "BULK ACTION" button.
- [x] Select "BULK ACTION" button and confirm dropdown comes down. 
- [x] Attempt to give new status (e.g. publish) a post
- [x] Attempt to add post to collection
- [x] Attempt to delete post

While logged in as regular user
- [x] Navigate to data view; confirm you do see "BULK ACTION" button.
- [x] Select "BULK ACTION" button and confirm dropdown comes down. 
- [x] Confirm you do not have the option to give status (publish) or delete posts
- [x] Attempt to add post to collection

Fixes ushahidi/platform#2102

Ping @ushahidi/platform
