### PR TITLE
2091 - fixes saved search dropdown not visible when there are saved searches available

### DIFF
--- a/app/main/posts/views/filters/filter-saved-search.directive.js
+++ b/app/main/posts/views/filters/filter-saved-search.directive.js
@@ -13,6 +13,9 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope) {
 
     function FilterSavedSearchLink(scope, element, attrs, ngModel) {
         scope.selectedSavedSearch = null;
+        scope.searches = [];
+        scope.searchesLength = 0;
+
         function activate() {
             ngModel.$render = renderModelValue;
             if (ngModel.$viewValue.length > 0) {
@@ -38,6 +41,7 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope) {
                     return search.featured || isOwner;
                 });
                 scope.searches = _.indexBy(searchesTmp, 'id');
+                scope.searchesLength = _.keys(scope.searches).length;
             }).then(function () {
                 activate();
             });

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -1,5 +1,5 @@
-<fieldset ng-show="searches.length > 0">
-    <label translate="app.saved_search"></label>
+<fieldset ng-show="searchesLength > 0">
+<label translate="app.saved_search"></label>
     <div class="custom-select" ng-model-options="{ updateOn: 'default' }">
         <select
                 ng-model="selectedSavedSearch"


### PR DESCRIPTION


This pull request makes the following changes:
- adds a scope var with length of searchs calculated by keys, since we are switching an array to an object length was not changing when we go the data.

Testing checklist:
- [x] Logged out: verify that you don't see saved searches 
- [x] Logged in, with saved searches available to your user: verify that you see a dropdown with saved searches
- [x] Logged in, select a saved search and check that the filter is applied in the bug icons. 

Fixes ushahidi/platform# .

Ping @ushahidi/platform