### PR TITLE
removing bug that automatically redirects user to post-detail-view

### DIFF
--- a/app/main/posts/views/post-view-list.directive.js
+++ b/app/main/posts/views/post-view-list.directive.js
@@ -145,8 +145,8 @@ function PostListController(
             }
         });
     }
-    function goToPost(id) {
-        $location.path('/posts/' + id);
+    function goToPost(post) {
+        $location.path('/posts/' + post.id);
     }
     function groupPosts(posts) {
         var now = moment(),

--- a/app/main/posts/views/post-view-list.html
+++ b/app/main/posts/views/post-view-list.html
@@ -11,7 +11,7 @@
             can-select="userHasBulkActionPermissions()"
             post="post"
             selected-posts="selectedPosts"
-            click-action="goToPost(post.id)"
+            click-action="goToPost"
         >
         </post-card>
 

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -180,8 +180,8 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             });
         }
 
-        function goToPost(id) {
-            $location.path('/posts/' + id);
+        function goToPost(post) {
+            $location.path('/posts/' + post.id);
         }
 
         function onEachFeature(feature, layer) {
@@ -201,7 +201,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                         var scope = $rootScope.$new();
                         scope.post = details;
                         scope.goToPost = goToPost;
-                        var el = $compile('<post-card post="post" short-content="true" click-action="goToPost(post.id)"></post-card>')(scope);
+                        var el = $compile('<post-card post="post" short-content="true" click-action="goToPost"></post-card>')(scope);
 
                         layer.bindPopup(el[0], {
                             'minWidth': '300',


### PR DESCRIPTION
This pull request makes the following changes:
- changes how click-functions are sent to the post-card directive

Testing checklist:
- [x] go to map view, click on a marker, you should not be redirected to the post automatically
- [x] click on the post-card, you should be redirected to the post-view
- [x] go to /views/list, you should stay on timeline and not be redirected to post-view
- [x] click on a post-card, you should be redirected to that post-view

Fixes ushahidi/platform# .

Ping @ushahidi/platform