### PR TITLE
2091 reactive filters should be enabled once we clear them, just as when we apply them. In map view this is not required as they are always enabled

### DIFF
--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -29,6 +29,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope) {
         $scope.clearFilters = function () {
             $scope.filtersVar = PostFilters.clearFilters();
             $scope.filtersDropdownToggle = false;
+            PostFilters.reactiveFilters = 'enabled';
         };
         $scope.enableQuery = function () {
             PostFilters.qEnabled = true;


### PR DESCRIPTION
This pull request makes the following changes:
- Apply filters on clear (data view)

Testing checklist:
Data view:
- [x] Add filters. Apply them. See the post list change. 
- [x] Clear filters. See the post list change to the original list with no filters.

Fixes ushahidi/platform#2091 .

Ping @ushahidi/platform
