### PR TITLE
2091 IndexBy id because the modelValue is actually the id, not the index

### DIFF
--- a/app/main/posts/views/filters/filter-transformers.service.js
+++ b/app/main/posts/views/filters/filter-transformers.service.js
@@ -13,7 +13,7 @@ function FilterTransformersService(_, FormEndpoint, TagEndpoint, RoleEndpoint,
             roles = results[0];
             users = results[1];
             tags = results[2];
-            forms = results[3];
+            forms = _.indexBy(results[3], 'id');
             savedSearches = results[4];
         });
     };


### PR DESCRIPTION
This pull request makes the following changes:
- forms are Indexed by id because the modelValue is actually the id, not the index

Testing checklist:
- [x] Select `show only` for a survey. Check that the correct survey is shown in the filter bug icons. 

Fixes ushahidi/platform#2091 .

Ping @ushahidi/platform