### PR TITLE
Layout usage improvements

### DIFF
--- a/app/common/services/view-helper.js
+++ b/app/common/services/view-helper.js
@@ -11,6 +11,10 @@ function (
         {
             name: 'list',
             display_name: $translate.instant('views.list')
+        },
+        {
+            name: 'data',
+            display_name: $translate.instant('views.data')
         }
     ];
 

--- a/app/config.js
+++ b/app/config.js
@@ -5,3 +5,7 @@
 // 	backendUrl : "https://ushahidi-platform-api-release.herokuapp.com",
 // 	mapboxApiKey: ""
 // };
+window.ushahidi = {
+    platform_websocket_redis_adapter_url: '127.0.0.1',
+    platform_websocket_redis_adapter_port: '6379'
+};

--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,7 @@
         <base href="/">
     </head>
     <!-- TODO: swap namespace based on rtlEnabled variable -->
+    <!--<body ng-class="{ 'modal-visible': modalVisible , 'layout-class': globalLayout}" class="ltr-namespace" canvas>-->
     <body ng-class="{ 'modal-visible': modalVisible }" class="{{ globalLayout }} ltr-namespace" canvas>
     <!-- TODO: set layouts per view directive -->
         <div id="bootstrap-loading">

--- a/app/main/posts/collections/collections-controller.js
+++ b/app/main/posts/collections/collections-controller.js
@@ -15,9 +15,12 @@ module.exports = [
         UserEndpoint,
         _
     ) {
+
         // Add set to the scope
         $scope.collection = collection;
         $scope.currentView = currentView;
+        var viewLayouts = {'data': 'd', 'list': 'a', 'map': 'a'};
+        $scope.layout = viewLayouts[$scope.currentView()];
 
         activate();
 

--- a/app/main/posts/collections/collections.html
+++ b/app/main/posts/collections/collections.html
@@ -1,6 +1,6 @@
 <div>
-    <layout-class layout="a"></layout-class>
-    <collection-mode-context></collection-mode-context>
+    <layout-class layout="{{layout}}"></layout-class>
+    <collection-mode-context  ng-if="layout === 'a'"></collection-mode-context>
 
     <main role="main">
         <post-view current-view="currentView()" filters="filters">

--- a/app/main/posts/savedsearches/mode-context.directive.js
+++ b/app/main/posts/savedsearches/mode-context.directive.js
@@ -36,7 +36,7 @@ function SavedSearchModeContextController(
     $scope.showNotificationLink = true;
     $scope.canEdit = false;
     $scope.notification = false;
-
+    $scope.collectionView =
     $scope.saveNotification = saveNotification;
     $scope.removeNotification = removeNotification;
     $scope.editSavedSearch = editSavedSearch;

--- a/app/main/posts/savedsearches/mode-context.directive.js
+++ b/app/main/posts/savedsearches/mode-context.directive.js
@@ -36,7 +36,7 @@ function SavedSearchModeContextController(
     $scope.showNotificationLink = true;
     $scope.canEdit = false;
     $scope.notification = false;
-    $scope.collectionView =
+    $scope.collectionView = 'map';
     $scope.saveNotification = saveNotification;
     $scope.removeNotification = removeNotification;
     $scope.editSavedSearch = editSavedSearch;

--- a/app/main/posts/savedsearches/mode-context.html
+++ b/app/main/posts/savedsearches/mode-context.html
@@ -110,7 +110,7 @@
         </div>
         <!--// END IF //-->
         <div class="form-field">
-            <a ng-href="/views/{{collection.view}}" type="button" class="button-link">
+            <a ng-href="/views/{{collectionView}}" type="button" class="button-link">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#arrow-left"></use>
                 </svg>

--- a/app/main/posts/savedsearches/savedsearches-controller.js
+++ b/app/main/posts/savedsearches/savedsearches-controller.js
@@ -19,6 +19,7 @@ module.exports = [
     ) {
         // Set view based on route or set view
         $scope.currentView = function () {
+            console.log(savedSearch);
             return $routeParams.view || savedSearch.view;
         };
 

--- a/app/main/posts/savedsearches/savedsearches-controller.js
+++ b/app/main/posts/savedsearches/savedsearches-controller.js
@@ -17,11 +17,12 @@ module.exports = [
         UserEndpoint,
         Notify
     ) {
+        var viewLayouts = {'data': 'd', 'list': 'a', 'map': 'a'};
         // Set view based on route or set view
         $scope.currentView = function () {
-            console.log(savedSearch);
             return $routeParams.view || savedSearch.view;
         };
+        $scope.layout = viewLayouts[$scope.currentView()];
 
         $scope.$emit('event:savedsearch:show', savedSearch);
         $scope.$on('$destroy', function () {

--- a/app/main/posts/savedsearches/savedsearches.html
+++ b/app/main/posts/savedsearches/savedsearches.html
@@ -1,6 +1,6 @@
 <div>
-    <layout-class layout="a"></layout-class>
-    <saved-search-mode-context></saved-search-mode-context>
+    <layout-class layout="{{layout}}"></layout-class>
+    <saved-search-mode-context ng-if="layout === 'a'"></saved-search-mode-context>
 
     <main role="main">
         <post-view current-view="currentView()" filters="filters">

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -59,9 +59,7 @@ function PostViewDataController(
     $scope.addNewestPosts = addNewestPosts;
     $scope.editMode = {editing: false};
 
-    if (PostFilters.getMode() !== 'collection' && PostFilters.getMode() !== 'savedsearch') {
-        $rootScope.setLayout('layout-d');
-    }
+    $rootScope.setLayout('layout-d');
 
     activate();
     function activate() {

--- a/app/main/posts/views/post-views.controller.js
+++ b/app/main/posts/views/post-views.controller.js
@@ -4,7 +4,9 @@ PostViewsController.$inject = ['$scope', '$translate', '$routeParams', 'PostFilt
 function PostViewsController($scope, $translate, $routeParams, PostFilters) {
     // Set view and layout based out route
     $scope.currentView = $routeParams.view;
-    $scope.layout = $routeParams.view === 'data' ? 'd' : 'a';
+    console.log($scope.currentView);
+    var viewLayouts = {'data': 'd', 'list': 'a', 'map': 'a'};
+    $scope.layout = viewLayouts[$routeParams.view];
     // Set the page title
     $translate('post.posts').then(function (title) {
         $scope.title = title;

--- a/app/main/posts/views/post-views.controller.js
+++ b/app/main/posts/views/post-views.controller.js
@@ -4,9 +4,8 @@ PostViewsController.$inject = ['$scope', '$translate', '$routeParams', 'PostFilt
 function PostViewsController($scope, $translate, $routeParams, PostFilters) {
     // Set view and layout based out route
     $scope.currentView = $routeParams.view;
-    console.log($scope.currentView);
     var viewLayouts = {'data': 'd', 'list': 'a', 'map': 'a'};
-    $scope.layout = viewLayouts[$routeParams.view];
+    $scope.layout = !$routeParams.view ? 'a' : viewLayouts[$routeParams.view];
     // Set the page title
     $translate('post.posts').then(function (title) {
         $scope.title = title;

--- a/test/unit/common/services/view-helper-spec.js
+++ b/test/unit/common/services/view-helper-spec.js
@@ -23,7 +23,7 @@ describe('view helper', function () {
 
     it('should return view and display name for map and list', function () {
         var views = ViewHelper.views();
-        expect(_.pluck(views, 'name')).toEqual(['map', 'list']);
-        expect(_.pluck(views, 'display_name')).toEqual(['views.map', 'views.list']);
+        expect(_.pluck(views, 'name')).toEqual(['map', 'list', 'data']);
+        expect(_.pluck(views, 'display_name')).toEqual(['views.map', 'views.list', 'views.data']);
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Improvements to layout in saved searches.

Testing checklist:
- [x] Open a saved search with the default view "data".  Verify that you can see the view data with it. 
- [x] Click on the map view and see your saved search in the map.  Verify that you can see the view map with it. 
- [x] Check that the normal map and data modes are still working
- [x] When clicking return to all posts, it should show the map . (I think?) @Angamanga ? I left collectionView in the scope to set whatever the right view would be. Empty for now and loads the default view instead which is map. 
- [x] Open a collection with the default view "data".  Verify that you can see the view data with it. 
- [x] Click on the map view and see your collection in the map.  Verify that you can see the view map with it. 
- [x] Check that the normal map and data modes are still working
- [ ] When clicking return to all posts, it should show the map . (I think?) @Angamanga ? I left collectionView in the scope to set whatever the right view would be. Empty for now and loads the default view instead which is map. 


Fixes ushahidi/platform# .

Ping @ushahidi/platform