### PR TITLE
2091 bugfixing - adding indexBy that was removed in a refactor by mistake

### DIFF
--- a/app/main/posts/views/filters/filter-transformers.service.js
+++ b/app/main/posts/views/filters/filter-transformers.service.js
@@ -7,14 +7,15 @@ function FilterTransformersService(_, FormEndpoint, TagEndpoint, RoleEndpoint,
     var roles, users, tags, forms, savedSearches = [];
     var self = this;
     this.rawFilters = {};
+
     this.requestsFiltersData = function () {
         return $q.all([RoleEndpoint.query().$promise, UserEndpoint.query().$promise,
             TagEndpoint.query().$promise, FormEndpoint.query().$promise, SavedSearchEndpoint.query({}).$promise]).then(function (results) {
-            roles = results[0];
-            users = results[1];
-            tags = results[2];
-            forms = results[3];
-            savedSearches = results[4];
+            roles = _.indexBy(results[0], 'name');
+            users = _.indexBy(results[1], 'id');
+            tags = _.indexBy(results[2], 'id');
+            forms = _.indexBy(results[3], 'id');
+            savedSearches = _.indexBy(results[4], 'id');
         });
     };
     this.transformers = {


### PR DESCRIPTION

This pull request makes the following changes:
- adding all lists with indexBy since that was removed in a refactor by mistake

Testing checklist:
- [x]  Check that saved searches, surveys, and categories are shown correctly in the active filters. 


Fixes ushahidi/platform#2091 .

Ping @ushahidi/platform