### PR TITLE
Removing timeline from view options

### DIFF
--- a/app/common/services/view-helper.js
+++ b/app/common/services/view-helper.js
@@ -9,10 +9,6 @@ function (
             display_name: $translate.instant('views.map')
         },
         {
-            name: 'list',
-            display_name: $translate.instant('views.list')
-        },
-        {
             name: 'data',
             display_name: $translate.instant('views.data')
         }

--- a/test/unit/common/services/view-helper-spec.js
+++ b/test/unit/common/services/view-helper-spec.js
@@ -23,7 +23,7 @@ describe('view helper', function () {
 
     it('should return view and display name for map and list', function () {
         var views = ViewHelper.views();
-        expect(_.pluck(views, 'name')).toEqual(['map', 'list', 'data']);
-        expect(_.pluck(views, 'display_name')).toEqual(['views.map', 'views.list', 'views.data']);
+        expect(_.pluck(views, 'name')).toEqual(['map', 'data']);
+        expect(_.pluck(views, 'display_name')).toEqual(['views.map', 'views.data']);
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Removes the Timeline(list) view options from clients

Testing checklist:
- [ ] Ensure that the view Timeline(list) option is no longer available on the Collection create/edit modal
- [ ] Ensure that the view Timeline(list) option is no longer available on the Savedsearch create/edit modal

Fixes ushahidi/platform#2131

Ping @ushahidi/platform
