### PR TITLE
Ui fixes data view

### DIFF
--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -241,7 +241,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 '<p><i translate>notify.post.leave_confirm_message</i></p>' +
                 '    <button class="button button-flat" ng-click="confirm()" translate>notify.post.leave_confirm</button>' +
                 '    <button class="button-alpha button-flat" ng-click="save()" translate>notify.generic.save</button>' +
-                '</div>', confirmText, false, scope, false, false);
+                '</div>', confirmText, false, scope, false, true);
 
         return deferred.promise;
     }

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -66,10 +66,15 @@ function PostActionsDirective(
                 Notify.error('post.already_locked');
                 return;
             }
+            /**
+             * keep the same post obj reference if we got one from the parent
+             * if not, recreate the object
+             */
             if ($scope.selectedPost && $scope.selectedPost.post) {
                 $scope.selectedPost.post = $scope.post ;
+            } else {
+                $scope.selectedPost = {post: $scope.post};
             }
-
             if ($location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + id + '/edit');
             } else if ($scope.editMode.editing) {

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -23,8 +23,8 @@ function PostActionsDirective(
         replace: true,
         scope: {
             post: '=',
-            editMode: '=',
-            selectedPost: '='
+            selectedPosts: '=',
+            editMode: '='
         },
         template: require('./post-actions.html'),
         link: PostActionsLink
@@ -35,6 +35,7 @@ function PostActionsDirective(
         $scope.updateStatus = updateStatus;
         $scope.openEditMode = openEditMode;
         $scope.postIsUnlocked = postIsUnlocked;
+
         activate();
 
         function activate() {
@@ -65,7 +66,9 @@ function PostActionsDirective(
                 Notify.error('post.already_locked');
                 return;
             }
-            $scope.selectedPost.post = $scope.post;
+            if ($scope.selectedPost && $scope.selectedPost.post) {
+                $scope.selectedPost.post = $scope.post ;
+            }
 
             if ($location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + id + '/edit');

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -1,6 +1,7 @@
 module.exports = PostActionsDirective;
 
 PostActionsDirective.$inject = [
+    '$rootScope',
     'PostEndpoint',
     'Notify',
     '$location',
@@ -9,6 +10,7 @@ PostActionsDirective.$inject = [
     'PostLockService'
 ];
 function PostActionsDirective(
+    $rootScope,
     PostEndpoint,
     Notify,
     $location,
@@ -21,7 +23,8 @@ function PostActionsDirective(
         replace: true,
         scope: {
             post: '=',
-            editMode: '='
+            editMode: '=',
+            selectedPost: '='
         },
         template: require('./post-actions.html'),
         link: PostActionsLink
@@ -62,8 +65,12 @@ function PostActionsDirective(
                 Notify.error('post.already_locked');
                 return;
             }
-            if ($location.path() !== '/views/data') {
+            $scope.selectedPost.post = $scope.post;
+
+            if ($location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + id + '/edit');
+            } else if ($scope.editMode.editing) {
+                $rootScope.$broadcast('event:edit:leave:form');
             } else {
                 $scope.editMode.editing = true;
             }

--- a/app/main/posts/common/post-actions.html
+++ b/app/main/posts/common/post-actions.html
@@ -1,4 +1,4 @@
-<div class="postcard-actions" dropdown>
+<div class="postcard-actions" dropdown ng-click="$event.stopPropagation();">
   <button class="button-gamma button-flat init" data-toggle="dropdown-menu" dropdown-toggle>
       <svg class="iconic">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#ellipses"></use>

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -9,7 +9,8 @@ function PostDetailData() {
             filters: '=',
             isLoading: '=',
             post: '=',
-            editMode: '='
+            editMode: '=',
+            postContainer: '='
         },
         controller: PostDetailDataController,
         template: require('./post-detail-data.html')

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -65,7 +65,6 @@ function PostDataEditorController(
     PostActionsService,
     MediaEditService
   ) {
-
     // Setup initial stages container
     $scope.post = angular.copy($scope.postContainer.post);
     $scope.everyone = $filter('translate')('post.modify.everyone');
@@ -286,6 +285,7 @@ function PostDataEditorController(
             post_id: $scope.post.id
         }).$promise.then(function (result) {
             $scope.editMode.editing = false;
+            // redirecting if user is leaving page
             if (url) {
                 $location.path(url);
             }
@@ -309,6 +309,11 @@ function PostDataEditorController(
     function leavePost(url) {
         Notify.confirmLeave('notify.post.leave_without_save').then(function () {
             $scope.cancel(url);
+        }, function () {
+            // redirecting if user is leaving the page
+            if (url) {
+                $location.path(url);
+            }
         });
     }
 

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -103,9 +103,9 @@ function PostDataEditorController(
         }
     });
 
-    $scope.$on('$locationChangeStart', function (e) {
+    $scope.$on('$locationChangeStart', function (e, next) {
         e.preventDefault();
-        $scope.leavePost();
+        $scope.leavePost(next);
     });
 
     activate();
@@ -280,12 +280,15 @@ function PostDataEditorController(
         return PostEditService.validatePost($scope.post, $scope.postForm, $scope.tasks);
     }
 
-    function cancel() {
+    function cancel(url) {
         PostLockEndpoint.unlock({
             id: $scope.post.lock.id,
             post_id: $scope.post.id
         }).$promise.then(function (result) {
             $scope.editMode.editing = false;
+            if (url) {
+                $location.path(url);
+            }
         });
     }
 
@@ -303,9 +306,9 @@ function PostDataEditorController(
         return MediaEditService.saveMedia($scope.medias, $scope.post);
     }
 
-    function leavePost() {
+    function leavePost(url) {
         Notify.confirmLeave('notify.post.leave_without_save').then(function () {
-            $scope.cancel();
+            $scope.cancel(url);
         });
     }
 

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -16,7 +16,7 @@
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>
 
-        <post-actions edit-mode="editMode" post="post"></post-actions>
+        <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
       </header>
       <div class="postcard-overflow">
         <div class="postcard-title">

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -12,7 +12,8 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
             inFocus: '=',
             shortContent: '@',
             clickAction: '=',
-            editMode: '='
+            editMode: '=',
+            selectedPost: '='
         },
         template: require('./card.html'),
         link: function ($scope) {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -75,6 +75,8 @@ function PostViewDataController(
     $scope.selectBulkActions = selectBulkActions;
     $scope.bulkActionsSelected = '';
     $scope.closeBulkActions = closeBulkActions;
+    $scope.selectedPost = {post: null};
+    $scope.selectedPostId = null;
 
     $rootScope.setLayout('layout-d');
 
@@ -113,15 +115,12 @@ function PostViewDataController(
             Notify.confirmLeave('notify.post.leave_without_save').then(function () {
                 //PostLockService.unlockSilent($scope.selectedPost);
                 $scope.editMode.editing = false;
-                $scope.selectedPost = {post: post};
+                $scope.selectedPost.post = post;
                 $scope.selectedPostId = post.id;
             });
         } else if (post.id !== $scope.selectedPostId) {
-            $scope.selectedPost = {post: post};
+            $scope.selectedPost.post = post;
             $scope.selectedPostId = post.id;
-        } else {
-            $scope.selectedPost = {post: null};
-            $scope.selectedPostId = null;
         }
     }
 

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -118,7 +118,7 @@ function PostViewDataController(
                 $scope.selectedPost.post = post;
                 $scope.selectedPostId = post.id;
             });
-        } else if (post.id !== $scope.selectedPostId) {
+        } else {
             $scope.selectedPost.post = post;
             $scope.selectedPostId = post.id;
         }

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -164,4 +164,5 @@
     <div class="post-col">
         <post-detail-data ng-if="selectedPost.post && !editMode.editing" edit-mode="editMode" filters="filters" is-loading="isLoading" post="selectedPost.post"></post-detail-data>
         <post-data-editor edit-mode="editMode" ng-if="editMode.editing" post-container="selectedPost"></post-data-editor>
+    </div>
 </div>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -21,6 +21,7 @@
                 click-action="showPost"
                 in-focus="selectedPostId === post.id",
                 edit-mode="editMode"
+                selected-post="selectedPost"
             >
             </post-card>
 


### PR DESCRIPTION
This pull request makes the following changes:
Bugfixes:
> ... is clickable but the whole card is clicked as well @Angamanga

> No x is displayed on leave-edit-mode-warning @Angamanga

> When navigating away from a card after cicking 'continue' or 'save' on the warning-modal, it doesnt continue to where the user was going, I stay on the post-details-view @Angamanga

> I get redirected to a new page altogether when clicking edit in data-view when in saved-search/collection-mode

Testing checklist:
- [ ] when clicking ... in post-card, the whole card is not clicked as well
- [ ] edit button in ... works as expected
- [ ] x is displayed on leave-edit-mode-warning
- [ ] when in edit mode, if i make changes and go to another url (for example map-view) without saving, the warning shows up. If clicking continue, i should be redirected to the view I wanted to go to
- [ ] when in saved-searches or collection-mode and i click edit in data-view, edit-view should appear in the same view (#2135)

Fixes ushahidi/platform# .

Ping @ushahidi/platform