### PR TITLE
Enabled bulk actions select

### DIFF
--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -1,16 +1,13 @@
 <article ng-class="['postcard', {selected: inFocus}]" ng-click="clickAction(post)">
     <div class="post-band" ng-style="{backgroundColor: post.form.color}"></div>
-
+    <div class="listing-item-select">
+        <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
+    </div>
     <div class="listing-item-locked" ng-show="isPostLocked()">
         <svg class="iconic">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
         </svg>
     </div>
-
-    <!--TODO: This HTML is causing a display issue I'm disabling it until it is fixed-->
-    <!--<div class="listing-item-select">
-        <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts">
-    </div>-->
     <div class="postcard-body">
       <header class="postcard-header">
 

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -17,14 +17,6 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
         template: require('./card.html'),
         link: function ($scope) {
             $scope.isPostLocked = isPostLocked;
-
-            $rootScope.$on('bulkActionsSelected:true', function () {
-                $scope.canSelect = true;
-            });
-            $rootScope.$on('bulkActionsSelected:false', function () {
-                $scope.canSelect = false;
-            });
-
             activate();
 
             function isPostLocked() {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -257,13 +257,11 @@ function PostViewDataController(
     }
 
     function selectBulkActions() {
-        $scope.bulkActionsSelected = 'toolbar-active';
-        $rootScope.$broadcast('bulkActionsSelected:true');
+        $scope.bulkActionsSelected = true;
     }
 
     function closeBulkActions() {
         $scope.bulkActionsSelected = '';
-        $rootScope.$broadcast('bulkActionsSelected:false');
     }
 
     function clearSelectedPosts() {

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -6,8 +6,7 @@
             <span ng-switch-when="1" translate="post.see_more_singular" translate-values="{ newPostsCount }">See new post</span>
         </span>
     </button>
-
-    <div class="timeline-col" ng-class="bulkActionsSelected">
+    <div class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
         <div class="listing timeline init">
         <div class="bulk-action">
             <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
@@ -15,7 +14,7 @@
         </div>
             <post-card
                 ng-repeat="post in posts"
-                can-select="false"
+                can-select="bulkActionsSelected"
                 post="post.id === selectedPostId ? selectedPost.post : post"
                 selected-posts="selectedPosts"
                 click-action="showPost"


### PR DESCRIPTION
This pull request makes the following changes:
- Remove broadcast for bulkactions checkboxes. That is not needed since we have 2 way data binding available there. 
- Small modifications to make the lock and checkboxes appear

Testing checklist:
- [x] I can see the checkboxes when I click bulk actions
- [x] If there is a lock enabled in the post, I see the lock.
- [x] If there is a lock enabled in the post and bulk actions is enabled, I see the lock and the checkbox
- [x] I can select one or many posts with their checkboxes. 
- [x] I can see the bulk toolbar changes the total selected items counter when I check/uncheck posts

TODO Fix checkbox + lock styles

Fixes ushahidi/platform# .

Ping @ushahidi/platform