### PR TITLE
Loading actions in Data View

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -60,6 +60,7 @@ function PostViewDataController(
     $scope.posts = [];
     $scope.groupedPosts = {};
     $scope.deletePosts = deletePosts;
+    $scope.hasFilters = hasFilters;
     $scope.userHasBulkActionPermissions = userHasBulkActionPermissions;
     $scope.statuses = PostActionsService.getStatuses();
     $scope.changeStatus = changeStatus;
@@ -134,6 +135,7 @@ function PostViewDataController(
             offset: ($scope.currentPage - 1) * $scope.itemsPerPage,
             limit: $scope.itemsPerPage
         });
+        $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
             //Clear posts
             $scope.clearPosts ? resetPosts() : null;
@@ -229,6 +231,10 @@ function PostViewDataController(
                 return postDate.fromNow();
             }
         });
+    }
+
+    function hasFilters() {
+        return PostFilters.hasFilters($scope.filters);
     }
 
     function groupPosts(postList) {

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -9,7 +9,7 @@
 
     <div class="timeline-col" ng-class="bulkActionsSelected">
         <div class="listing timeline init">
-        <div class="bulk-action">
+        <div class="bulk-action" ng-if="posts.length > 0 || !isLoading.state">
             <div class="bulk-action-primary">{{posts.length}} of {{total}} reports</div>
             <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin">Bulk Actions</button>
         </div>
@@ -156,8 +156,28 @@
                     </button>
                 </div>
         </div> -->
+            <div class="listing-item" ng-if="posts.length == 0 && hasFilters() && !isLoading.state">
+                <h4 translate>post.no_search_results</h4>
+            </div>
 
-            <button class="button-gamma button-flat" ng-click="loadMore()">Load more</button>
+            <div class="listing-item" ng-if="posts.length == 0 && !hasFilters() && !isLoading.state">
+                <h4 translate>post.no_posts_yet</h4>
+            </div>
+
+            <div class="listing-item" ng-if="posts.length > 0 || isLoading.state">
+                <div class="listing-item-primary">
+                    <button ng-disabled="isLoading.state" ng-hide="isLoading.state" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
+                    </button>
+                    <button type="button" class="button-gamma button-flat" ng-show="isLoading.state">
+                        <div class="loading">
+                            <div class="line"></div>
+                            <div class="line"></div>
+                            <div class="line"></div>
+                        </div>
+                        <span class="button-label" translate="app.loading">Loading</span>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
     <div class="post-col">


### PR DESCRIPTION
This pull request makes the following changes:
- Adds loading bar and progress bar to data view when posts are loading
- removes bulk actions text when posts are loading
- gives message when there are no posts or no posts return from filtering

Testing checklist:
- [x] Go to Data View, confirm that loading bar and progress bar appear while posts load
- [x] Confirm "BULK ACTIONS" and "X of X reports" are not visible while posts are loading
- [x] filter posts so that it will not return any (i.e. set filter dates to sometime last year), confirm that "Your search didn't match any posts" appears

Fixes ushahidi/platform# .

Ping @ushahidi/platform
