### PR TITLE
qEnabled in search filters button outside of dropdown has to enable r eactive filters to be effective

### DIFF
--- a/app/common/directives/filter-system/filter-searchbar.js
+++ b/app/common/directives/filter-system/filter-searchbar.js
@@ -25,6 +25,7 @@ function ($timeout, PostFilters) {
 
             $scope.enableQuery = function () {
                 PostFilters.qEnabled = true;
+                PostFilters.reactiveFilters = 'enabled';
             };
         };
     return {


### PR DESCRIPTION

This pull request makes the following changes:
- Enabled reactive filters when you click the outer "Search all " button (outside of dropdown) so that the search param is actually applied. 

Testing checklist:
Both map and data mode: 
- [x] 1. Write a search query. 
- [x] 2. Click "Search all " without the filters drop-down open. 
- [x] 3. Check that the search is applied
In map mode: 
- [x] 1. Make sure that the filter is NOT applied as you type. You should not see multiple loading bars one after each keydown. You should see the query applied when you  click the search all button. 


Fixes ushahidi/platform#2140

Ping @ushahidi/platform#2140