### PR TITLE
Changing to ensure that lock is representated as a consistent hydrate…

### DIFF
--- a/app/main/posts/common/post-lock.directive.js
+++ b/app/main/posts/common/post-lock.directive.js
@@ -23,7 +23,7 @@ function PostLockDirective(UserEndpoint, PostLockService, Notify, $rootScope) {
 
             function activate() {
                 $scope.canUnlock = userHasUnlockPermission();
-                UserEndpoint.get({id: $scope.post.lock.user_id}).$promise.then(function (result) {
+                UserEndpoint.get({id: $scope.post.lock.user.id}).$promise.then(function (result) {
                     $scope.user = result;
                 });
             }

--- a/app/main/posts/common/post-lock.service.js
+++ b/app/main/posts/common/post-lock.service.js
@@ -49,7 +49,7 @@ function PostLockService(
         // is different from the User who owns the lock
         if (post.lock) {
             if ($rootScope.currentUser) {
-                return $rootScope.currentUser.userId !== parseInt(post.lock.user_id);
+                return $rootScope.currentUser.userId !== parseInt(post.lock.user.id);
             }
         } else {
             return false;


### PR DESCRIPTION
This pull request makes the following changes:
- Changes tests to ensure that related user is always represented as a user object for locks

Testing checklist:
- [x] Edit a post
- [x] Save the post
- [x] You should not see a message telling you that the post is locked

Fixes ushahidi/platform# .

Ping @ushahidi/platform
