### PR TITLE
Changing unlock to limit to Admins

### DIFF
--- a/app/main/posts/common/post-lock.directive.js
+++ b/app/main/posts/common/post-lock.directive.js
@@ -17,7 +17,7 @@ function PostLockDirective(UserEndpoint, PostLockService, Notify, $rootScope) {
             $scope.unlock = unlock;
 
             $scope.showLockMessage = showLockMessage;
-            $scope.hasPermission = $rootScope.hasPermission;
+            $scope.isAdmin = $rootScope.isAdmin;
 
             activate();
 

--- a/app/main/posts/common/post-lock.html
+++ b/app/main/posts/common/post-lock.html
@@ -8,7 +8,7 @@
     <div class="message-body">
         <p translate-values="{ user: user.realname }" translate="post.locking.locked_message">The report is locked because <strong>Seth Hall</strong> is working on it right now. Try editing a different post.</p>
 
-        <div class="button-group" ng-if="hasPermission('Manage Posts')">
+        <div class="button-group" ng-if="isAdmin()">
              <button class="button button-alpha" translate="post.locking.unlock" ng-click="unlock()">Unlock</button>
         </div>
     </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Change permission to only allow admins to unlock

Testing checklist:
- [ ] Only admins should have the option to unlock posts

Fixes ushahidi/platform# .

Ping @ushahidi/platform
