### PR TITLE
Prevent anon users from seeing lock info

### DIFF
--- a/app/main/posts/common/post-lock.service.js
+++ b/app/main/posts/common/post-lock.service.js
@@ -45,8 +45,14 @@ function PostLockService(
     }
 
     function isPostLockedForCurrentUser(post) {
-        // We only wish to show the lock message when the Current User
-        // is different from the User who owns the lock
+        /* We only wish to show the lock message when a lock exists
+         * a user is currently logged in and the owner of the lock is
+         * different from the currently logged in user
+         * Anonymous users should not see lock information
+         */
+        if (!$rootScope.loggedin) {
+            return false;
+        }
         if (post.lock) {
             if ($rootScope.currentUser) {
                 return $rootScope.currentUser.userId !== parseInt(post.lock.user.id);


### PR DESCRIPTION
This pull request makes the following changes:
- Adds check to ensure user is logged in before showing a lock message

Testing checklist:
- [ ] As a logged in user lock a post that is published
- [ ] From a separate browser while not logged in ensure that you can not see the lock icon on the Post Card or the lock message on the detail view

Fixes ushahidi/platform#2159

Ping @ushahidi/platform
