### PR TITLE
Edit mode static object with editing=false sent in map

### DIFF
--- a/app/main/posts/views/post-view.html
+++ b/app/main/posts/views/post-view.html
@@ -1,5 +1,5 @@
 <div>
-    <post-toolbar is-loading="isLoading" current-view="currentView" filters="filters" ng-if="currentView !== 'data'"></post-toolbar>
+    <post-toolbar is-loading="isLoading" current-view="currentView" filters="filters" ng-if="currentView !== 'data'" edit-mode="{editing: false}"></post-toolbar>
     <ng-transclude ng-if="currentView !== 'data'"></ng-transclude>
      <!-- todo: toolbox-->
 


### PR DESCRIPTION
This pull request makes the following changes:
- sends a dummy editmode=false to avoid the share button from hiding in the toolbar while being used in the map view

Testing checklist:
- [x] Check that you see the Share button in the map mode
- [x] Check that you see the Share button in the data mode
- [x] Check that you don't see the share button in the data mode while editing. 
- [x] Check that you don't see the share button in a post's  detail page. 


Fixes ushahidi/platform# . 


Ping @ushahidi/platform