### PR TITLE
Create new post from data view

### DIFF
--- a/app/main/posts/views/add-post-button.html
+++ b/app/main/posts/views/add-post-button.html
@@ -1,5 +1,5 @@
 <div class="fab" data-message="add-post">
-    <button type="button" class="button-alpha button-fab" ng-click="handleClick()" ng-disabled="disabled">
+    <button type="button" class="button-alpha button-fab" ng-click="handleClick()" ng-disabled="disabled" ng-class="{'disabled': $parent.$parent.bulkActionsSelected}">
         <svg class="iconic">
             <use xlink:href="/img/iconic-sprite.svg#plus"></use>
             <foreignObject>

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -2,7 +2,7 @@
     <!-- toolbar -->
 
     <!-- floating action button -->
-    <add-post-button ng-if="currentView !== 'data'"></add-post-button>
+    <add-post-button></add-post-button>
 
     <filter-posts current-view="currentView" filters="filters" embed-only="false"></filter-posts>
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.2-rc.14",
+    "ushahidi-platform-pattern-library": "3.7.2-rc.15",
     "socket.io-client": "2.0.3"
   },
   "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- adds fab button to data view and making it show only when bulk actions is not selected.


Testing checklist:
- [x] Navigate to data view. Confirm yellow "Create New Post" button is there and looks nice. 
- [ ] Select "bulk actions" and confirm that yellow button slides up and out of site, then returns when you close "bulk actions"

Fixes ushahidi/platform#2141

Ping @ushahidi/platform
