### PR TITLE
2125 data view mobile

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -127,12 +127,18 @@ function PostViewDataController(
         return deferred.promise;
     }
 
+    function goToPost(post) {
+        $location.path('/posts/' + post.id);
+    }
+
     function showPost(post) {
         return confirmEditingExit().then(function () {
             var currentWidth = $window.innerWidth;
             if (currentWidth > 1023) {
                 $scope.selectedPost.post = post;
                 $scope.selectedPostId = post.id;
+            } else {
+                goToPost(post);
             }
         });
     }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -30,7 +30,8 @@ PostViewDataController.$inject = [
 '$timeout',
 '$location',
 '$anchorScroll',
-'Notify'
+'Notify',
+'$window'
 ];
 
 function PostViewDataController(
@@ -48,7 +49,8 @@ function PostViewDataController(
     $timeout,
     $location,
     $anchorScroll,
-    Notify
+    Notify,
+    $window
 ) {
 
     $scope.currentPage = 1;
@@ -127,8 +129,11 @@ function PostViewDataController(
 
     function showPost(post) {
         return confirmEditingExit().then(function () {
-            $scope.selectedPost.post = post;
-            $scope.selectedPostId = post.id;
+            var currentWidth = $window.innerWidth;
+            if (currentWidth > 1023) {
+                $scope.selectedPost.post = post;
+                $scope.selectedPostId = post.id;
+            }
         });
     }
 

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -110,19 +110,26 @@ function PostViewDataController(
         checkForNewPosts(30000);
     }
 
-    function showPost(post) {
-        // displaying warning if user is in editmode when trying to change post
-        if ($scope.editMode.editing) {
+    function confirmEditingExit() {
+        var deferred = $q.defer();
+
+        if (!$scope.editMode.editing) {
+            deferred.resolve();
+        } else {
             Notify.confirmLeave('notify.post.leave_without_save').then(function () {
                 //PostLockService.unlockSilent($scope.selectedPost);
                 $scope.editMode.editing = false;
-                $scope.selectedPost.post = post;
-                $scope.selectedPostId = post.id;
+                deferred.resolve();
             });
-        } else {
+        }
+        return deferred.promise;
+    }
+
+    function showPost(post) {
+        return confirmEditingExit().then(function () {
             $scope.selectedPost.post = post;
             $scope.selectedPostId = post.id;
-        }
+        });
     }
 
     function getPosts(query) {


### PR DESCRIPTION
This pull request makes the following changes:
- Reroutes to an individual post when the width of the browser window is less than 1024px
- Refactors the showPosts function to reduce duplication

Testing checklist:
- [x] Navigate to Data View in full screen width; click on post; post should appear in split-view format
- [x] Resize browser to <1024px (as soon as design changes); click on post; you should be rerouted to the full post view

Fixes ushahidi/platform#2125

Ping @ushahidi/platform
