### PR TITLE
Adds the required-asterisk to fieldset-type-field-types

### DIFF
--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -59,7 +59,8 @@
                   id="values[{{attribute.key}}][{{key}}]"
                   name="values_{{attribute.id}}"
                   ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required">
+                  ng-required="attribute.required"
+                >
                   <option ng-repeat="opt in attribute.options" value="{{opt}}">{{opt}}</option>
               </select>
               <!-- type: number -->
@@ -163,7 +164,11 @@
   <fieldset ng-if="isFieldSetStructure(attribute)">
 
     <!-- Attribute Label -->
-    <label>{{attribute.label}}</label>
+    <label ng-class="{
+        'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+        'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+        'required': attribute.required
+      }">{{attribute.label}}</label>
     <!-- Attribute Instructions -->
     <p>{{attribute.instructions}}</p>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the required-asterisk to field-types using fieldset in post-edit/post-add-views
- Adds a message if required fields of the field-types using fieldset are skipped
Testing checklist:
- [x] Add or edit a post in data or map-view with a form that has required radio-buttons or checkboxes (not categories, they cannot be required)
- [x] A red asterisk should be visible to the right of the label
- [x] If you try to save without adding a value to the radio-button/checkbox, a red message should appear below the field

To make the asterisk look the same as the other fields, this pl-pr is required: https://github.com/ushahidi/platform-pattern-library/pull/157

Fixes ushahidi/platform#2151 .

Ping @ushahidi/platform