### PR TITLE
Selected post on first load works now (clicking on context menu button)

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -23,7 +23,7 @@ function PostActionsDirective(
         replace: true,
         scope: {
             post: '=',
-            selectedPosts: '=',
+            selectedPost: '=',
             editMode: '='
         },
         template: require('./post-actions.html'),
@@ -66,15 +66,7 @@ function PostActionsDirective(
                 Notify.error('post.already_locked');
                 return;
             }
-            /**
-             * keep the same post obj reference if we got one from the parent
-             * if not, recreate the object
-             */
-            if ($scope.selectedPost && $scope.selectedPost.post) {
-                $scope.selectedPost.post = $scope.post ;
-            } else {
-                $scope.selectedPost = {post: $scope.post};
-            }
+            $scope.selectedPost.post = $scope.post;
             if ($location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + id + '/edit');
             } else if ($scope.editMode.editing) {


### PR DESCRIPTION
This pull request makes the following changes:
- Removes error caused by first load + click on context menu of post card (left side of data mode) 

Testing checklist:
- [x] Open data mode for the first time in a session
- [x] Click on a card's .... button on the list. Click edit. 
- [x] Check that the post loads. 

Avoid regressions with right side button:
- [x] Open data mode for the first time in a session
- [x] Click on a card's .... button, but after having selected it (click the right side button).  Click edit. 
- [ ] Check that the post loads. 

Fixes ushahidi/platform# .

Ping @ushahidi/platform
