### PR TITLE
2171 : Edit mode now works on all screens

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -60,15 +60,16 @@ function PostActionsDirective(
             return !PostLockService.isPostLockedForCurrentUser($scope.post);
         }
 
-        function openEditMode(id) {
+        function openEditMode(postId) {
             // Ensure Post is not locked before proceeding
             if (!postIsUnlocked()) {
                 Notify.error('post.already_locked');
                 return;
             }
-            $scope.selectedPost.post = $scope.post;
+
+            $scope.selectedPost.post = $scope.post ;
             if ($location.path().indexOf('data') === -1) {
-                $location.path('/posts/' + id + '/edit');
+                $location.path('/posts/' + postId + '/edit');
             } else if ($scope.editMode.editing) {
                 $rootScope.$broadcast('event:edit:leave:form');
             } else {

--- a/app/main/posts/detail/detail.html
+++ b/app/main/posts/detail/detail.html
@@ -42,9 +42,8 @@
           {{form.description}}
         </p>
         <div class="postcard-header">
-
           <post-metadata post="post"></post-metadata>
-          <post-actions post="post"></post-actions>
+          <post-actions post="post" selected-post="selectedPost"></post-actions>
         </div>
         <div
           ng-repeat="(key,value) in post.values"

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -68,6 +68,7 @@ function PostDetailDataController(
     $scope.canCreatePostInSurvey = PostSurveyService.canCreatePostInSurvey;
     $scope.mapDataLoaded = false;
     $scope.form_attributes = [];
+    $scope.selectedPost = {post: $scope.post};
 
     activate();
 

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -10,7 +10,7 @@
 
             <div class="postcard-header">
                 <post-metadata post="post" hide-date-this-week="true"></post-metadata>
-                <post-actions  edit-mode="editMode" post="post"></post-actions>
+                <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
             </div>
             <div
               ng-repeat="(key,value) in post.values"

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -46,6 +46,7 @@ function (
     $scope.canCreatePostInSurvey = PostSurveyService.canCreatePostInSurvey;
     $scope.mapDataLoaded = false;
     $scope.form_attributes = [];
+    $scope.selectedPost = {post: post};
     $scope.publishedFor = function () {
         if ($scope.post.status === 'draft') {
             return 'post.publish_for_you';

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -7,12 +7,13 @@
       <header class="postcard-header">
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>
-
+        <!-- this is used in the map view card and the sidebar card in the data view-->
         <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
       </header>
       <div class="postcard-overflow">
         <div class="postcard-title">
             <div class="postcard-field">
+                {{selectedPost.post.id}}
               {{ post.title || post.content | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}
             </div>
         </div>

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -201,7 +201,9 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                         var scope = $rootScope.$new();
                         scope.post = details;
                         scope.goToPost = goToPost;
-                        var el = $compile('<post-card post="post" short-content="true" click-action="goToPost"></post-card>')(scope);
+                        scope.selectedPost = {post : details};
+
+                        var el = $compile('<post-card selected-post="selectedPost" post="post" short-content="true" click-action="goToPost"></post-card>')(scope);
 
                         layer.bindPopup(el[0], {
                             'minWidth': '300',


### PR DESCRIPTION
This pull request makes the following changes:
- 2171 : Edit mode now works on all screens. Adds selectedPost everywhere where its needed. 

Testing checklist:
- [x] Test that you can click edit and see the edit form in : 
    - [x] Data mode, by clicking the actions ... button in the card (left side)
    - [x] Data mode,   by clicking the actions ... button in the detail view (right side)
    - [x] Map mode, by clicking the actions ... button in the card popup for a marker 
    - [x] Going directly to the edit url of a post you have permissions to edit. 

Fixes ushahidi/platform#2171 .

Ping @ushahidi/platform