### PR TITLE
Remove post id from card title

### DIFF
--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -13,7 +13,6 @@
       <div class="postcard-overflow">
         <div class="postcard-title">
             <div class="postcard-field">
-                {{selectedPost.post.id}}
               {{ post.title || post.content | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}
             </div>
         </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes a mistakenly added id from the post card title

Testing checklist:
- [ ] You should not see the post id in the post card (in data mode and map markers card) 

Fixes ushahidi/platform# .

Ping @ushahidi/platform
