### PR TITLE
2178 - Offset created by load more should not be applied to other filters automatically when you add filters

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -85,7 +85,7 @@ function PostViewDataController(
 
     activate();
     function activate() {
-        getPosts();
+        getPosts(false, false);
         // whenever the reactiveFilters var changes, do a dummy update of $scope.filters.reactiveFilters
         // to force the $scope.filters watcher to run
         $scope.$watch(function () {
@@ -101,7 +101,7 @@ function PostViewDataController(
         }, function (newValue, oldValue) {
             if (PostFilters.reactiveFilters === 'enabled' && (newValue !== oldValue)) {
                 $scope.clearPosts = true;
-                getPosts();
+                getPosts(false, false);
                 PostFilters.reactiveFilters = 'disabled';
             }
         }, true);
@@ -143,15 +143,18 @@ function PostViewDataController(
         });
     }
 
-    function getPosts(query) {
+    function getPosts(query, useOffset) {
         query = query || PostFilters.getQueryParams($scope.filters);
         PostEndpoint.stats(query).$promise.then(function (results) {
             $scope.total = results.totals[0].values[0].total;
         });
+
         var postQuery = _.extend({}, query, {
-            offset: ($scope.currentPage - 1) * $scope.itemsPerPage,
             limit: $scope.itemsPerPage
         });
+        if (useOffset === true) {
+            postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
+        }
         $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
             //Clear posts
@@ -206,7 +209,7 @@ function PostViewDataController(
 
                 if (!$scope.posts.length) {
                     $scope.clearPosts = true;
-                    getPosts();
+                    getPosts(false, false);
                 }
             }
         });
@@ -276,7 +279,7 @@ function PostViewDataController(
         // Increment page
         $scope.currentPage++;
         $scope.clearPosts = false;
-        getPosts();
+        getPosts(false, true);
     }
 
     function selectBulkActions() {


### PR DESCRIPTION
This pull request makes the following changes:
-Load more sets an offset, other calls to getPosts don't

Testing checklist:

- [ ] Click load posts. 
- [ ] Search in the search bar. 
- [ ] You should get the first set of posts that match your filters (vs the empty set that you got before, or the truncated set starting at offset x) 

Fixes ushahidi/platform#2178 .

Ping @ushahidi/platform