### PR TITLE
Hiding 'Load More' button when all posts have been loaded

### DIFF
--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -169,7 +169,7 @@
 
             <div class="listing-item" ng-if="posts.length > 0 || isLoading.state">
                 <div class="listing-item-primary">
-                    <button ng-disabled="isLoading.state" ng-hide="isLoading.state" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
+                    <button ng-disabled="isLoading.state" ng-hide="( isLoading.state || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
                     </button>
                     <button type="button" class="button-gamma button-flat" ng-show="isLoading.state">
                         <div class="loading">


### PR DESCRIPTION
This pull request makes the following changes:
- adds a condition to hide the 'Load More' button when all known posts are loaded

Testing checklist:
- [x]  If there are no more posts to load, "Load More" should disappear


Fixes ushahidi/platform#2176 .

Ping @ushahidi/platform
