### PR TITLE
Reload conversations and locations whenever a new post is selected in data view

### DIFF
--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -14,16 +14,6 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
     function DetailMapLink($scope, element, attrs) {
         var map;
         $scope.hideMap = false;
-        console.log('post id is currently: ' + $scope.postId);
-
-        $scope.$watch('postId', function (postId) {
-            console.log('post changed to ' + postId + ', reloading location content.');
-            console.log('What is this map?: ', map);
-            if (map) {
-                map.remove();
-            }
-            activate();
-        });
 
         activate();
 

--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -14,6 +14,16 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
     function DetailMapLink($scope, element, attrs) {
         var map;
         $scope.hideMap = false;
+        console.log('post id is currently: ' + $scope.postId );
+
+        $scope.$watch('postId', function (postId) {
+            console.log('post changed to ' + postId + ', reloading location content.');
+            console.log('What is this map?: ', map);
+            if (map) {
+                map.remove();
+            }
+            activate();
+        });
 
         activate();
 

--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -15,6 +15,13 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
         var map;
         $scope.hideMap = false;
 
+        $scope.$watch('postId', function (postId) {
+            if (map) {
+                map.remove();
+                activate();
+            }
+        });
+
         activate();
 
         function activate() {

--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -14,7 +14,7 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
     function DetailMapLink($scope, element, attrs) {
         var map;
         $scope.hideMap = false;
-        console.log('post id is currently: ' + $scope.postId );
+        console.log('post id is currently: ' + $scope.postId);
 
         $scope.$watch('postId', function (postId) {
             console.log('post changed to ' + postId + ', reloading location content.');

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -28,27 +28,42 @@ function (
         template: require('./post-messages.html'),
         link: function ($scope) {
 
+            $scope.$watch('post', function (post) {
+                console.log('post changed to ' + post.id + ', reloading messages content.');
+                activate();
+            });
+
             // Pagination
             $scope.currentPage = 1;
             $scope.itemsPerPage = 5;
             $scope.totalItems = $scope.itemsPerPage;
             $scope.pageChanged = getMessagesForPagination;
+            $scope.isLoadingMessages = false;
 
-            // Initialize
-            ContactEndpoint.get({ id: $scope.post.contact.id })
-                .$promise.then(function (contact) {
-                    $scope.contact = contact;
-                });
+            function activate()
+            {
+                $scope.messages = []; // init to blank
+                // Initialize
+                ContactEndpoint.get({ id: $scope.post.contact.id })
+                    .$promise.then(function (contact) {
+                        $scope.contact = contact;
+                    });
 
-            getMessagesForPagination();
+                getMessagesForPagination();
+            }
+
+            activate();
 
             function getMessagesForPagination() {
+                $scope.isLoadingMessages = true; // show progress bar
+
                 if ($scope.post.contact.id) {
                     MessageEndpoint.allInThread({
                         contact: $scope.post.contact.id,
                         offset: ($scope.currentPage - 1) * $scope.itemsPerPage,
                         limit: $scope.itemsPerPage
                     }).$promise.then(function (response) {
+
                         var created,
                             messages = response.results;
 
@@ -63,7 +78,9 @@ function (
                             message.displayTime = formatDate(created);
 
                             $scope.totalItems = response.total_count;
+
                         });
+                        $scope.isLoadingMessages = false; //hide progress bar
                     });
                 }
             }

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -40,8 +40,7 @@ function (
             $scope.pageChanged = getMessagesForPagination;
             $scope.isLoadingMessages = false;
 
-            function activate()
-            {
+            function activate() {
                 $scope.messages = []; // init to blank
                 // Initialize
                 ContactEndpoint.get({ id: $scope.post.contact.id })

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -29,7 +29,6 @@ function (
         link: function ($scope) {
 
             $scope.$watch('post', function (post) {
-                console.log('post changed to ' + post.id + ', reloading messages content.');
                 activate();
             });
 

--- a/app/main/posts/detail/post-messages.html
+++ b/app/main/posts/detail/post-messages.html
@@ -1,6 +1,8 @@
 <div class="listing card">
   <h3 class="listing-heading" translate>post.messages.title</h3>
 
+  <div class="progress-bar" ng-show="isLoadingMessages"><span>Loading...</span></div>
+
     <div ng-repeat="message in messages track by message.id" class="listing-item">
       <div class="listing-item-primary">
         <div class="listing-item-image" ng-if="message.direction == 'outgoing'">
@@ -69,5 +71,3 @@
   </div>
   -->
 </div>
-
-


### PR DESCRIPTION
This pull request makes the following changes:
- Watches the post variable in conversation directive to see if it's been changed (i.e., to see if someone has selected a different post)
- moves all setup and init'ing of the message directive into an activate() function
- adds a progress bar to the directive, because everyone loves progress bars
and
- Watches the post variable in maps directive to see if it's been changed (i.e., to see if someone has selected a different post), then reloads the map with new data

Testing checklist:
- [x] In data list view, select a post with a conversation -- generally SMS or Twitter posts
- [x] A progress bar should appear as that conversation loads
- [x] Once that conversation loads, the progress bar should disappear
- [x] The thread of conversations should pertain only to the selected post
- [x] In data list view, select another post with a conversation
- [x] The conversations should clear, and a progress bar should appear as that conversation loads
- [x] The thread of conversations should pertain only to the newly selected post
- [x] In data list view, select a post with a mapped location
- [x] The map should only display the location(s) pertaining to that post
- [x] In data list view, select another post with a map
- [x] The map should refresh and only display the location(s) pertaining to that post

Fixes ushahidi/platform#2175.

Ping @ushahidi/platform
