### PR TITLE
Unhide map when it has data

### DIFF
--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -18,14 +18,15 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
         $scope.$watch('postId', function (postId) {
             if (map) {
                 map.remove();
-                activate();
             }
+            activate();
         });
 
         activate();
 
         function activate() {
             // Start loading data
+            $scope.hideMap = true;
             var geojson = PostEndpoint.geojson({id: $scope.postId}).$promise;
             var createMap = Maps.createMap(element[0].querySelector('#post-map'))
             .then(function (data) {
@@ -56,6 +57,7 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
                 $scope.hideMap = true;
                 return;
             }
+            $scope.hideMap = false;
 
             var geojson = L.geoJson(geojsonData, {
                 pointToLayer: Maps.pointToLayer


### PR DESCRIPTION
This pull request makes the following changes:
- Sets $scope.hideMap = false on reload. This was staying true when each post was selected.

Testing checklist:
- [x] Select a post with a map, verify that the map is shown
- [x] Select a post without a map, verify that the map is hidden
- [x] Select another post with a map, verify that the map is shown 


Fixes ushahidi/platform#2184.

Ping @ushahidi/platform
