### PR TITLE
removing one-time binding for message authors

### DIFF
--- a/app/main/posts/detail/post-messages.html
+++ b/app/main/posts/detail/post-messages.html
@@ -13,8 +13,8 @@
         </div>
       <h2 class="listing-item-title">
 
-        <span ng-if="message.direction == 'incoming'">{{ ::contact.contact }}</span>
-        <span ng-if="message.direction == 'outgoing' && message.user.realname">{{ ::message.user.realname }}</span>
+        <span ng-if="message.direction == 'incoming'">{{ contact.contact }}</span>
+        <span ng-if="message.direction == 'outgoing' && message.user.realname">{{ message.user.realname }}</span>
       </h2>
       <!--
       <p>{{message.updated || message.created | date:'mediumDate'}} at {{message.updated || message.created | date:'shortTime'}}</p>


### PR DESCRIPTION
This pull request makes the following changes:
- removes one-time binding in messages for message authors

Testing checklist:
- [x] select a post with messages, verify that the messages author is correct
- [x] select another post with messages, verify that the messages author is correct
- [x] select first post with messages again, verify that the messages author is correct

Fixes ushahidi/platform#2175 .

Ping @ushahidi/platform
