### PR TITLE
Use ngModel with post-location directive to set form state

### DIFF
--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -5,17 +5,17 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
     return {
         restrict: 'E',
         replace: true,
+        require: 'ngModel',
         scope: {
             id: '@',
             name: '@',
-            model: '=',
             required: '='
         },
         template: require('./location.html'),
         link: PostLocationLink
     };
 
-    function PostLocationLink($scope, element, attrs) {
+    function PostLocationLink($scope, element, attrs, ngModel) {
         var currentPositionControl, map, marker,
             zoom = 8;
 
@@ -41,14 +41,12 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
             .then(function (data) {
                 map = data;
 
-                // init marker with current model value
-                if ($scope.model &&
-                    typeof $scope.model.lat !== 'undefined' &&
-                    typeof $scope.model.lon !== 'undefined'
-                ) {
-                    updateMarkerPosition($scope.model.lat, $scope.model.lon);
-                    centerMapTo($scope.model.lat, $scope.model.lon);
-                }
+                // Init marker with current model value
+                renderViewValue();
+
+                // Update Map if model changes
+                ngModel.$render = renderViewValue;
+
                 map.on('click', onMapClick);
                 // treat locationfound same as map click
                 map.on('locationfound', onMapClick);
@@ -61,11 +59,9 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                         }
                     }).addTo(map);
                 }
-                // @todo: Should we watch the model and update map?
             });
 
             $document.on('click', onDocumentClick);
-
         }
 
         function onDocumentClick(event) {
@@ -83,11 +79,21 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
             updateModelLatLon(lat, lon);
         }
 
+        function renderViewValue() {
+            if (ngModel.$viewValue &&
+                typeof ngModel.$viewValue.lat !== 'undefined' &&
+                typeof ngModel.$viewValue.lon !== 'undefined'
+            ) {
+                updateMarkerPosition(ngModel.$viewValue.lat, ngModel.$viewValue.lon);
+                centerMapTo(ngModel.$viewValue.lat, ngModel.$viewValue.lon);
+            }
+        }
+
         function updateModelLatLon(lat, lon) {
-            $scope.model = {
+            ngModel.$setViewValue({
                 lat: lat,
                 lon: lon
-            };
+            });
         }
 
         function updateMarkerPosition(lat, lon) {
@@ -112,7 +118,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         }
 
         function clear() {
-            $scope.model = null;
+            ngModel.$setViewValue(null);
             if (marker) {
                 map.removeLayer(marker);
                 marker = null;

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -1,15 +1,15 @@
- 
+
 <div class="location-wrapper">
     <div id="{{id}}-map" class="map" style="height: 265px; width: 100%;"></div>
     <form class="searchbar">
-        <div class="searchbar-input init" role="search"> 
+        <div class="searchbar-input init" role="search">
             <div class="form-field tooltip">
-                <input name="{{name}}" 
-                    type="search" 
-                    maxlength="250" 
-                    placeholder="{{'location.placeholder' | translate}}" 
-                    ng-model="searchLocationTerm" 
-                    ng-focus="showSearchResults()" 
+                <input name="{{name}}"
+                    type="search"
+                    maxlength="250"
+                    placeholder="{{'location.placeholder' | translate}}"
+                    ng-model="searchLocationTerm"
+                    ng-focus="showSearchResults()"
                     ng-keydown="handleActiveSearch($event)"
                 />
             </div>
@@ -18,8 +18,8 @@
                 <div class="form-field">
                     <button class="button-beta button-plain" ng-click="chooseCurrentLocation()" ng-if="showCurrentPositionControl" >
                         <svg class="iconic">
-                            <use 
-                                xmlns:xlink="http://www.w3.org/1999/xlink" 
+                            <use
+                                xmlns:xlink="http://www.w3.org/1999/xlink"
                                 xlink:href="/img/iconic-sprite.svg#location">
                             </use>
                         </svg>
@@ -31,8 +31,8 @@
                     <dl ng-repeat="result in searchResults" ng-if="!processing && searchResults.length > 0">
                         <dt class="list-item" ng-click="chooseLocation(result)">
                             <svg class="iconic">
-                                <use 
-                                    xmlns:xlink="http://www.w3.org/1999/xlink" 
+                                <use
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
                                     xlink:href="/img/iconic-sprite.svg#map-marker">
                                 </use>
                             </svg>

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -127,7 +127,6 @@
                   key="key"
                   id="values[{{attribute.key}}][{{key}}]"
                   name="values_{{attribute.id}}"
-                  model="post.values[attribute.key][key]"
                   ng-model="post.values[attribute.key][key]"
                   ng-required="attribute.required"
                   ng-switch-when="location"></post-location>

--- a/test/unit/main/post/modify/location.directive.spec.js
+++ b/test/unit/main/post/modify/location.directive.spec.js
@@ -14,7 +14,8 @@ describe('post location directive', function () {
     Maps,
     map,
     marker,
-    currentPositionControl;
+    currentPositionControl,
+    ngModel;
 
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
@@ -61,12 +62,15 @@ describe('post location directive', function () {
             lat: 3,
             lon: 4
         };
-        element = '<post-location attribute="attribute" key="key" model="model" id="1"></post-location>';
+        element = '<post-location attribute="attribute" key="key" ng-model="model" id="1"></post-location>';
         element = $compile(element)($scope);
         $scope.$digest();
         isolateScope = element.children().scope();
+        ngModel = element.controller('ngModel');
+
         spyOn(isolateScope, 'chooseCurrentLocation').and.callThrough();
         spyOn(currentPositionControl, 'start').and.callThrough();
+        spyOn(ngModel, '$setViewValue').and.callThrough();
     }));
 
     describe('test directive functions', function () {
@@ -104,19 +108,23 @@ describe('post location directive', function () {
             var elementToClick = element[0].querySelector('.list-item');
             elementToClick.dispatchEvent(new Event('click'));
             expect(isolateScope.chooseLocation).toHaveBeenCalledWith(newLocation);
-            expect(isolateScope.model.lat).toEqual(1);
-            expect(isolateScope.model.lon).toEqual(2);
+            expect(ngModel.$setViewValue).toHaveBeenCalledWith({
+                lat: 1,
+                lon: 2
+            });
+            expect(ngModel.$viewValue.lat).toEqual(1);
+            expect(ngModel.$viewValue.lon).toEqual(2);
             expect(marker.setLatLng).toHaveBeenCalledWith([1, 2]);
             expect(map.setView).toHaveBeenCalledWith([1, 2], 8);
         });
         it('should clear scope model, and remove the marker', function () {
             isolateScope.$apply(function () {
-                isolateScope.model = { lat: 100, lng: 200 };
+                ngModel.$setViewValue({ lat: 100, lng: 200 });
             });
 
             isolateScope.clear();
 
-            expect(isolateScope.model).toBeNull();
+            expect(ngModel.$viewValue).toBeNull();
             expect(marker.remove).toBeCalled;
         });
         it('should start checking for current location', function () {


### PR DESCRIPTION
This pull request makes the following changes:
- Replace `model` param with `ng-model`
- Update state from model
- Update model when state changes

Testing checklist:
- [x] Go to data view
- [x] Select a post with location and edit it
- [x] Change the location
- [x] Click cancel and you should be prompted to save or continue

- [x] Select a post with location and edit it
- [x] Change the location
- [x] Save the post and location should be updated

Fixes ushahidi/platform#2188

Ping @ushahidi/platform
