### PR TITLE
Move dot outside of post status highlight

### DIFF
--- a/app/main/posts/common/post-metadata.html
+++ b/app/main/posts/common/post-metadata.html
@@ -4,25 +4,27 @@
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
         </svg>
       </div>
-      <li class="status-indicator" ng-if="post.status=='published'">
-          <svg class="iconic">
-              <use xlink:href="/img/iconic-sprite.svg#globe"></use>
-          </svg>
-          <span class="label" translate="post.status_published" ng-if="post.status=='published'">post.status_published</span>
+      <li>
+          <span class="status-indicator" ng-if="post.status=='published'">
+              <svg class="iconic">
+                  <use xlink:href="/img/iconic-sprite.svg#globe"></use>
+              </svg>
+              <span class="label" translate="post.status_published" ng-if="post.status=='published'">post.status_published</span>
+          </span>
+          <span class="status-indicator yellow" ng-if="post.status=='draft'">
+              <svg class="iconic">
+                <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
+              </svg>
+              <span class="label" translate="post.status_review" ng-if="post.status=='draft'"></span>
+          </span>
+          <span class="status-indicator dark" ng-if="post.status=='archived'">
+              <svg class="iconic">
+                 <use xlink:href="/img/iconic-sprite.svg#box" ></use>
+              </svg>
+               <span class="label" translate="post.status_archived" ng-if="post.status=='archived'"></span>
+          </span>
       </li>
-      <li class="status-indicator yellow" ng-if="post.status=='draft'">
-          <svg class="iconic">
-            <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
-          </svg>
-          <span class="label" translate="post.status_review" ng-if="post.status=='draft'"></span>
-      </li>
-      <li class="status-indicator dark" ng-if="post.status=='archived'">
-          <svg class="iconic">
-             <use xlink:href="/img/iconic-sprite.svg#box" ></use>
-          </svg>
-           <span class="label" translate="post.status_archived" ng-if="post.status=='archived'"></span>
-      </li>
-        
+
       <li>
         <img src="//www.gravatar.com/avatar/{{ post.user.gravatar || '00000000000000000000000000000000' }}?d=retro&s=40" class="avatar">
         <strong class="label" ng-show="post.user && !post.author_realname">{{ post.user.realname }}</strong>


### PR DESCRIPTION
This pull request makes the following changes:

<img width="391" alt="screenshot 2017-10-20 14 56 32" src="https://user-images.githubusercontent.com/7965/31801809-0cff15c0-b5a7-11e7-8c07-d186faa897ae.png">

<img width="408" alt="screenshot 2017-10-20 14 57 41" src="https://user-images.githubusercontent.com/7965/31801810-0d287b68-b5a7-11e7-870e-b1e966a54f21.png">

