### PR TITLE
updating min-max length for categories to match db-settings #2195

### DIFF
--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -45,7 +45,7 @@
               <!-- Title -->
               <div class="form-field title">
                 <label class="hidden" translate="category.editor.name"></label>
-                <input type="text" placeholder="{{'category.editor.name' | translate}}" ng-minlength="3" ng-maxlength="150" ng-model="category.tag" required>
+                <input type="text" placeholder="{{'category.editor.name' | translate}}" ng-minlength="2" ng-maxlength="255" ng-model="category.tag" required>
               </div>
               <!-- Description -->
               <div class="form-field">


### PR DESCRIPTION
This pull request makes the following changes:
- Increases the character-length for tags to match api

Testing checklist:
- [x] Go to create a new category
- [x] You should be able to save a category that is 
   - [x] Minimum of 2 characters 
   - [x] Maximum of 255 characters
- [x] Add category to a survey
- [x] Add a post to that survey
- [x] The full category-name should be visible when adding post and displaying it

Fixes ushahidi/platform# .

Ping @ushahidi/platform