### PR TITLE
scrolling to top of column 2092

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -341,8 +341,7 @@ function PostViewDataController(
         $scope.totalItems = $scope.totalItems + $scope.newPostsCount;
         $scope.recentPosts = [];
         $scope.newPostsCount = 0;
-        $location.hash('post-data-view-top');
-        $anchorScroll();
+        $window.document.getElementById('post-data-view-top').scrollTop = 0;
     }
 
     function checkForNewPosts(time) {

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,6 +1,6 @@
-<div class="flex-container" id='post-data-view-top'>
+<div class="flex-container">
     <post-toolbar saving-post="savingPost" is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
-    <div class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
+    <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
         <listing-toolbar
             entities="posts"
             selected-set="selectedPosts"


### PR DESCRIPTION
This pull request makes the following changes:
- Scrolls to the top of the timeline-col-div (= the post-card-column) when clicking new posts.

#Question:
Should the right-hand-column also be scrolled to top if the user has scrolled down in for example edit-view or a very long post-detail?


Testing checklist:
- [ ] go to data-view, scroll down a bit
- [ ] add a post from another browser
- [ ] click on the load-more-button that appear in the first browser
- [ ] New posts should be loaded and you should be scrolled to the top of the column

- [ ] Click on a random post
- [ ] add a new post from another browser again
- [ ] scroll down a bit in the first browser
- [ ] click on the load-more button
- [ ] New post should be loaded and you should be scrolled to the top of the column

Fixes ushahidi/platform# .

Ping @ushahidi/platform