### PR TITLE
Reload metadata directive when new post has been selected

### DIFF
--- a/app/main/posts/common/post-metadata.directive.js
+++ b/app/main/posts/common/post-metadata.directive.js
@@ -27,6 +27,10 @@ function PostMetadataDirective(
             $scope.timeago = '';
             $scope.hideDateThisWeek = $scope.hideDateThisWeek || false;
 
+            $scope.$watch('post', function (post) {
+                activate();
+            });
+
             activate();
 
             function activate() {


### PR DESCRIPTION
This pull request makes the following changes:
- adds a watch to post variable, reloads directive's activate() when post has changed

Testing checklist:
- [x] go to data-view, click a post and make sure the metadata reflects the selected post
- [x] click another post and make sure the metadata reflects that newly selected post


Fixes ushahidi/platform#2199 .

Ping @ushahidi/platform
