### PR TITLE
2208 full loader on gotopost

### DIFF
--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -144,6 +144,8 @@ function (
             });
             $scope.tasks_with_attributes = _.uniq($scope.tasks_with_attributes);
 
+            angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
+            angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
         });
     }
 

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -168,6 +168,8 @@ function PostViewDataController(
     }
 
     function goToPost(post) {
+        angular.element(document.getElementById('bootstrap-app')).addClass('hidden');
+        angular.element(document.getElementById('bootstrap-loading')).removeClass('hidden');
         $location.path('/posts/' + post.id);
     }
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a full page loader when you go to post detail

Testing checklist:
- [x] Open the data view mode in mobile viewport
- [x] Click on a post
- [x] You should see the full page ". . . " jumping around. 
- [x] The post should load and the '. . . 'dissapear

Fixes ushahidi/platform#2208 .

Ping @ushahidi/platform
