### PR TITLE
2210 ASC order should not allow the see new posts button to appear

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -318,6 +318,9 @@ function PostViewDataController(
         $scope.totalItems = $scope.itemsPerPage;
         $scope.currentPage = 1;
         $scope.selectedPosts = [];
+        recentPosts = [];
+        $scope.newPostsCount = 0;
+        newPostsAfter = moment.utc().format();
     }
 
     function loadMore() {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -69,11 +69,10 @@ function PostViewDataController(
     $scope.changeStatus = changeStatus;
     $scope.showPost = showPost;
     $scope.loadMore = loadMore;
-    $scope.resetPosts = resetPosts;
-    $scope.clearPosts = false;
+    var clearPosts = false;
     $scope.clearSelectedPosts = clearSelectedPosts;
     $scope.newPostsCount = 0;
-    $scope.recentPosts = [];
+    var recentPosts = [];
     $scope.addNewestPosts = addNewestPosts;
     $scope.editMode = {editing: false};
     $scope.selectBulkActions = selectBulkActions;
@@ -106,7 +105,7 @@ function PostViewDataController(
             return $scope.filters;
         }, function (newValue, oldValue) {
             if (PostFilters.reactiveFilters === 'enabled' && (newValue !== oldValue)) {
-                $scope.clearPosts = true;
+                clearPosts = true;
                 getPosts(false, false);
                 PostFilters.reactiveFilters = 'disabled';
             }
@@ -204,7 +203,7 @@ function PostViewDataController(
         $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
             //Clear posts
-            $scope.clearPosts ? resetPosts() : null;
+            clearPosts ? resetPosts() : null;
             // Add posts to full set of posts
             // @todo figure out if we can store these more efficiently
             Array.prototype.push.apply($scope.posts, postsResponse.results);
@@ -254,7 +253,7 @@ function PostViewDataController(
                 clearSelectedPosts();
 
                 if (!$scope.posts.length) {
-                    $scope.clearPosts = true;
+                    clearPosts = true;
                     getPosts(false, false);
                 }
             }
@@ -324,7 +323,7 @@ function PostViewDataController(
     function loadMore() {
         // Increment page
         $scope.currentPage++;
-        $scope.clearPosts = false;
+        clearPosts = false;
         getPosts(false, true);
     }
 
@@ -358,7 +357,7 @@ function PostViewDataController(
                 date_after: newPostsAfter
             });
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-                Array.prototype.unshift.apply($scope.recentPosts, postsResponse.results);
+                Array.prototype.unshift.apply(recentPosts, postsResponse.results);
                 $scope.newPostsCount += postsResponse.count;
                 if (postsResponse.count > 0) {
                     // after we get the posts, we set the mostrecentpost
@@ -370,10 +369,10 @@ function PostViewDataController(
     }
 
     function addNewestPosts() {
-        Array.prototype.unshift.apply($scope.posts, $scope.recentPosts);
-        groupPosts($scope.recentPosts);
+        Array.prototype.unshift.apply($scope.posts, recentPosts);
+        groupPosts(recentPosts);
         $scope.totalItems = $scope.totalItems + $scope.newPostsCount;
-        $scope.recentPosts = [];
+        recentPosts = [];
         $scope.newPostsCount = 0;
         $window.document.getElementById('post-data-view-top').scrollTop = 0;
     }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -348,8 +348,7 @@ function PostViewDataController(
     function getNewPosts() {
         var existingFilters = PostFilters.getQueryParams($scope.filters);
         var filterDate = moment(existingFilters.date_before).utc().format();
-
-        if (filterDate >= newPostsAfter) {
+        if (filterDate >= newPostsAfter && existingFilters.order !== 'asc') {
             var query = existingFilters;
             var postQuery = _.extend({}, query, {
                 order: $scope.filters.order,

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,7 +1,7 @@
 <div class="flex-container">
     <post-toolbar saving-post="savingPost" is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
     <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">     
-        <div class="button-group" ng-show="newPostsCount > 0">
+        <div class="button-group" ng-show="newPostsCount > 0 && filters.order !== 'asc'">
             <button class="button-flat full-width" ng-click="addNewestPosts()">
                 <span ng-switch on="newPostsCount">
                     <span ng-switch-default translate="post.see_more_plural" translate-values="{ newPostsCount }">See new posts</span>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,7 +1,7 @@
 <div class="flex-container">
     <post-toolbar saving-post="savingPost" is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
-    <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">     
-        <div class="button-group" ng-show="newPostsCount > 0 && filters.order !== 'asc'">
+    <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
+        <div class="button-group" ng-show="newPostsCount > 0">
             <button class="button-flat full-width" ng-click="addNewestPosts()">
                 <span ng-switch on="newPostsCount">
                     <span ng-switch-default translate="post.see_more_plural" translate-values="{ newPostsCount }">See new posts</span>
@@ -167,7 +167,7 @@
             <div class="listing-item" ng-if="posts.length == 0 && !hasFilters() && !isLoading.state">
                 <h4 translate>post.no_posts_yet</h4>
             </div>
-    
+
             <div class="listing-item" ng-if="posts.length > 0 || isLoading.state">
                 <div class="listing-item-primary">
                     <button ng-disabled="isLoading.state" ng-hide="( isLoading.state || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more


### PR DESCRIPTION
This pull request makes the following changes:
- do not get new posts when sorting by ASC Order

### Testing checklist:

Test normal behavior: 
- [x] Browser 1: load data view. Don't use sorting options
- [x] Browser 2: create and publish a new post
- [x] Browser 1 : wait ˜ 30 seconds and see the "see new posts"button appear.

Test new edge case: 
- [x] Browser 1: load data view. Use "oldest first" as your sort order
- [ ] Browser 2: create and publish a new post
- [x] Browser 1 : wait >30 seconds and don't see the "See new posts" button appear

Fixes ushahidi/platform#2210 .

Ping @ushahidi/platform
