### PR TITLE
2203 : check if lock exists before we try to remove it

### DIFF
--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -312,13 +312,21 @@ function PostDataEditorController(
     function cancel(url) {
         $scope.isLoading.state = false;
         $scope.savingPost.saving = false;
-        PostLockEndpoint.unlock({
-            id: $scope.post.lock.id,
-            post_id: $scope.post.id
-        }).$promise.then(function (result) {
+        /** @DEVNOTE I think we shouldn't need to check this,
+         * but in unstructured posts the lock is not available consistently.
+        **/
+        if ($scope.post.lock) {
+            PostLockEndpoint.unlock({
+                id: $scope.post.lock.id,
+                post_id: $scope.post.id
+            }).$promise.then(function (result) {
+                $scope.editMode.editing = false;
+                doChangePage(url);
+            });
+        } else {
             $scope.editMode.editing = false;
             doChangePage(url);
-        });
+        }
     }
 
     function deletePost(post) {


### PR DESCRIPTION
This pull request makes the following changes:
- lets the user cancel on unstructured posts

Testing checklist:

#### Testing with no changes: 
- [x] Open an unstructured post (one with  no survey attached)
- [x] Don't make any changes
- [x] Try to cancel. It should show the post detail view (right side in data mode) 

#### Testing with no changes: 
- [x] Open an unstructured post (one with  no survey attached)
- [x] Change the title or some other field without saving. 
- [x] Try to cancel. It should show "Are you sure" modal 


Fixes ushahidi/platform#2203 .

Ping @ushahidi/platform