### PR TITLE
Don't reinit the map unless post id changed

### DIFF
--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -15,14 +15,17 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
         var map;
         $scope.hideMap = false;
 
-        $scope.$watch('postId', function (postId) {
-            if (map) {
-                map.remove();
-            }
-            activate();
-        });
-
         activate();
+
+        $scope.$watch('postId', function (postId, oldPostId) {
+            if (postId !== oldPostId) {
+                if (map) {
+                    map.remove();
+                    map = null;
+                }
+                activate();
+            }
+        });
 
         function activate() {
             // Start loading data
@@ -46,8 +49,10 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
             $scope.$on('$destroy', function () {
                 if (map) {
                     map.remove();
+                    map = null;
                 }
             });
+
         }
 
         function addGeoJSONToMap(data) {


### PR DESCRIPTION
This pull request makes the following changes:
- Don't reinit the map unless post id changed
- Don't watch postId till the map is initialized

Testing checklist:
- [x] Load data view and check for leaflet errors
- [x] Switch to map view - check for leaflet errors

Fixes ushahidi/platform#2189

Ping @ushahidi/platform