### PR TITLE
2213 pagination users

### DIFF
--- a/app/common/configs/uib-pagination.html
+++ b/app/common/configs/uib-pagination.html
@@ -1,39 +1,35 @@
-<nav class="pagination" ng-show="pages.length > 1">
-    <ul>
-        <li ng-if="::boundaryLinks" ng-class="{disabled: noPrevious()||ngDisabled}" ng-click="selectPage(1, $event)">
-            <a ng-click="selectPage(1, $event)">{{::getText('first')}}</a>
-        </li>
-        <li ng-if="::directionLinks" ng-class="{disabled: noPrevious()||ngDisabled}" class="prev">
-            <a ng-click="selectPage(page - 1, $event)">
-                <svg class="iconic">
-                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-left"></use>
-                </svg>
-                <span class="hidden">Previous</span>
+
+<li ng-if="::boundaryLinks" ng-class="{disabled: noPrevious()||ngDisabled}" ng-click="selectPage(1, $event)">
+    <a ng-click="selectPage(1, $event)">{{::getText('first')}}</a>
+</li>
+<li ng-if="::directionLinks" ng-class="{disabled: noPrevious()||ngDisabled}" class="prev">
+    <a ng-click="selectPage(page - 1, $event)">
+        <svg class="iconic">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-left"></use>
+        </svg>
+        <span class="hidden">Previous</span>
+    </a>
+</li>
+<li>
+    <ul class="page-numbers">
+        <li class="pg-number" ng-repeat="page in pages track by $index" ng-class="{active: page.active}">
+            <a ng-if="!page.active" ng-click="selectPage(page.number, $event)">
+                {{page.text}}
             </a>
-        </li>
-        <li>
-        	<ul class="page-numbers">
-        		<li class="pg-number" ng-repeat="page in pages track by $index" ng-class="{active: page.active}">
-                    <a ng-if="!page.active" ng-click="selectPage(page.number, $event)">
-                        {{page.text}}
-                    </a>
-                    <span ng-if="page.active">
-                        {{page.text}}
-                    </span>
-                </li>
-        	</ul>
-        </li>
-        <li ng-if="::directionLinks" ng-class="{disabled: noNext()||ngDisabled}" class="next" >
-            <a ng-click="selectPage(page + 1, $event)">
-                <svg class="iconic">
-                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-right"></use>
-                </svg>
-                <span class="hidden">Next</span>
-            </a>
-        </li>
-        <li ng-if="::boundaryLinks" ng-class="{disabled: noNext()||ngDisabled}">
-            <a ng-click="selectPage(totalPages, $event)">{{::getText('last')}}</a>
+            <span ng-if="page.active">
+                {{page.text}}
+            </span>
         </li>
     </ul>
-</nav>
-
+</li>
+<li ng-if="::directionLinks" ng-class="{disabled: noNext()||ngDisabled}" class="next" >
+    <a ng-click="selectPage(page + 1, $event)">
+        <svg class="iconic">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-right"></use>
+        </svg>
+        <span class="hidden">Next</span>
+    </a>
+</li>
+<li ng-if="::boundaryLinks" ng-class="{disabled: noNext()||ngDisabled}">
+    <a ng-click="selectPage(totalPages, $event)">{{::getText('last')}}</a>
+</li>

--- a/app/main/activity/activity-timeline.html
+++ b/app/main/activity/activity-timeline.html
@@ -209,9 +209,6 @@
            </div>
        </div>
   </div>
-
-   <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
-
 </div> <!--end main column-->
 
 <div>

--- a/app/settings/categories/categories.html
+++ b/app/settings/categories/categories.html
@@ -86,9 +86,13 @@
                     </button>
                 </listing-toolbar>
             </div>
-
+            <!--
+            @FIXME
+            I don't know if we actually need pagination here. Since we didn't use to have a working pagination, I'm commenting out for the moment.
+             Opening a ticket for this and if it turns out we don't need it I'll just delete this code.
+            so I can send the PR for users which do need pagination
             <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
-
-        </div>
-    </main>
+            !-->
+       </div>
+   </main>
 </div>

--- a/app/settings/roles/roles.html
+++ b/app/settings/roles/roles.html
@@ -47,9 +47,6 @@
                     </div>
                 </div>
             </div>
-
-            <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
-
         </div>
     </main>
 </div>

--- a/app/settings/users/users.controller.js
+++ b/app/settings/users/users.controller.js
@@ -138,6 +138,7 @@ function (
         UserEndpoint.queryFresh(filters).$promise.then(function (usersResponse) {
             $scope.users = usersResponse.results;
             $scope.totalItems = usersResponse.total_count;
+            $scope.showPagination = $scope.totalItems / $scope.itemsPerPage < 2;
         });
     };
 
@@ -155,7 +156,6 @@ function (
     $scope.itemsPerPage = $scope.itemsPerPageOptions[0];
     // untill we have the correct total_count value from backend request:
     $scope.totalItems = $scope.itemsPerPage;
-
     $scope.getUsersForPagination();
     // --- end: initialization
     $scope.$watch('filters', function () {

--- a/app/settings/users/users.controller.js
+++ b/app/settings/users/users.controller.js
@@ -138,7 +138,7 @@ function (
         UserEndpoint.queryFresh(filters).$promise.then(function (usersResponse) {
             $scope.users = usersResponse.results;
             $scope.totalItems = usersResponse.total_count;
-            $scope.showPagination = $scope.totalItems / $scope.itemsPerPage < 2;
+            $scope.showPagination = $scope.totalItems > 0  ? $scope.totalItems / $scope.itemsPerPage > 1 : false;
         });
     };
 

--- a/app/settings/users/users.html
+++ b/app/settings/users/users.html
@@ -1,6 +1,5 @@
 <div>
     <div class="mode-context init" dropdown>
-
         <header class="mode-context-header">
             <ol class="breadcrumbs">
                 <li><a href="/" ng-controller="navigation as nav">{{nav.site.name}}</a></li>
@@ -90,7 +89,7 @@
                     </button>
                 </listing-toolbar>
              </div>
-            <nav class="pagination" ng-if="showPagination">
+            <nav class="pagination" ng-show="showPagination">
                 <ul uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></ul>
             </nav>
         </div>

--- a/app/settings/users/users.html
+++ b/app/settings/users/users.html
@@ -90,9 +90,9 @@
                     </button>
                 </listing-toolbar>
              </div>
-
-           <uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></uib-pagination>
-
+            <nav class="pagination" ng-if="showPagination">
+                <ul uib-pagination ng-model="currentPage" items-per-page="itemsPerPage" total-items="totalItems" ng-change="pageChanged()" max-size="5" boundary-links="false" rotate="false"></ul>
+            </nav>
         </div>
     </main>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- add pagination for users
-  remove pagination html where not needed
- commented out pagination in categories while we clarify the requirement there since it was not working and It's not obvious why it would exist


Testing checklist:
- [ ] Load the users (settings/user) screen.  
- [ ] Load the users (settings/user) screen. If there are more than 10 users, there is pagination 
- [ ] Load the users (settings/user) screen. If there are 10 users or less, there is no pagination 
Nothing new, but worth mentioning: 
- [ ] Load the categories page. There is no pagination
- [ ] Load the activity page. There is no pagination
- [ ] Load the roles page. There is no pagination

Fixes ushahidi/platform#2213.

Ping @ushahidi/platform