### PR TITLE
saving values from post-data-editor

### DIFF
--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -392,11 +392,13 @@ function PostDataEditorController(
 
             // Avoid messing with original object
             // Clean up post values object
+
             if ('message_location' in $scope.post.values) {
                 $scope.post.values.message_location = [];
             }
-            var post = PostEditService.cleanPostValues(angular.copy($scope.post));
 
+
+            var post = PostEditService.cleanPostValues(_.clone($scope.post));
             // adding neccessary tags to post.tags, needed for filtering
             if ($scope.tagKeys.length > 0) {
                 post.tags = _.chain(post.values)

--- a/app/main/posts/modify/post-edit.service.js
+++ b/app/main/posts/modify/post-edit.service.js
@@ -11,7 +11,7 @@ function (
 ) {
     var PostEditService = {
         cleanPostValues: function (post) {
-            _.each(post.values, function (value, key) {
+            _.forEach(post.values, function (value, key) {
                 // Strip out empty values
                 post.values[key] = _.filter(value);
                 // Remove entirely if no values are left


### PR DESCRIPTION
This pull request makes the following changes:
- Changes the way post.values are copied and looped through when cleaning empty values in post-data-editor

Testing checklist:
- [x] go to post-data-view
- [x] select a post with some fields empty
- [x] choose to edit, add values in the empty fields
- [x] save
- [x] values should be saved and visible in the post-detail-view

Fixes ushahidi/platform#2215 .

Ping @ushahidi/platform
