### PR TITLE
2206 post edit mode

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -71,12 +71,12 @@ function PostActionsDirective(
                 return;
             }
 
-            $scope.selectedPost.post = _.clone($scope.post);
             if ($routeParams.view !== 'data' && $location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + postId + '/edit');
             } else if ($scope.editMode.editing) {
                 $rootScope.$broadcast('event:edit:leave:form');
                 $scope.$on('event:edit:leave:form:complete', function () {
+                    $scope.selectedPost.post = _.clone($scope.post);
                     $scope.editMode.editing = true;
                     $rootScope.$broadcast('event:edit:post:reactivate');
                 });

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -74,13 +74,12 @@ function PostActionsDirective(
             if ($routeParams.view !== 'data' && $location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + postId + '/edit');
             } else if ($scope.editMode.editing) {
+                // At this point we are not certain we will switch to this Post so we back it up
+                // in anticipation of using it later if the current Post exists corectly
+                $scope.selectedPost.next = _.clone($scope.post);
                 $rootScope.$broadcast('event:edit:leave:form');
-                $scope.$on('event:edit:leave:form:complete', function () {
-                    $scope.selectedPost.post = _.clone($scope.post);
-                    $scope.editMode.editing = true;
-                    $rootScope.$broadcast('event:edit:post:reactivate');
-                });
             } else {
+                $scope.selectedPost.post = _.clone($scope.post);
                 $scope.editMode.editing = true;
             }
         }

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -8,7 +8,8 @@ PostActionsDirective.$inject = [
     '$route',
     'PostActionsService',
     'PostLockService',
-    '$routeParams'
+    '$routeParams',
+    '_'
 ];
 function PostActionsDirective(
     $rootScope,
@@ -18,7 +19,8 @@ function PostActionsDirective(
     $route,
     PostActionsService,
     PostLockService,
-    $routeParams
+    $routeParams,
+    _
 ) {
     return {
         restrict: 'E',
@@ -69,11 +71,15 @@ function PostActionsDirective(
                 return;
             }
 
-            $scope.selectedPost.post = $scope.post ;
+            $scope.selectedPost.post = _.clone($scope.post);
             if ($routeParams.view !== 'data' && $location.path().indexOf('data') === -1) {
                 $location.path('/posts/' + postId + '/edit');
             } else if ($scope.editMode.editing) {
                 $rootScope.$broadcast('event:edit:leave:form');
+                $scope.$on('event:edit:leave:form:complete', function () {
+                    $scope.editMode.editing = true;
+                    $rootScope.$broadcast('event:edit:post:reactivate');
+                });
             } else {
                 $scope.editMode.editing = true;
             }

--- a/app/main/posts/common/post-actions.html
+++ b/app/main/posts/common/post-actions.html
@@ -1,4 +1,4 @@
-<div class="postcard-actions" dropdown ng-click="$event.stopPropagation();">
+<div class="postcard-actions" dropdown >
   <button class="button-gamma button-flat init" data-toggle="dropdown-menu" dropdown-toggle>
       <svg class="iconic">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#ellipses"></use>

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -74,6 +74,7 @@ function PostDetailDataController(
 
     function activate() {
         // Set page title to post title, if there is one available.
+        $scope.isLoading.state = true;
         if ($scope.post.title && $scope.post.title.length) {
             $scope.$emit('setPageTitle', $scope.post.title);
         } else {
@@ -153,11 +154,12 @@ function PostDetailDataController(
                     }
                 });
                 $scope.tasks_with_attributes = _.uniq($scope.tasks_with_attributes);
+                $scope.isLoading.state = false;
             });
-
         } else {
             // for when user switch between posts, if new post has no form, there are no tasks either.
             $scope.tasks = [];
+            $scope.isLoading.state = false;
         }
     }
 

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -364,9 +364,8 @@ function PostDataEditorController(
             leaveEditMode();
             $scope.isLoading.state = false;
             $scope.savingPost.saving = false;
-            doChangePage(url);
+            $scope.cancel(url);
         } else {
-            //$scope.editMode.editing = true;
             if (ev) {
                 ev.preventDefault();
             }
@@ -375,10 +374,9 @@ function PostDataEditorController(
                 $scope.savingPost.saving = false;
                 $scope.cancel(url);
             }, function () {
-                //$scope.editMode.editing = true;
                 $scope.isLoading.state = false;
                 $scope.savingPost.saving = false;
-                doChangePage(url);
+                $scope.cancel(url);
             });
         }
     }

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -431,10 +431,13 @@ function PostDataEditorController(
                 var success_message = (response.status && response.status === 'published') ? 'notify.post.save_success' : 'notify.post.save_success_review';
 
                 // Save the updated post back to outside context
-                $scope.postContainer.post = $scope.post;
+                $scope.postContainer.post = response;
 
                 // DEVNOTE: Not sure how this would ever happen in the case of data view
                 // ideally this will go away when the two editors are integrated
+                // This is not currently relevant to the data view directive
+                // if data view becomes capable of creating Posts this will need to be changed
+                // as it will not currently prevent display of the Post
 
                 if (response.id && response.allowed_privileges.indexOf('read') !== -1) {
                     $scope.post.id = response.id;
@@ -444,7 +447,7 @@ function PostDataEditorController(
                 Notify.notify(success_message, { name: $scope.post.title });
 
                 $scope.isLoading.state = false;
-                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess');
+                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response});
 
                 leaveEditMode();
             }, function (errorResponse) { // errors

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -106,7 +106,7 @@
         </post-tabs>
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
-          <button class="button-flat" ng-click="leavePost()" translate>app.cancel</button>
+          <button class="button-flat" ng-click="exit()" translate>app.cancel</button>
           <button class="button button-alpha" ng-click="savePost()" ng-if="!savingPost.saving" translate="">app.save</button>
           <button class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
             <div class="loading">

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -106,7 +106,7 @@
         </post-tabs>
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
-          <button class="button-flat" ng-click="exit()" translate>app.cancel</button>
+          <button class="button-flat" ng-click="leavePost()" translate>app.cancel</button>
           <button class="button button-alpha" ng-click="savePost()" ng-if="!savingPost.saving" translate="">app.save</button>
           <button class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
             <div class="loading">

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -1,4 +1,4 @@
-<article ng-class="['postcard', {selected: inFocus}]" ng-click="clickAction(post)">
+<article ng-class="['postcard', {selected: post.id === selectedPost.post.id}]" >
     <div class="post-band" ng-style="{backgroundColor: post.form.color}"></div>
     <div class="listing-item-select">
         <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts" ng-click="stopClickPropagation($event)">
@@ -10,23 +10,23 @@
         <!-- this is used in the map view card and the sidebar card in the data view-->
         <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
       </header>
-        <div class="postcard-overflow">
-        <div class="postcard-title">
-            <div class="postcard-field">
-              {{ post.title || post.content | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}
+        <div class="postcard-overflow" ng-click="clickAction(post)">
+            <div class="postcard-title">
+                <div class="postcard-field">
+                {{ post.title || post.content | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}
+                </div>
             </div>
-        </div>
 
 
-        <post-preview-media post="post"></post-preview-media>
-        <!-- <img src="http://lorempixel.com/400/300/" class="postcard-image"> -->
+            <post-preview-media post="post"></post-preview-media>
+            <!-- <img src="http://lorempixel.com/400/300/" class="postcard-image"> -->
 
-        <div ng-if="!shortContent" class="postcard-field">
-            {{ post.content }}
-        </div>
-        <div ng-if="shortContent" class="postcard-field">
-            {{ post.content | limitTo:150 }}{{ post.content.length > 150 ? ' ...' : ''}}
-        </div>
+            <div ng-if="!shortContent" class="postcard-field">
+                {{ post.content }}
+            </div>
+            <div ng-if="shortContent" class="postcard-field">
+                {{ post.content | limitTo:150 }}{{ post.content.length > 150 ? ' ...' : ''}}
+            </div>
         </div>
     </div> <!-- /postcard-body -->
 </article>

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -9,7 +9,6 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
             post:  '=',
             canSelect: '=',
             selectedPosts: '=',
-            inFocus: '=',
             shortContent: '@',
             clickAction: '=',
             editMode: '=',

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -122,14 +122,24 @@ function PostViewDataController(
         $scope.$on('event:edit:leave:form:complete', function () {
             // Bercause there is no state management
             // We copy the next Post to be the current Post
-            // if the previous Post existed correctly
+            // if the previous Post exited correctly
             // Ideally Post Card would become a service more akin
-            // to Notify
+            // to Notify and manage its own scope
             if (!_.isEmpty($scope.selectedPost.next)) {
                 $scope.selectedPost.post = $scope.selectedPost.next;
                 $scope.selectedPost.next = {};
                 $scope.editMode.editing = true;
                 $rootScope.$broadcast('event:edit:post:reactivate');
+            }
+        });
+
+        // When a Post has been saved in the Data View it must be updated in the
+        // Post list so that the change will persist.
+        // This event is expected to be fired on successful completion of a Post save
+        // it expects the updated Post data as an argument passed via the event
+        $scope.$on('event:edit:post:data:mode:saveSuccess', function (event, args) {
+            if (args.post) {
+                persistUpdatedPost(args.post);
             }
         });
 
@@ -152,6 +162,11 @@ function PostViewDataController(
             }
         });
         checkForNewPosts(30000);
+    }
+
+    function persistUpdatedPost(updatedPost) {
+        _.extend(_.findWhere($scope.posts, { id: updatedPost.id }), updatedPost);
+        console.log();
     }
 
     function confirmEditingExit() {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -78,7 +78,7 @@ function PostViewDataController(
     $scope.selectBulkActions = selectBulkActions;
     $scope.bulkActionsSelected = '';
     $scope.closeBulkActions = closeBulkActions;
-    $scope.selectedPost = {post: null};
+    $scope.selectedPost = {post: null, next: {}};
     $scope.selectedPostId = null;
     $scope.formData = {form: {}};
     $rootScope.setLayout('layout-d');
@@ -118,6 +118,20 @@ function PostViewDataController(
                 $timeout.cancel(stopInterval);
             }
         );
+
+        $scope.$on('event:edit:leave:form:complete', function () {
+            // Bercause there is no state management
+            // We copy the next Post to be the current Post
+            // if the previous Post existed correctly
+            // Ideally Post Card would become a service more akin
+            // to Notify
+            if (!_.isEmpty($scope.selectedPost.next)) {
+                $scope.selectedPost.post = $scope.selectedPost.next;
+                $scope.selectedPost.next = {};
+                $scope.editMode.editing = true;
+                $rootScope.$broadcast('event:edit:post:reactivate');
+            }
+        });
 
         $scope.$watch(function () {
             return $location.path();

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -165,8 +165,10 @@ function PostViewDataController(
     }
 
     function persistUpdatedPost(updatedPost) {
-        _.extend(_.findWhere($scope.posts, { id: updatedPost.id }), updatedPost);
-        console.log();
+        var index = _.findIndex($scope.posts, function (post) {
+            return post.id === updatedPost.id;
+        });
+        $scope.posts.splice(index, 1, updatedPost);
     }
 
     function confirmEditingExit() {

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -62,10 +62,9 @@
             <post-card
                 ng-repeat="post in posts"
                 can-select="bulkActionsSelected"
-                post="post.id === selectedPostId ? selectedPost.post : post"
+                post="post"
                 selected-posts="selectedPosts"
                 click-action="showPost"
-                in-focus="selectedPostId === post.id",
                 edit-mode="editMode"
                 selected-post="selectedPost"
             >


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes the issue where you could not select a Post other than the currently selected Post to edit from the post card action menu

Testing checklist:
- [x] On Data View, select a Post
  - [x] Click edit
  - [x] Click the ... menu on a different Post
    - [x] Click edit
      - [x] You should be shown the edit view for the new post
- [x] On Data View, select a Post
  - [x] Click the ... menu on a different Post
  - [x] Click edit
    - [x] You should be shown the Edit view for that Post
- [x] On Data View, select a Post
  - [x] Click Edit
   - [x] Change the value of one of the fields
     - [x] Click the ... menu on a different Post
     - [x] Click edit
       - [x] You should see a warning that you have unsaved changes
         - [x] Click the X in the top right hand corner
           - [x] You should remain on the current Post
         - [x] Click continue without saving 
           - [x] You should move to the new Post
         - [x] Click save
           - [x] You should move to the new Post
- [x] On Map view
  - [x] Click the ... menu on a Post
  - [x] Click edit
    - [x] You should be taken to the edit page for the Post

Fixes ushahidi/platform#2206

Ping @ushahidi/platform
