### PR TITLE
2215 fix saving changes to post values

### DIFF
--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -37,8 +37,17 @@ function (
                 return normalizePost(angular.fromJson(data));
             }
         },
+        save: {
+            method: 'POST',
+            transformResponse: function (data /*, header*/) {
+                return normalizePost(angular.fromJson(data));
+            }
+        },
         update: {
-            method: 'PUT'
+            method: 'PUT',
+            transformResponse: function (data /*, header*/) {
+                return normalizePost(angular.fromJson(data));
+            }
         },
         options: {
             method: 'OPTIONS'

--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -22,20 +22,19 @@ function (
             params: {
                 order: 'desc',
                 orderby: 'post_date'
+            },
+            transformResponse: (data) => {
+                data = angular.fromJson(data);
+                data.results = data.results.map(normalizePost);
+
+                return data;
             }
+
         },
         get: {
             method: 'GET',
             transformResponse: function (data /*, header*/) {
-                data = angular.fromJson(data);
-                // Ensure values is always an object
-                if (_.isArray(data.values)) {
-                    data.values = _.object(data.values);
-                }
-                if (!_.isArray(data.published_to)) {
-                    data.published_to = [];
-                }
-                return data;
+                return normalizePost(angular.fromJson(data));
             }
         },
         update: {
@@ -76,6 +75,18 @@ function (
     $rootScope.$on('event:authentication:logout:succeeded', function () {
         PostEndpoint.query();
     });
+
+    function normalizePost(post) {
+        // Ensure values is always an object
+        if (_.isArray(post.values)) {
+            post.values = _.object(post.values);
+        }
+        if (!_.isArray(post.published_to)) {
+            post.published_to = [];
+        }
+
+        return post;
+    }
 
     return PostEndpoint;
 

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -392,13 +392,11 @@ function PostDataEditorController(
 
             // Avoid messing with original object
             // Clean up post values object
-
             if ('message_location' in $scope.post.values) {
                 $scope.post.values.message_location = [];
             }
+            var post = PostEditService.cleanPostValues(angular.copy($scope.post));
 
-
-            var post = PostEditService.cleanPostValues(_.clone($scope.post));
             // adding neccessary tags to post.tags, needed for filtering
             if ($scope.tagKeys.length > 0) {
                 post.tags = _.chain(post.values)

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -415,7 +415,8 @@ function PostDataEditorController(
             }
             request.$promise.then(function (response) {
                 var success_message = (response.status && response.status === 'published') ? 'notify.post.save_success' : 'notify.post.save_success_review';
-                $scope.postContainer.post = $scope.post;
+                // Save the updated post back to outside context
+                $scope.postContainer.post = response;
                 if (response.id && response.allowed_privileges.indexOf('read') !== -1) {
                     $scope.savingPost.saving = false;
                     $scope.post.id = response.id;

--- a/app/main/posts/modify/post-edit.service.js
+++ b/app/main/posts/modify/post-edit.service.js
@@ -11,7 +11,7 @@ function (
 ) {
     var PostEditService = {
         cleanPostValues: function (post) {
-            _.forEach(post.values, function (value, key) {
+            _.each(post.values, function (value, key) {
                 // Strip out empty values
                 post.values[key] = _.filter(value);
                 // Remove entirely if no values are left


### PR DESCRIPTION
This pull request makes the following changes:
- Normalize posts returned from the posts endpoint .query() method
- Revert #874

Testing checklist:
- [x] go to post-data-view
- [x] select a post with *all custom fields empty* (ie. it can have title + description but nothing else)
- [x] choose to edit, add values in the empty fields
- [x] save
- [x] values should be saved and visible in the post-detail-view

Fixes ushahidi/platform#2215

Ping @ushahidi/platform
