### PR TITLE
2208 loadposts - show loading page while switching to the posts screen 

### DIFF
--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -71,6 +71,8 @@ function (
             $scope.$emit('setPageTitle', title);
         });
     }
+    angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
+    angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
 
     // Load the post form
     if ($scope.post.form && $scope.post.form.id) {
@@ -143,13 +145,7 @@ function (
                 }
             });
             $scope.tasks_with_attributes = _.uniq($scope.tasks_with_attributes);
-
-            angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
-            angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
         });
-    } else {
-        angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
-        angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
     }
 
     $scope.taskHasValues = function (task) {

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -147,6 +147,9 @@ function (
             angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
             angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
         });
+    } else {
+        angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
+        angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
     }
 
     $scope.taskHasValues = function (task) {


### PR DESCRIPTION
This pull request makes the following changes:
- show loading page while switching to the posts screen 

Testing checklist:
- [x] Open the data view mode in mobile viewport
- [x] Click on a post
- [x] You should see the full page ". . . " jumping around. 
- [x] The post should load and the '. . . 'dissapear

+ Test for this fixed scenario

Testing checklist:
- [x] Open the data view mode in mobile viewport
- [x] Click on a post that is unstructured (does not have a survey/form)
- [x] You should see the full page ". . . " jumping around. 
- [x] The post should load and the '. . . 'dissapear

Fixes ushahidi/platform#2208 .

Ping @ushahidi/platform