### PR TITLE
Handle empty post responses before trying to normalize a post

### DIFF
--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -23,31 +23,57 @@ function (
                 order: 'desc',
                 orderby: 'post_date'
             },
-            transformResponse: (data) => {
-                data = angular.fromJson(data);
-                data.results = data.results.map(normalizePost);
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                (data) => {
+                    if (!data) {
+                        return data;
+                    }
 
-                return data;
-            }
+                    data.results = data.results.map(normalizePost);
 
+                    return data;
+                }
+            ]
         },
         get: {
             method: 'GET',
-            transformResponse: function (data /*, header*/) {
-                return normalizePost(angular.fromJson(data));
-            }
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
+                }
+            ]
         },
         save: {
             method: 'POST',
-            transformResponse: function (data /*, header*/) {
-                return normalizePost(angular.fromJson(data));
-            }
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
+                }
+            ]
         },
         update: {
             method: 'PUT',
-            transformResponse: function (data /*, header*/) {
-                return normalizePost(angular.fromJson(data));
-            }
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
+                }
+            ]
         },
         options: {
             method: 'OPTIONS'


### PR DESCRIPTION
This pull request makes the following changes:
- Handle empty post responses before trying to normalize a post

Testing checklist:
- [ ] As a non-logged in user, create a new post on a survey that requires approval. See success message
- [ ] As a non-logged in user, create a new post on a survey that does not require approval. See success message

Fixes ushahidi/platform#2241

Ping @ushahidi/platform
