### PR TITLE
Minor auth improvements

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -2,6 +2,7 @@ module.exports = AuthenticationEvents;
 
 AuthenticationEvents.$inject = ['$rootScope', '$location', 'Authentication', 'Session', '_', '$route', 'TermsOfService', 'Notify'];
 function AuthenticationEvents($rootScope, $location, Authentication, Session, _, $route, TermsOfService, Notify) {
+    let loginPath = null;
     $rootScope.currentUser = null;
     $rootScope.loggedin = false;
 
@@ -68,7 +69,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     };
 
     $rootScope.$on('event:authentication:login:succeeded', function () {
-        doLogin(Session.getSessionDataEntry('loginPath'));
+        doLogin(loginPath);
     });
 
     $rootScope.$on('event:authentication:logout:succeeded', function () {
@@ -81,8 +82,9 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     // });
 
     $rootScope.$on('event:unauthorized', function () {
-        if ($location.url() !== '/login') {
-            Session.setSessionDataEntry('loginPath', $location.url());
+        let currentUrl = $location.url();
+        if (currentUrl !== '/login') {
+            loginPath = currentUrl;
         }
         Authentication.logout(true);
         doLogout();
@@ -94,10 +96,11 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
             // We're logged in hit forbidden page
             $location.url('/forbidden');
         } else {
+            let currentUrl = $location.url();
             // We're logged out, redirect to login
-            if ($location.url() !== '/login') {
-                Session.setSessionDataEntry('loginPath', $location.url());
-                // We're logged in hit forbidden page
+            if (currentUrl !== '/login') {
+                loginPath = currentUrl;
+                // Show forbidden page until we're logged in
                 $location.url('/forbidden');
             }
             Authentication.openLogin();

--- a/app/common/auth/authentication-interceptor.config.js
+++ b/app/common/auth/authentication-interceptor.config.js
@@ -28,7 +28,11 @@ function AuthInterceptor($rootScope, $injector, $q, CONST, Session, _) {
 
         function handleRequestSuccess(authResponse) {
             var accessToken = authResponse.data.access_token;
+            // Save access token
             Session.setSessionDataEntry('accessToken', accessToken);
+            // Save token expires time
+            Session.setSessionDataEntry('accessTokenExpires', authResponse.data.expires);
+            // Add Authorization header
             config.headers.Authorization = 'Bearer ' + accessToken;
             deferred.resolve(config);
         }
@@ -90,9 +94,11 @@ function AuthInterceptor($rootScope, $injector, $q, CONST, Session, _) {
         }
 
         var accessToken = Session.getSessionDataEntry('accessToken');
+        var accessTokenExpires = Session.getSessionDataEntry('accessTokenExpires');
+        var now = Math.floor(Date.now() / 1000);
 
-        if (accessToken !== undefined && accessToken !== null) {
-            // if we already have an accessToken,
+        if (accessToken !== undefined && accessToken !== null && accessTokenExpires > now) {
+            // if we already have a valid accessToken,
             // we will set it straight ahead
             // and resolve the promise for the config hash
             config.headers.Authorization = 'Bearer ' + accessToken;

--- a/app/common/auth/authentication.service.js
+++ b/app/common/auth/authentication.service.js
@@ -24,11 +24,13 @@ function (
     ModalService
 ) {
 
-    // check whether we have initially an old access_token and userId
+    // check whether we have initially an valid access_token and userId
     // and assume that, if yes, we are still loggedin
-    var loginStatus = !!Session.getSessionDataEntry('accessToken') && !!Session.getSessionDataEntry('userId'),
+    var loginStatus = !!Session.getSessionDataEntry('accessToken') &&
+        Session.getSessionDataEntry('accessTokenExpires') > Math.floor(Date.now() / 1000) &&
+        !!Session.getSessionDataEntry('userId');
 
-    setToLoginState = function (userData) {
+    function setToLoginState(userData) {
         Session.setSessionDataEntries({
             userId: userData.id,
             realname: userData.realname,
@@ -39,13 +41,13 @@ function (
             language: userData.language
         });
         loginStatus = true;
-    },
+    }
 
-    setToLogoutState = function () {
+    function setToLogoutState() {
         Session.clearSessionData();
         UserEndpoint.invalidateCache();
         loginStatus = false;
-    };
+    }
 
     return {
 
@@ -70,6 +72,7 @@ function (
             handleRequestSuccess = function (authResponse) {
                 var accessToken = authResponse.data.access_token;
                 Session.setSessionDataEntry('accessToken', accessToken);
+                Session.setSessionDataEntry('accessTokenExpires', authResponse.data.expires);
 
                 $http.get(Util.apiUrl('/users/me')).then(
                     function (userDataResponse) {

--- a/app/common/auth/session.service.js
+++ b/app/common/auth/session.service.js
@@ -9,6 +9,7 @@ function (
         realname: undefined,
         email: undefined,
         accessToken: undefined,
+        accessTokenExpires: undefined,
         role: undefined,
         permissions: undefined,
         loginPath: undefined,

--- a/app/common/auth/session.service.js
+++ b/app/common/auth/session.service.js
@@ -12,7 +12,6 @@ function (
         accessTokenExpires: undefined,
         role: undefined,
         permissions: undefined,
-        loginPath: undefined,
         gravatar: undefined
     };
 

--- a/test/unit/common/auth/authentication-interceptor.config.spec.js
+++ b/test/unit/common/auth/authentication-interceptor.config.spec.js
@@ -15,7 +15,8 @@ describe('authentication interceptor', function () {
         });
 
         mockedSessionData = {
-            accessToken: null
+            accessToken: null,
+            accessTokenExpires: null
         };
         mockAuthentication = {
             loginStatus : false,
@@ -69,6 +70,7 @@ describe('authentication interceptor', function () {
             describe('with an accessToken stored in the Session service', function () {
                 beforeEach(function () {
                     mockedSessionData.accessToken = 'fooBarToken';
+                    mockedSessionData.accessTokenExpires = 9999999999999;
                 });
 
                 it('should add the authorization token header', function () {

--- a/test/unit/common/auth/authentication.service.spec.js
+++ b/test/unit/common/auth/authentication.service.spec.js
@@ -100,6 +100,7 @@ describe('Authentication', function () {
 
                 it('should add the accessToken to the Session', function () {
                     expect(mockedSessionData.accessToken).toEqual(mockedOauthTokenResponse.access_token);
+                    expect(mockedSessionData.accessTokenExpires).toEqual(mockedOauthTokenResponse.expires);
                 });
 
                 it('should add the userData to the Session', function () {

--- a/test/unit/common/auth/session-spec.js
+++ b/test/unit/common/auth/session-spec.js
@@ -14,8 +14,9 @@ describe('Session', function () {
             permissions: undefined,
             accessToken: undefined,
             accessTokenExpires: undefined,
-            loginPath: undefined,
-            gravatar: undefined        };
+
+            gravatar: undefined
+        };
 
         var testApp = makeTestApp();
 
@@ -89,7 +90,6 @@ describe('Session', function () {
                     permissions: undefined,
                     accessToken: 'secrettoken',
                     accessTokenExpires: undefined,
-                    loginPath: undefined,
                     gravatar: undefined
                 };
 

--- a/test/unit/common/auth/session-spec.js
+++ b/test/unit/common/auth/session-spec.js
@@ -13,6 +13,7 @@ describe('Session', function () {
             role: undefined,
             permissions: undefined,
             accessToken: undefined,
+            accessTokenExpires: undefined,
             loginPath: undefined,
             gravatar: undefined        };
 
@@ -87,6 +88,7 @@ describe('Session', function () {
                     role: undefined,
                     permissions: undefined,
                     accessToken: 'secrettoken',
+                    accessTokenExpires: undefined,
                     loginPath: undefined,
                     gravatar: undefined
                 };


### PR DESCRIPTION
This pull request makes the following changes:
- Move loginPath out of Session service so it doesn't get wiped on a failed login (ushahidi/platform#2222)
- Save access token expiry time and check it before attempting to use a token

Testing 1:
- [x] Log in
- [x] Wait for session to expire (You might need to hack local storage values to avoid waiting a long time)
- [x] With Network tab open, Reload the app. You should see requests are *not* sent with the auth token. 

Test 2:
- [x] Login in
- [x] Go to an unpublished post
- [x] Logout ... get redirected to 'forbidden' and logged out
- [x] Log in with wrong user/pass
- [x] Log in with correct user/pass. You should be directed to the post again, not left on /forbidden

Fixes ushahidi/platform#2222

Ping @ushahidi/platform
