### PR TITLE
Update data view when posts no longer match search/filters

### DIFF
--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -22,24 +22,59 @@ function (
             params: {
                 order: 'desc',
                 orderby: 'post_date'
-            }
+            },
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                (data) => {
+                    if (!data) {
+                        return data;
+                    }
+                    if (data.results) {
+                        data.results = data.results.map(normalizePost);
+                    }
+
+                    return data;
+                }
+            ]
         },
         get: {
             method: 'GET',
-            transformResponse: function (data /*, header*/) {
-                data = angular.fromJson(data);
-                // Ensure values is always an object
-                if (_.isArray(data.values)) {
-                    data.values = _.object(data.values);
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
                 }
-                if (!_.isArray(data.published_to)) {
-                    data.published_to = [];
+            ]
+        },
+        save: {
+            method: 'POST',
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
                 }
-                return data;
-            }
+            ]
         },
         update: {
-            method: 'PUT'
+            method: 'PUT',
+            transformResponse: [
+                $http.defaults.transformResponse[0],
+                function (data /*, header*/) {
+                    if (!data) {
+                        return data;
+                    }
+
+                    return normalizePost(data);
+                }
+            ]
         },
         options: {
             method: 'OPTIONS'
@@ -76,6 +111,18 @@ function (
     $rootScope.$on('event:authentication:logout:succeeded', function () {
         PostEndpoint.query();
     });
+
+    function normalizePost(post) {
+        // Ensure values is always an object
+        if (_.isArray(post.values)) {
+            post.values = _.object(post.values);
+        }
+        if (!_.isArray(post.published_to)) {
+            post.published_to = [];
+        }
+
+        return post;
+    }
 
     return PostEndpoint;
 

--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -22,59 +22,24 @@ function (
             params: {
                 order: 'desc',
                 orderby: 'post_date'
-            },
-            transformResponse: [
-                $http.defaults.transformResponse[0],
-                (data) => {
-                    if (!data) {
-                        return data;
-                    }
-                    if (data.results) {
-                        data.results = data.results.map(normalizePost);
-                    }
-
-                    return data;
-                }
-            ]
+            }
         },
         get: {
             method: 'GET',
-            transformResponse: [
-                $http.defaults.transformResponse[0],
-                function (data /*, header*/) {
-                    if (!data) {
-                        return data;
-                    }
-
-                    return normalizePost(data);
+            transformResponse: function (data /*, header*/) {
+                data = angular.fromJson(data);
+                // Ensure values is always an object
+                if (_.isArray(data.values)) {
+                    data.values = _.object(data.values);
                 }
-            ]
-        },
-        save: {
-            method: 'POST',
-            transformResponse: [
-                $http.defaults.transformResponse[0],
-                function (data /*, header*/) {
-                    if (!data) {
-                        return data;
-                    }
-
-                    return normalizePost(data);
+                if (!_.isArray(data.published_to)) {
+                    data.published_to = [];
                 }
-            ]
+                return data;
+            }
         },
         update: {
-            method: 'PUT',
-            transformResponse: [
-                $http.defaults.transformResponse[0],
-                function (data /*, header*/) {
-                    if (!data) {
-                        return data;
-                    }
-
-                    return normalizePost(data);
-                }
-            ]
+            method: 'PUT'
         },
         options: {
             method: 'OPTIONS'
@@ -111,18 +76,6 @@ function (
     $rootScope.$on('event:authentication:logout:succeeded', function () {
         PostEndpoint.query();
     });
-
-    function normalizePost(post) {
-        // Ensure values is always an object
-        if (_.isArray(post.values)) {
-            post.values = _.object(post.values);
-        }
-        if (!_.isArray(post.published_to)) {
-            post.published_to = [];
-        }
-
-        return post;
-    }
 
     return PostEndpoint;
 

--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -29,10 +29,7 @@ function (
                     if (!data) {
                         return data;
                     }
-                    if (data.results) {
-                        data.results = data.results.map(normalizePost);
-                    }
-
+                    data.results = data.results.map(normalizePost);
                     return data;
                 }
             ]

--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -29,8 +29,9 @@ function (
                     if (!data) {
                         return data;
                     }
-
-                    data.results = data.results.map(normalizePost);
+                    if (data.results) {
+                        data.results = data.results.map(normalizePost);
+                    }
 
                     return data;
                 }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -107,18 +107,13 @@ function PostViewDataController(
             let query = PostFilters.getQueryParams($scope.filters);
 
             let postQuery = _.extend({}, query, {
-                limit: $scope.itemsPerPage
+                post_id: $scope.selectedPostId
             });
 
-            postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
-
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-                for (let i = 0; i < postsResponse.results.length; i++) {
-                    if (postsResponse.results[i].id === $scope.selectedPostId) {
-                        return;
-                    }
+                if (!postsResponse) {
+                    removePostFromList();
                 }
-                removePostFromList();
             });
         }
     });

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -93,8 +93,10 @@ function PostViewDataController(
         function removePostFromList() {
             for (var i = 0; i < $scope.posts.length; i++) {
                 if ($scope.posts[i].id === $scope.selectedPostId) {
+                    let nextInLine = $scope.posts[i + 1];
                     $scope.posts.splice(i, 1);
                     groupPosts($scope.posts);
+                    $scope.selectedPost.post = nextInLine;
                 }
             }
         }
@@ -106,6 +108,8 @@ function PostViewDataController(
             let postQuery = _.extend({}, query, {
                 limit: $scope.itemsPerPage
             });
+
+            postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
 
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
                 for (let i = 0; i < postsResponse.results.length; i++) {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -111,7 +111,7 @@ function PostViewDataController(
             });
 
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-                if (!postsResponse) {
+                if (postsResponse.count === 0) {
                     removePostFromList();
                 }
             });

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -235,10 +235,8 @@ function PostViewDataController(
         if (useOffset === true) {
             postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
         }
-
         $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-
             //Clear posts
             clearPosts ? resetPosts() : null;
             // Add posts to full set of posts

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -97,6 +97,7 @@ function PostViewDataController(
                     $scope.posts.splice(i, 1);
                     groupPosts($scope.posts);
                     $scope.selectedPost.post = nextInLine;
+                    $scope.selectedPostId = nextInLine.id;
                 }
             }
         }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -91,15 +91,15 @@ function PostViewDataController(
 
     $rootScope.$on('event:edit:post:data:mode:saveSuccess', function () {
         function removePostFromList() {
-            for (var i = 0; i < $scope.posts.length; i++) {
-                if ($scope.posts[i].id === $scope.selectedPostId) {
-                    let nextInLine = $scope.posts[i + 1];
-                    $scope.posts.splice(i, 1);
+            $scope.posts.forEach((post, index) => {
+                if (post.id === $scope.selectedPostId) {
+                    let nextInLine = $scope.posts[index + 1];
+                    $scope.posts.splice(index, 1);
                     groupPosts($scope.posts);
                     $scope.selectedPost.post = nextInLine;
                     $scope.selectedPostId = nextInLine.id;
                 }
-            }
+            });
         }
 
         if ($scope.hasFilters()) {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -111,7 +111,7 @@ function PostViewDataController(
             });
 
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-                if (postsResponse.count === 0) {
+                if (!postsResponse) {
                     removePostFromList();
                 }
             });

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -90,7 +90,7 @@ function PostViewDataController(
     $scope.savingPost = {saving: false};
 
     $rootScope.$on('event:edit:post:data:mode:saveSuccess', function () {
-        console.log($scope.groupedPosts);
+        console.log($scope.selectedPost);
     })
     activate();
     function activate() {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -88,6 +88,10 @@ function PostViewDataController(
      */
     var newPostsAfter = moment().utc();
     $scope.savingPost = {saving: false};
+
+    $rootScope.$on('event:edit:post:data:mode:saveSuccess', function () {
+        console.log($scope.groupedPosts);
+    })
     activate();
     function activate() {
         getPosts(false, false);

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -236,14 +236,9 @@ function PostViewDataController(
             postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
         }
 
-        // if (changedPostId) {
-        //     postQuery.id = changedPostId
-        // }
         $scope.isLoading.state = true;
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
-            // if (changedPostId) {
-            //     changedPost = postsResponse;
-            // }
+
             //Clear posts
             clearPosts ? resetPosts() : null;
             // Add posts to full set of posts

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,6 +1,6 @@
 <div class="flex-container">
     <post-toolbar saving-post="savingPost" is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
-    <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">     
+    <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
         <div class="button-group" ng-show="newPostsCount > 0">
             <button class="button-flat full-width" ng-click="addNewestPosts()">
                 <span ng-switch on="newPostsCount">
@@ -167,7 +167,7 @@
             <div class="listing-item" ng-if="posts.length == 0 && !hasFilters() && !isLoading.state">
                 <h4 translate>post.no_posts_yet</h4>
             </div>
-    
+
             <div class="listing-item" ng-if="posts.length > 0 || isLoading.state">
                 <div class="listing-item-primary">
                     <button ng-disabled="isLoading.state" ng-hide="( isLoading.state || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more


### PR DESCRIPTION
This pull request makes the following changes:
- Checks to see if, after a post has been edited, the post still matches existing filters;
- If it does not, it removes the post from the post list
- if it does still match, it does nothing

Testing checklist:
One example (can be replaced with any search)
- [ ] POST IS REMOVED FROM LIST WHEN NO LONGER MATCHING FILTERS
  - [ ] Filter posts to only show published posts
  - [ ] Select 'edit' on any post
  - [ ] Change status from Published to Under Review; select Save
  - [ ] Post should briefly change, then disappear from data view and detail view; next card in line should be select (unless you edited the last post in the list, then the selected post will be null)

- [ ] POST REMAINS IN LIST WHEN IT STILL MATCHES FILTERS 
  - [ ] Filter posts to only show published posts
  - [ ] Select 'edit' on any post
  - [ ] Make a change in the post, but leave the status set to Published; select Save
  - [ ] Postcard and post detail should update with change, but should remain in view

- [ ] Try this again using any and all filters!

Fixes ushahidi/platform#2227

Ping @ushahidi/platform
