### PR TITLE
2217 CSV download for mid/large size files working

### DIFF
--- a/app/common/services/endpoints/post-endpoint.js
+++ b/app/common/services/endpoints/post-endpoint.js
@@ -101,7 +101,8 @@ function (
     PostEndpoint.export = function (filters) {
         var config =  {
             params: filters,
-            paramSerializer: '$httpParamSerializerJQLike'
+            paramSerializer: '$httpParamSerializerJQLike',
+            responseType: 'arraybuffer'
         };
 
         return $http.get(Util.apiUrl('/posts/export'), config);


### PR DESCRIPTION
This pull request makes the following changes:
- Handles the CSV download headers correctly, creates a File is api is available or just a blob if not, then bundles that in a CSV file and downloads it. Cleans up the blob URL at the end for safety reasons. 

Testing checklist:
- [ ] Test together with  https://github.com/ushahidi/platform/pull/2250
- [ ]  Test a download with all posts, while logged in (in sandbox this should be > 5k posts) . It should work as expected by creating a file and downloading it with the same file name format we had in the past ({{hostname}}-{{date}}.csv) 

Fixes ushahidi/platform#2217 .

Ping @ushahidi/platform