### PR TITLE
2253 load new photo on changed post

### DIFF
--- a/app/main/posts/detail/post-media-value.directive.js
+++ b/app/main/posts/detail/post-media-value.directive.js
@@ -8,12 +8,24 @@ module.exports = ['MediaEndpoint', '_', function (MediaEndpoint, _) {
             mediaHasCaption: '='
         },
         template: require('./post-media-value.html'),
-        link: function ($scope) {
+        link: MediaValueLink
+    };
+
+    function MediaValueLink($scope) {
+        function loadMedia()
+        {
             if (!_.isNull($scope.mediaId)) {
                 MediaEndpoint.get({id: $scope.mediaId}).$promise.then(function (media) {
                     $scope.media = media;
                 });
             }
         }
-    };
+
+        $scope.$watch('mediaId', function (newMediaId, oldMediaId) {
+            if (newMediaId !== oldMediaId) {
+                loadMedia();
+            }
+        });
+    }
+
 }];

--- a/app/main/posts/detail/post-media-value.directive.js
+++ b/app/main/posts/detail/post-media-value.directive.js
@@ -12,17 +12,20 @@ module.exports = ['MediaEndpoint', '_', function (MediaEndpoint, _) {
     };
 
     function MediaValueLink($scope) {
-        function loadMedia()
-        {
+        function loadMedia() {
             if (!_.isNull($scope.mediaId)) {
+                $scope.mediaLoaded = false;
                 MediaEndpoint.get({id: $scope.mediaId}).$promise.then(function (media) {
                     $scope.media = media;
+                    $scope.mediaLoaded = true;
                 });
             }
         }
+        loadMedia();
 
         $scope.$watch('mediaId', function (newMediaId, oldMediaId) {
             if (newMediaId !== oldMediaId) {
+                console.log('new media loading...');
                 loadMedia();
             }
         });

--- a/app/main/posts/detail/post-media-value.directive.js
+++ b/app/main/posts/detail/post-media-value.directive.js
@@ -25,7 +25,6 @@ module.exports = ['MediaEndpoint', '_', function (MediaEndpoint, _) {
 
         $scope.$watch('mediaId', function (newMediaId, oldMediaId) {
             if (newMediaId !== oldMediaId) {
-                console.log('new media loading...');
                 loadMedia();
             }
         });

--- a/app/main/posts/detail/post-media-value.html
+++ b/app/main/posts/detail/post-media-value.html
@@ -2,7 +2,14 @@
   <h2 class="form-label">
     {{label}}
   </h2>
-
-  <img ng-src="{{ media.original_file_url }}" class="postcard-image">
+  <button ng-hide="mediaLoaded" type="button" class="button button-full-width button-beta">
+    <div class="loading">
+        <div class="line"></div>
+        <div class="line"></div>
+        <div class="line"></div>
+    </div>
+    <span class="button-label">Loading</span>
+    </button>
+  <img ng-show="mediaLoaded" ng-src="{{ media.original_file_url }}" class="postcard-image">
   <p class="small" ng-if="mediaHasCaption"><em>{{ media.caption }}</em></p>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- watches the mediaId to see if it has changed
- adds a "loading.." button when new media is being fetched
- refactors the link function

Testing checklist:
- [x] Search for all posts in one survey.
- [x] Select a post with a photo. 
- [x] As that photo loads, a "Loading..." div should display. 
- [x] That photo should display in the detail view.
- [x] Select another post with a different photo.
- [x] As that photo loads, a "Loading..." div should display. 
- [x] That new photo should display in the detail view.


Fixes ushahidi/platform#2253 .

Ping @ushahidi/platform
