### PR TITLE
filtering out posts when changing status from post-actions #2227

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -89,7 +89,7 @@ function PostActionsDirective(
 
             PostEndpoint.update($scope.post).$promise.then(function () {
                 // adding post to broadcast to make sure it gets filtered out from post-list if it does not match the filters.
-                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: $scope.post});
+                $rootScope.$broadcast('event:edit:post:status:data:mode:saveSuccess', {post: $scope.post});
                 Notify.notify('notify.post.save_success', { name: $scope.post.title });
             }, function (errorResponse) {
                 Notify.apiErrors(errorResponse);

--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -88,6 +88,8 @@ function PostActionsDirective(
             $scope.post.status = status;
 
             PostEndpoint.update($scope.post).$promise.then(function () {
+                // adding post to broadcast to make sure it gets filtered out from post-list if it does not match the filters.
+                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: $scope.post});
                 Notify.notify('notify.post.save_success', { name: $scope.post.title });
             }, function (errorResponse) {
                 Notify.apiErrors(errorResponse);

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -447,6 +447,7 @@ function PostDataEditorController(
                 Notify.notify(success_message, { name: $scope.post.title });
 
                 $scope.isLoading.state = false;
+                // adding post to broadcast to make sure it gets filtered out from post-list if it does not match the filters.
                 $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response});
 
                 leaveEditMode();

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -89,10 +89,11 @@ function PostViewDataController(
     var newPostsAfter = moment().utc();
     $scope.savingPost = {saving: false};
 
-    $rootScope.$on('event:edit:post:data:mode:saveSuccess', function () {
+    $rootScope.$on('event:edit:post:data:mode:saveSuccess', function (event, args) {
         function removePostFromList() {
             $scope.posts.forEach((post, index) => {
-                if (post.id === $scope.selectedPostId) {
+                // args.post is the post being updated/saved and sent from the broadcast
+                if (post.id === args.post.id) {
                     let nextInLine = $scope.posts[index + 1];
                     $scope.posts.splice(index, 1);
                     groupPosts($scope.posts);
@@ -101,13 +102,10 @@ function PostViewDataController(
                 }
             });
         }
-
         if ($scope.hasFilters()) {
-
             let query = PostFilters.getQueryParams($scope.filters);
-
             let postQuery = _.extend({}, query, {
-                post_id: $scope.selectedPostId
+                post_id: args.post.id
             });
 
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -131,17 +131,16 @@ function PostViewDataController(
     }
 
     function newStatusMatchesFilters(postObj) {
-        if ($scope.hasFilters()) {
-            let matchingStatus = false;
-            $scope.filters.status.forEach((status) => {
-                if (postObj.status === status) {
-                    matchingStatus = true;
-                }
-            });
-            return matchingStatus;
-        } else {
-            return true;
-        }
+        let filters = $scope.hasFilters() ?  $scope.filters.status : PostFilters.getDefaults().status;
+        let matchingStatus = false;
+
+        filters.forEach((status) => {
+            if (postObj.status === status) {
+                matchingStatus = true;
+            }
+        });
+
+        return matchingStatus;
     }
 
     activate();

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -123,9 +123,15 @@ function PostViewDataController(
             if (post.id === postObj.id) {
                 let nextInLine = $scope.posts[index + 1];
                 $scope.posts.splice(index, 1);
-                groupPosts($scope.posts);
-                $scope.selectedPost.post = nextInLine;
-                $scope.selectedPostId = nextInLine.id;
+                if ($scope.posts.length) {
+                    groupPosts($scope.posts);
+                    $scope.selectedPost.post = nextInLine;
+                    $scope.selectedPostId = nextInLine.id;
+                } else {
+                    $scope.selectedPost = {post: null, next: {}};
+                    $scope.selectedPostId = null;
+                    getPosts(false, false);
+                }
             }
         });
     }

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -101,7 +101,7 @@ function PostViewDataController(
 
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
                 if (postsResponse.count === 0) {
-                    removePostFromList(args);
+                    removePostFromList(args.post);
                 }
             });
         }


### PR DESCRIPTION
This pull request makes the following changes:
- removes the post from filters if status is changed in the '...' menu

Testing checklist:
... button checklist
- [x] Go to data-view
- [x] set a status-filter (like 'under review')
- [x] update to a status that not matches the filters for post through the '...' -menu
- [x] post should go away and the next one selected
- [x] Try this for several posts and the '...' menu in the detailed view
- [x] confirm the opposite: change the status of a post to match current filters (e.g. set filters to 'under review and archived', change a post to from under review to archived and confirm it remains)

Bulk Actions checklist
- [x] run same checklist but edit status through bulk actions

Detail Edit View Checklist
- [x] run same checklist but through data view detail editor

No filters
- [ ] if there are no status filters set, change a post status to archived using each method above and confirm that it is removed. 
- [ ] then change a status from 'under review' to 'published' and confirm it remains

Fixes ushahidi/platform#2227 .

Ping @ushahidi/platform
