### PR TITLE
Switching localStorage in favor of sessionstorage  for the caching issues

### DIFF
--- a/app/common/configs/cache-config.js
+++ b/app/common/configs/cache-config.js
@@ -2,7 +2,7 @@ module.exports = ['CacheFactoryProvider', function (CacheFactoryProvider) {
     angular.extend(CacheFactoryProvider.defaults, {
         maxAge: 15 * 60 * 1000, // 15 mins
         cacheFlushInterval: 60 * 60 * 1000, // This cache will clear itself every hour.
-        storageMode: 'localStorage',
+        storageMode: 'sessionStorage',
         storagePrefix: 'ush-caches.',
         deleteOnExpire: 'aggressive'
     });


### PR DESCRIPTION
This pull request makes the following changes:
-Switching localStorage in favor of sessionstorage  for the caching issues

Testing checklist:
- [ ] clear your localstorage and session storage. 
- [ ] access the app
- [ ] verify that you have the caches now living in sessionStorage instead of localStorage 

Check that the app still works, that you can access forms, edit posts, access your settings ,etc
Fixes ushahidi/platform# .

Ping @ushahidi/platform