### PR TITLE
Change to getFresh in post edit and datasource configuration

### DIFF
--- a/app/main/posts/modify/post-edit.controller.js
+++ b/app/main/posts/modify/post-edit.controller.js
@@ -36,7 +36,7 @@ function (
         });
 
         if (post.form) {
-            $scope.form = FormEndpoint.get({ id: post.form.id }, function (form) {
+            $scope.form = FormEndpoint.getFresh({ id: post.form.id }, function (form) {
                 // Set page title to post title, if there is one available.
                 if (post.title && post.title.length) {
                     $translate('post.modify.edit_type', { type: form.name, title: post.title }).then(function (title) {

--- a/app/settings/datasources/datasources.controller.js
+++ b/app/settings/datasources/datasources.controller.js
@@ -88,7 +88,7 @@ function (
         }
     };
 
-    $q.all([DataProviderEndpoint.queryFresh().$promise, ConfigEndpoint.get({ id: 'data-provider' }).$promise]).then(function (response) {
+    $q.all([DataProviderEndpoint.queryFresh().$promise, ConfigEndpoint.getFresh({ id: 'data-provider' }).$promise]).then(function (response) {
         $scope.providers = response[0];
         $scope.settings = response[1];
 

--- a/test/unit/main/post/modify/post-edit.controller.spec.js
+++ b/test/unit/main/post/modify/post-edit.controller.spec.js
@@ -5,6 +5,9 @@ describe('Post edit controller', function () {
     var mockFormEndpoint = {
         get: function (parameters, success, error) {
             return success({name: 'test form'});
+        },
+        getFresh: function (parameters, success, error) {
+            return success({name: 'test form'});
         }
     };
     var mockPostEndpoint = {


### PR DESCRIPTION
This pull request makes the following changes:
- Change to getFresh in post edit and datasource configuration

Testing checklist:
- [ ] in the network panel, check that datasources is going to get the config data to the backend (settings->datasources)
- [ ] in the network panel, check that post edit is going to get the attributes to the backend (select a post, edit) 
Fixes ushahidi/platform#.

Ping @ushahidi/platform