### PR TITLE
2257 Adding back map by latitude and longitude

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1208,8 +1208,7 @@
         "click_map": "<em>You can search or click the area of map where you want to place the marker.</em>",
         "placeholder":"Search for addresses, place names, or coordinates...",
         "search_results": "Search results",
-        "error":"Sorry we could not find a location matching your search",
-        "coordinates_tooltip": "Example Coordinates"
+        "error":"Sorry we could not find a location matching your search"
     },
     "notification": {
         "title": "Notifications",

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -100,6 +100,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         function manualLatLong(lat, lon) {
             updateMarkerPosition(lat, lon);
             centerMapTo(lat, lon);
+            updateModelLatLon(lat, lon);
         }
 
         function updateMarkerPosition(lat, lon) {

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -33,6 +33,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         $scope.chooseCurrentLocation = chooseCurrentLocation;
         $scope.searchResults = [];
         $scope.showCurrentPositionControl = false;
+        $scope.manualLatLong = manualLatLong;
         activate();
 
         function activate() {
@@ -94,6 +95,11 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 lat: lat,
                 lon: lon
             });
+        }
+
+        function manualLatLong(lat, lon) {
+            updateMarkerPosition(lat, lon);
+            centerMapTo(lat, lon);
         }
 
         function updateMarkerPosition(lat, lon) {

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -14,7 +14,6 @@
                 />
             </div>
             <div id="searchbar-results" class="searchbar-results dropdown-menu init">
-                <span class="bug"><span translate="location.coordinates_tooltip">Example Coordinates</span>: -1.2832533, 36.8172449</span>
                 <div class="form-field">
                     <button class="button-beta button-plain" ng-click="chooseCurrentLocation()" ng-if="showCurrentPositionControl" >
                         <svg class="iconic">

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -58,4 +58,21 @@
         </div>
     </form>
     <p translate>location.click_map</p>
+    <div class="form-field">
+      <label>Lat</label>
+      <input type="text" ng-model="model.lat">
+   </div>
+   <div class="form-field">
+      <label>Long</label>
+      <input type="text" ng-model="model.lon">
+   </div>
+   <button type="button" class="button-primary" ng-click="manualLatLong(model.lat, model.lon)">
+        <svg class="iconic">
+       <use 
+                                xmlns:xlink="http://www.w3.org/1999/xlink" 
+                                xlink:href="/img/iconic-sprite.svg#location">
+                            </use>
+        </svg>
+        <span class="button-label">Update Map</span>
+    </button>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the old code that allows a user to search by latitude and longitude in input fields, rather than in the map search field. This ensures the map marker placement is _exact_.

Testing checklist:
- [x] Add a new post; add location coordinates using the inputs and select Update Map; Map should place marker at location from coordinates
- [x] Save post; confirm location persists in map
- [x] do the same when editing a post

Fixes ushahidi/platform#2257

Ping @ushahidi/platform
