### PR TITLE
Fix initialization of cache, and clear expired items on cache load

### DIFF
--- a/app/common/configs/cache-config.js
+++ b/app/common/configs/cache-config.js
@@ -1,7 +1,7 @@
 module.exports = ['CacheFactoryProvider', function (CacheFactoryProvider) {
     angular.extend(CacheFactoryProvider.defaults, {
         maxAge: 15 * 60 * 1000, // 15 mins
-        cacheFlushInterval: 60 * 60 * 1000, // This cache will clear itself every hour.
+        cacheFlushInterval: 60 * 60 * 1000, // This cache will clear itself every hour
         storageMode: 'localStorage',
         storagePrefix: 'ush-caches.',
         deleteOnExpire: 'aggressive'

--- a/app/common/services/endpoints/config.js
+++ b/app/common/services/endpoints/config.js
@@ -21,8 +21,9 @@ function (
 ) {
     var cache;
     if (!(cache = CacheFactory.get('configCache'))) {
-        cache = new CacheFactory('configCache', { storageMode : 'memory' });
+        cache = CacheFactory.createCache('configCache', { storageMode : 'memory' });
     }
+    cache.removeExpired();
 
     var ConfigEndpoint = $resource(Util.apiUrl('/config/:id'), {
         'id': '@id'

--- a/app/common/services/endpoints/data-providers.js
+++ b/app/common/services/endpoints/data-providers.js
@@ -13,8 +13,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('providerCache'))) {
-        cache = new CacheFactory('providerCache');
+        cache = CacheFactory.createCache('providerCache');
     }
+    cache.removeExpired();
 
     var DataProviderEndpoint = $resource(Util.apiUrl('/dataproviders/:id'), {
         id: '@id'

--- a/app/common/services/endpoints/form-attributes.js
+++ b/app/common/services/endpoints/form-attributes.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('attrCache'))) {
-        cache = new CacheFactory('attrCache');
+        cache = CacheFactory.createCache('attrCache');
     }
+    cache.removeExpired();
 
     var FormAttributeEndpoint = $resource(Util.apiUrl('/forms/:formId/attributes/:id'), {
         formId: '@formId',

--- a/app/common/services/endpoints/form-roles.js
+++ b/app/common/services/endpoints/form-roles.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('formRoleCache'))) {
-        cache = new CacheFactory('formRoleCache');
+        cache = CacheFactory.createCache('formRoleCache');
     }
+    cache.removeExpired();
 
     var FormRoleEndpoint = $resource(Util.apiUrl('/forms/:formId/roles/'), {
         formId: '@formId',

--- a/app/common/services/endpoints/form-stages.js
+++ b/app/common/services/endpoints/form-stages.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('stageCache'))) {
-        cache = new CacheFactory('stageCache');
+        cache = CacheFactory.createCache('stageCache');
     }
+    cache.removeExpired();
 
     var FormStageEndpoint = $resource(Util.apiUrl('/forms/:formId/stages/:id'), {
         formId: '@formId',

--- a/app/common/services/endpoints/form.js
+++ b/app/common/services/endpoints/form.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('formCache'))) {
-        cache = new CacheFactory('formCache');
+        cache = CacheFactory.createCache('formCache');
     }
+    cache.removeExpired();
 
     var FormEndpoint = $resource(Util.apiUrl('/forms/:id'), {
             id: '@id'

--- a/app/common/services/endpoints/permission.js
+++ b/app/common/services/endpoints/permission.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('permissionCache'))) {
-        cache = new CacheFactory('permissionCache');
+        cache = CacheFactory.createCache('permissionCache');
     }
+    cache.removeExpired();
 
     var PermissionEndpoint = $resource(Util.apiUrl('/permissions/:id'), {
             id: '@id'

--- a/app/common/services/endpoints/role.js
+++ b/app/common/services/endpoints/role.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('roleCache'))) {
-        cache = new CacheFactory('roleCache');
+        cache = CacheFactory.createCache('roleCache');
     }
+    cache.removeExpired();
 
     var RoleEndpoint = $resource(Util.apiUrl('/roles/:id'), {
             id: '@id'

--- a/app/common/services/endpoints/tag.js
+++ b/app/common/services/endpoints/tag.js
@@ -11,9 +11,9 @@ function (
 ) {
     var cache;
     if (!(cache = CacheFactory.get('tagCache'))) {
-        cache = new CacheFactory('tagCache');
+        cache = CacheFactory.createCache('tagCache');
     }
-
+    cache.removeExpired();
 
     var TagEndpoint = $resource(Util.apiUrl('/tags/:id'), {
         id: '@id'

--- a/app/common/services/endpoints/user-endpoint.js
+++ b/app/common/services/endpoints/user-endpoint.js
@@ -12,8 +12,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('userCache'))) {
-        cache = new CacheFactory('userCache');
+        cache = CacheFactory.createCache('userCache');
     }
+    cache.removeExpired();
 
     var UserEndpoint = $resource(Util.apiUrl('/users/:id'), {
         id: '@id'

--- a/app/common/services/endpoints/webhooks.js
+++ b/app/common/services/endpoints/webhooks.js
@@ -10,8 +10,9 @@ function (
     var cache;
 
     if (!(cache = CacheFactory.get('webhookCache'))) {
-        cache = new CacheFactory('webhookCache');
+        cache = CacheFactory.createCache('webhookCache');
     }
+    cache.removeExpired();
 
     var WebhookEndpoint = $resource(Util.apiUrl('/webhooks/:id'), {
             id: '@id'

--- a/app/main/posts/common/post-metadata.service.js
+++ b/app/main/posts/common/post-metadata.service.js
@@ -25,7 +25,7 @@ function PostMetadataService(
         },
         loadUser: function (post) {
             if (post.user && post.user.id) {
-                return UserEndpoint.getFresh({id: post.user.id});
+                return UserEndpoint.get({id: post.user.id});
             }
         },
         loadContact: function (post) {

--- a/app/main/posts/common/post-survey.service.js
+++ b/app/main/posts/common/post-survey.service.js
@@ -52,7 +52,7 @@ function PostSurveyService(
     function allowedSurveys() {
         var allowed_forms = $q.defer();
 
-        FormEndpoint.queryFresh()
+        FormEndpoint.query()
         .$promise
         .then(function (forms) {
             if ($rootScope.hasPermission('Manage Posts')) {

--- a/app/main/posts/detail/post-add-form.directive.js
+++ b/app/main/posts/detail/post-add-form.directive.js
@@ -35,7 +35,7 @@ function (
                 });
             };
 
-            FormEndpoint.queryFresh().$promise.then(function (surveys) {
+            FormEndpoint.query().$promise.then(function (surveys) {
                 $scope.surveys = surveys;
 
                 if (surveys.length > 0) {

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -87,10 +87,10 @@ function PostDetailDataController(
         // Load the post form
         if ($scope.post.form && $scope.post.form.id) {
             $q.all([
-                FormEndpoint.getFresh({id: $scope.post.form.id}),
-                FormStageEndpoint.queryFresh({formId:  $scope.post.form.id, postStatus: $scope.post.status}).$promise,
-                FormAttributeEndpoint.queryFresh({formId: $scope.post.form.id}).$promise,
-                TagEndpoint.queryFresh().$promise
+                FormEndpoint.get({id: $scope.post.form.id}),
+                FormStageEndpoint.query({formId:  $scope.post.form.id, postStatus: $scope.post.status}).$promise,
+                FormAttributeEndpoint.query({formId: $scope.post.form.id}).$promise,
+                TagEndpoint.query().$promise
             ]).then(function (results) {
                 $scope.form = results[0];
                 $scope.form_name = results[0].name;

--- a/app/main/posts/detail/post-detail.controller.js
+++ b/app/main/posts/detail/post-detail.controller.js
@@ -77,10 +77,10 @@ function (
     // Load the post form
     if ($scope.post.form && $scope.post.form.id) {
         $q.all([
-            FormEndpoint.getFresh({id: $scope.post.form.id}),
-            FormStageEndpoint.queryFresh({formId:  $scope.post.form.id}).$promise,
-            FormAttributeEndpoint.queryFresh({formId: $scope.post.form.id}).$promise,
-            TagEndpoint.queryFresh().$promise
+            FormEndpoint.get({id: $scope.post.form.id}),
+            FormStageEndpoint.query({formId:  $scope.post.form.id}).$promise,
+            FormAttributeEndpoint.query({formId: $scope.post.form.id}).$promise,
+            TagEndpoint.query().$promise
         ]).then(function (results) {
             $scope.form = results[0];
             $scope.form_name = results[0].name;

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -68,7 +68,7 @@ function (
                         $scope.messages = messages;
                         _.each(messages, function (message, index) {
                             if (message.user) {
-                                message.user = UserEndpoint.getFresh({id: message.user.id});
+                                message.user = UserEndpoint.get({id: message.user.id});
                             }
 
                             // Format update time for display

--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -22,7 +22,7 @@ function CategorySelectDirective(TagEndpoint, _) {
 
         function activate() {
             // Load categories
-            TagEndpoint.queryFresh().$promise.then(function (result) {
+            TagEndpoint.query().$promise.then(function (result) {
                 scope.categories = result;
                 // adding children to tags
                 _.each(scope.categories, function (category) {

--- a/app/main/posts/views/filters/filter-form.directive.js
+++ b/app/main/posts/views/filters/filter-form.directive.js
@@ -23,7 +23,7 @@ function FormSelectDirective(FormEndpoint) {
 
         function activate() {
             // Load forms
-            scope.forms = FormEndpoint.queryFresh();
+            scope.forms = FormEndpoint.query();
 
             scope.$watch('selectedForms', saveValueToView, true);
             ngModel.$render = renderModelValue;

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -63,8 +63,8 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
 
     function activate() {
         // Load forms
-        $scope.forms = FormEndpoint.queryFresh();
-        $scope.tags = TagEndpoint.queryFresh();
+        $scope.forms = FormEndpoint.query();
+        $scope.tags = TagEndpoint.query();
         var postCountRequest = getPostStats($scope.filters);
         $q.all([$scope.forms.$promise, postCountRequest.$promise, $scope.tags.$promise]).then(function (responses) {
             if (!responses[1] || !responses[1].totals || !responses[1].totals[0]) {

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -31,7 +31,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
 
 
     function activate() {
-        FormEndpoint.queryFresh().$promise.then(function (result) {
+        FormEndpoint.query().$promise.then(function (result) {
             forms = result;
             // adding incoming messages to filter
             forms.push({id: 'none'});

--- a/app/main/posts/views/post-preview-media.directive.js
+++ b/app/main/posts/views/post-preview-media.directive.js
@@ -19,7 +19,7 @@ function (
                 return;
             }
 
-            FormAttributeEndpoint.queryFresh({formId: $scope.post.form.id}).$promise
+            FormAttributeEndpoint.query({formId: $scope.post.form.id}).$promise
                 .then(function (attributes) {
 
                     // Use image from the first media attribute

--- a/app/settings/data-import/data-import.controller.js
+++ b/app/settings/data-import/data-import.controller.js
@@ -30,7 +30,7 @@ function (
         file : null
     };
 
-    FormEndpoint.queryFresh().$promise.then(function (response) {
+    FormEndpoint.query().$promise.then(function (response) {
         $scope.forms = response;
     });
 }];

--- a/test/unit/main/post/common/post-metadata.service.spec.js
+++ b/test/unit/main/post/common/post-metadata.service.spec.js
@@ -47,9 +47,9 @@ describe('Post Metadata Service', function () {
                 }
             };
 
-            spyOn(UserEndpoint, 'getFresh').and.callThrough();
+            spyOn(UserEndpoint, 'get').and.callThrough();
             PostMetadataService.loadUser(post);
-            expect(UserEndpoint.getFresh).toHaveBeenCalled();
+            expect(UserEndpoint.get).toHaveBeenCalled();
         });
         it('should load a contact', function () {
             post = {

--- a/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
+++ b/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
@@ -26,8 +26,8 @@ describe('mode-context-form-filter directive', function () {
         PostSurveyService = _PostSurveyService_;
         PostFilters = _PostFilters_;
         $location = _$location_;
-        spyOn(FormEndpoint, 'queryFresh').and.callThrough();
-        spyOn(TagEndpoint, 'queryFresh').and.callThrough();
+        spyOn(FormEndpoint, 'query').and.callThrough();
+        spyOn(TagEndpoint, 'query').and.callThrough();
         spyOn(PostEndpoint, 'stats').and.callThrough();
         spyOn(PostFilters, 'getQueryParams').and.callThrough();
 
@@ -41,10 +41,10 @@ describe('mode-context-form-filter directive', function () {
     }));
     describe('test directive-functions', function () {
         it('should fetch forms from endpoint', function () {
-            expect(FormEndpoint.queryFresh).toHaveBeenCalled();
+            expect(FormEndpoint.query).toHaveBeenCalled();
         });
         it('should fetch tags from endpoint', function () {
-            expect(TagEndpoint.queryFresh).toHaveBeenCalled();
+            expect(TagEndpoint.query).toHaveBeenCalled();
         });
         it('should fetch queryParams from service', function () {
             expect(PostFilters.getQueryParams).toHaveBeenCalled();


### PR DESCRIPTION
- We don't need to `new` the cache. Use createCache() instead
- Remove expired items from cache during initialization
- Don't skip the cache to load forms, tags or users

Testing checklist:

- [x] Browser 1: Load map view http://deployment.com/views/map
- [x] Browser 1: Close the window as soon as the map has finished loading (make sure no other windows are open for that deployment)
- [x] Browser 2: Edit a survey and change the title. Save the survey
... wait 5mins (so cache should expire)
- [x] Browser 1: Load the post again  ie http://deployment.com/views/map
... Hopefully you see up to date survey names

Fixes ushahidi/platform#2088

Ping @ushahidi/platform
