### PR TITLE
ResetDefaults function added as a workaround for filters not being cleared in login and logout

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -1,7 +1,7 @@
 module.exports = AuthenticationEvents;
 
-AuthenticationEvents.$inject = ['$rootScope', '$location', 'Authentication', 'Session', '_', '$route', 'TermsOfService', 'Notify'];
-function AuthenticationEvents($rootScope, $location, Authentication, Session, _, $route, TermsOfService, Notify) {
+AuthenticationEvents.$inject = ['$rootScope', '$location', 'Authentication', 'Session', '_', '$route', 'TermsOfService', 'Notify', 'PostFilters'];
+function AuthenticationEvents($rootScope, $location, Authentication, Session, _, $route, TermsOfService, Notify, PostFilters) {
     let loginPath = null;
     $rootScope.currentUser = null;
     $rootScope.loggedin = false;
@@ -32,6 +32,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
                  * references https://github.com/ushahidi/platform/issues/1714
                  */
                 adminUserSetup();
+                PostFilters.resetDefaults();
                 if (redirect) {
                     $location.url(redirect);
                 }
@@ -42,10 +43,14 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     function doLogout(redirect) {
         $rootScope.currentUser = null;
         $rootScope.loggedin = false;
-        if (redirect) {
-            $location.url(redirect);
-        }
-        $route.reload();
+        // we don' wat to reload until after filters are correctly set with the backend default that the user
+        // would get when logged out
+        PostFilters.resetDefaults().then(function () {
+            if (redirect) {
+                $location.url(redirect);
+            }
+            $route.reload();
+        });
     }
 
     // todo: move to service

--- a/app/main/posts/views/filters/filter-category.html
+++ b/app/main/posts/views/filters/filter-category.html
@@ -1,4 +1,4 @@
-<fieldset ng-show="categories.length" overflow-toggle has-overflow="parents.length > 2" ng-model-options="{ updateOn: 'default' }">
+<fieldset ng-show="categories.length" overflow-toggle has-overflow="categories.length > 1" ng-model-options="{ updateOn: 'default' }">
     <label translate="nav.categories">Categories</label>
 
     <div class="form-field checkbox" ng-repeat="(index, category) in categories" ng-class="{ overflow : ($index > 1) }" ng-if="category.parent_id === null">

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -13,6 +13,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
     activate();
 
     return {
+        resetDefaults: resetDefaults,
         getDefaults: getDefaults,
         getQueryParams: getQueryParams,
         getFilters: getFilters,
@@ -30,6 +31,14 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         qEnabled: false
     };
 
+    /**
+     * function to deal with the fact that logout and login don't really reset the defaults.
+     */
+    function resetDefaults() {
+        return activate().then(function () {
+            clearFilters();
+        });
+    }
 
     function activate() {
         return $q.all([TagEndpoint.query().$promise, FormEndpoint.query().$promise]).then(function (results) {

--- a/test/unit/common/auth/authentication-events.run.spec.js
+++ b/test/unit/common/auth/authentication-events.run.spec.js
@@ -64,7 +64,7 @@ describe('global event handlers', function () {
         testApp.service('PostFilters', function () {
             return mockedPostFiltersService;
         })
-        testApp.service('Session', function () {
+        .service('Session', function () {
             return mockedSessionService;
         })
         .service('Authentication', function () {

--- a/test/unit/common/auth/authentication-events.run.spec.js
+++ b/test/unit/common/auth/authentication-events.run.spec.js
@@ -1,6 +1,7 @@
 describe('global event handlers', function () {
 
-    var mockedSessionData,
+    var mockedPostFiltersService,
+        mockedSessionData,
         mockedAuthenticationData,
         mockedAuthenticationService,
         mockTOS,
@@ -11,9 +12,16 @@ describe('global event handlers', function () {
         };
 
     beforeEach(function () {
-
         var testApp = makeTestApp();
-
+        mockedPostFiltersService = {
+            resetDefaults: function () {
+                return {
+                    then: function (successCallback, failCallback) {
+                        return {};
+                    }
+                };
+            }
+        };
         var mockedSessionService =
         {
             getSessionData: function () {
@@ -53,7 +61,9 @@ describe('global event handlers', function () {
         };
 
         spyOn(mockTOS, 'getTosEntry').and.callThrough();
-
+        testApp.service('PostFilters', function () {
+            return mockedPostFiltersService;
+        })
         testApp.service('Session', function () {
             return mockedSessionService;
         })
@@ -144,7 +154,6 @@ describe('global event handlers', function () {
                         beforeEach(function () {
                             $rootScope.$broadcast('event:authentication:logout:succeeded');
                         });
-
                         it('should set $rootScope.currentUser to null', function () {
                             expect($rootScope.currentUser).toEqual(null);
                         });


### PR DESCRIPTION

This pull request makes the following changes:
- ResetDefaults function added as a workaround for filters not being cleared in login and logout
- Fixes the bug that caused that `some` categories (public ones) were being shown as selected after login but not all of them (when you actually didn't have any selected filters)

Testing checklist:
### Categories and filters should be cleared in login and logout: 

- [x] Make sure you have at least 1 category that is set for "everyone" to see.  
- [x] Login
- [x] Look at the drop-down filters panel, make sure ALL categories are shown as selected in the categories checkboxes (they should because you have no filters) 
- [x] Logout.
- [x] Check your filters. You should only see the categories that you have set for "Everyone" to see in your categories checkboxes, and you should have no filters, in general. 
- [x] Login AGAIN
- [x] Look at the drop-down filters panel, make sure ALL categories are shown as selected in the categories checkboxes (they should because you have no filters) 
- [x] Uncheck one or more categories, select other filters. Make sure you see the bug icons appear and that they represent your current category filters. 
- [x] Make sure you Apply filters  (if you are in the data mode). Results should be consistent with the filters selected. 
- [x] Clear filters, and check that they are in fact clear. 



Fixes ushahidi/platform#2239.

Ping @ushahidi/platform