### PR TITLE
activating checkboxes for data-source-buckets #2107

### DIFF
--- a/app/main/posts/views/filter-by-datasource.directive.js
+++ b/app/main/posts/views/filter-by-datasource.directive.js
@@ -25,7 +25,7 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
     $scope.showOnlyIncoming = showOnlyIncoming;
     $scope.assignStatsToProviders = assignStatsToProviders;
     $scope.getTotals = getTotals;
-
+    $scope.toggleFilters = toggleFilters;
     $scope.$watch('postStats', function (postStats) {
         assignStatsToProviders();
     });
@@ -38,6 +38,15 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
                 $scope.dataSources = results.providers;
                 assignStatsToProviders();
             });
+        }
+    }
+
+    function toggleFilters(filter) {
+        var index = $scope.filters.source.indexOf(filter);
+        if (index !== -1) {
+            $scope.filters.source.splice(index, 1);
+        } else {
+            $scope.filters.source.push(filter);
         }
     }
 
@@ -83,6 +92,7 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
         }
         return 0;
     }
+
 
     function formatHeading(name) {
         switch (name) {

--- a/app/main/posts/views/filter-by-datasource.html
+++ b/app/main/posts/views/filter-by-datasource.html
@@ -11,6 +11,7 @@
                 <label>
                     <input 
                         type="checkbox"
+                        ng-checked="filters.source.indexOf(provider.label.toLowerCase()) !== -1"
                         translate
                         ng-click="toggleFilters(provider.label.toLowerCase())"
                     />

--- a/app/main/posts/views/filter-by-datasource.html
+++ b/app/main/posts/views/filter-by-datasource.html
@@ -11,9 +11,8 @@
                 <label>
                     <input 
                         type="checkbox"
-                        checklist-value="provider.label.toLowerCase()"
-                        checklist-model="filters.source"
                         translate
+                        ng-click="toggleFilters(provider.label.toLowerCase())"
                     />
                     {{provider.label}}
                 </label>

--- a/test/unit/main/post/views/filter-by-datasource.spec.js
+++ b/test/unit/main/post/views/filter-by-datasource.spec.js
@@ -90,5 +90,12 @@ describe('filter by datasource directive', function () {
             isolateScope.showOnlyIncoming('SMS');
             expect($location.path()).toEqual('/views/data');
         });
+        it('should toggle the filters based on if selected filter is activated or not', function () {
+            console.info(isolateScope.filters.source);
+            expect(isolateScope.filters.source).toEqual(['sms', 'twitter', 'web', 'email']);
+            var filter = isolateScope.filters.source[Math.floor(Math.random() * isolateScope.filters.source.length)];
+            isolateScope.toggleFilters(filter);
+            expect(isolateScope.filters.source).not.toContain(filter);
+        });
     });
 });

--- a/test/unit/main/post/views/filter-by-datasource.spec.js
+++ b/test/unit/main/post/views/filter-by-datasource.spec.js
@@ -91,7 +91,6 @@ describe('filter by datasource directive', function () {
             expect($location.path()).toEqual('/views/data');
         });
         it('should toggle the filters based on if selected filter is activated or not', function () {
-            console.info(isolateScope.filters.source);
             expect(isolateScope.filters.source).toEqual(['sms', 'twitter', 'web', 'email']);
             var filter = isolateScope.filters.source[Math.floor(Math.random() * isolateScope.filters.source.length)];
             isolateScope.toggleFilters(filter);


### PR DESCRIPTION
This pull request makes the following changes:
- activates the checkboxes for data buckets in map-view

Testing checklist:
- [ ] go to map-view
- [ ] checkboxes for data-sources should be checked
- [ ] deselect one checkbox
- [ ] posts from that data-source should be removed from the map
- [ ] the filter should not be selected in the filter- dropdow nor be visible as a bug-icon in the top of the dropdown
- [ ] select the checkbox again
- [ ] post should appear
- [ ] the filter should be checked in the filter-dropdown 

Fixes ushahidi/platform#2107 .

Ping @ushahidi/platform