### PR TITLE
Edit a saved search using 'Edit' Button

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -782,6 +782,7 @@
         "save_set" : "Save Collection",
         "save_savedsearch" : "Save Search",
         "update_savedsearch" : "Update Search",
+        "edit_savedsearch" : "Edit Search",
         "set_settings" : "Collection Settings",
         "add_notification" : "Add Notification",
         "remove" : "remove"

--- a/app/main/posts/views/filters/filter-saved-search.directive.js
+++ b/app/main/posts/views/filters/filter-saved-search.directive.js
@@ -16,7 +16,7 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope, ModalService, Po
         scope.searches = [];
         scope.searchesLength = 0;
         scope.loading = false;
-        scope.$on('savedSearch:update', loadSavedSearches);
+        scope.$on('event:savedSearch:update', loadSavedSearches);
         scope.$watch(PostFilters.getModeId, function (newValue, oldValue) {
             if (typeof (newValue) === 'undefined') {
                 scope.selectedSavedSearch = null;
@@ -24,9 +24,6 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope, ModalService, Po
                 scope.selectedSavedSearch =  scope.searches[newValue];
             }
         });
-        // scope.openSavedSearchListEditorModal = function () {
-        //     ModalService.openTemplate('<saved-search-list-editor-modal searches="searches"></saved-search-list-editor-modal>', 'set.delete_saved_searches', 'star', scope, false, false);
-        // };
 
         function activate() {
             if (ngModel.$viewValue) {

--- a/app/main/posts/views/filters/filter-saved-search.directive.js
+++ b/app/main/posts/views/filters/filter-saved-search.directive.js
@@ -24,9 +24,9 @@ function FilterSavedSearch(SavedSearchEndpoint, _,  $rootScope, ModalService, Po
                 scope.selectedSavedSearch =  scope.searches[newValue];
             }
         });
-        scope.openSavedSearchListEditorModal = function () {
-            ModalService.openTemplate('<saved-search-list-editor-modal searches="searches"></saved-search-list-editor-modal>', 'set.delete_saved_searches', 'star', scope, false, false);
-        };
+        // scope.openSavedSearchListEditorModal = function () {
+        //     ModalService.openTemplate('<saved-search-list-editor-modal searches="searches"></saved-search-list-editor-modal>', 'set.delete_saved_searches', 'star', scope, false, false);
+        // };
 
         function activate() {
             if (ngModel.$viewValue) {

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -11,7 +11,7 @@
             <option value="" translate="app.select_one">Select one</option>
         </select>
     </div>
-    <a class="button button-beta" ng-click="openSavedSearchListEditorModal()">Edit</a>
+    <a class="button button-beta" ng-show="selectedSavedSearch" ng-click="$parent.editSavedSearchModal('edit')">Edit</a>
 </fieldset>
 <fieldset ng-show="loading">
     <label translate="app.saved_search"></label>

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -62,13 +62,15 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
             $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
             ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', 'set.create_savedsearch', 'star', $scope, false, false);
         };
-        $scope.editSavedSearchModal = function () {
+        $scope.editSavedSearchModal = function (editOrUpdate) {
+            let modalHeaderText = editOrUpdate === 'edit' ? 'set.edit_savedsearch' : 'set.update_savedsearch';
+
             SavedSearchEndpoint.get({id: PostFilters.getModeId()}, function (savedSearch) {
                 $scope.savedSearch = savedSearch;
                 $scope.savedSearch.filter = PostFilters.getActiveFilters($scope.filtersVar);
                 // @TODO Prevent the user from creating one if they somehow manage to get to this point without being logged in
                 $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
-                ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', 'set.update_savedsearch', 'star', $scope, false, false);
+                ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', modalHeaderText, 'star', $scope, false, false);
             });
         };
     }

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="form-field">
-        <button type="button" class="button button-alpha button-right" ng-click="editSavedSearchModal()" ng-show="canUpdateSavedSearch" translate="set.update_savedsearch">Edit Saved search</button>
+        <button type="button" class="button button-alpha button-right" ng-click="editSavedSearchModal('update')" ng-show="canUpdateSavedSearch" translate="set.update_savedsearch">Edit Saved search</button>
     </div>
     <div class="divider"></div>
     <!-- sorting options -->


### PR DESCRIPTION
This pull request makes the following changes:
- removed 'delete saved search' modal and replaced it with 'update saved search' modal when user clicks edit next to saved search select dropdown. Edit button is now only shown when a SS is selected. Rather than rewrite the functionality in the filter saved search directive, I called the function from the parent scope.


Testing checklist:
- [ ] Go to data view without a SS selected. Confirm that edit button next to SS dropdown is not shown
- [ ] Select a SS. Confirm edit button appears
- [ ] Select edit; confirm that 'Edit Search' appears as the title header and that editing functionality works correctly
- [ ] Select a SS again; Scroll up to see that 'Update Search' appears. confirm that 'Edit Search' appears as the title header and that editing functionality works correctly
- [ ] Repeat in map view

Fixes ushahidi/platform#2207

Ping @ushahidi/platform
