### PR TITLE
removing only selected value from filter-arrays

### DIFF
--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -75,7 +75,13 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
     }
 
     function clearFilter(filterKey, value) {
-        filterState[filterKey] = getDefaults()[filterKey];
+        // if filter is in an array, we only want to remove that specific value
+        if (Array.isArray(filterState[filterKey])) {
+            filterState[filterKey].splice(filterState[filterKey].indexOf(value), 1);
+        } else {
+            filterState[filterKey] = getDefaults()[filterKey];
+        }
+
         /**
          * Since q is a special type of filter that gets applied on the click
          * of a button separate from the input control, and since it should be automatically

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -75,8 +75,11 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
     }
 
     function clearFilter(filterKey, value) {
-        // if filter is in an array, we only want to remove that specific value
-        if (Array.isArray(filterState[filterKey])) {
+        /*
+         * if filter is in an array, we only want to remove that specific value
+         * if all filter-values are removed from array, we want to reset to default
+         */
+        if (Array.isArray(filterState[filterKey]) && filterState[filterKey].length > 1) {
             filterState[filterKey].splice(filterState[filterKey].indexOf(value), 1);
         } else {
             filterState[filterKey] = getDefaults()[filterKey];

--- a/test/unit/main/post/views/filters/post-filters.service.spec.js
+++ b/test/unit/main/post/views/filters/post-filters.service.spec.js
@@ -107,6 +107,23 @@ describe('Post Filters Service', function () {
             expect(filters.source).toEqual(['sms', 'web', 'email']);
             expect(filters.form).toEqual(['testForm2', 'testForm3']);
         });
+        it('if filter is represented by an array, and all filter-values for that filters are removed, the filter should reset to default', function () {
+            var newFilters = {
+                status: ['archived', 'draft'],
+                tags: [1,3,4],
+                source: ['sms', 'twitter', 'web', 'email'],
+                form: ['testForm1', 'testForm2', 'testForm3']
+            };
+            PostFilters.setFilters(newFilters);
+
+            _.each(newFilters, function (values, filterKey) {
+                _.each(newFilters[filterKey], function (filterValue) {
+                    PostFilters.clearFilter(filterKey, filterValue);
+                });
+            });
+            var filters = PostFilters.getFilters();
+            expect(filters).toEqual(PostFilters.getDefaults());
+        });
         it ('if filter is not represented by an array, the selected filter should be reset to default ', function () {
             var defaultFilters = PostFilters.getDefaults();
 

--- a/test/unit/main/post/views/filters/post-filters.service.spec.js
+++ b/test/unit/main/post/views/filters/post-filters.service.spec.js
@@ -89,6 +89,41 @@ describe('Post Filters Service', function () {
                 order_unlocked_on_top: 'true'
             });
         });
+        it ('if filter is represented of an array, only selected filter-value should be removed', function () {
+            PostFilters.setFilters({
+                status: ['archived', 'draft'],
+                tags: [1,3,4],
+                source: ['sms', 'twitter', 'web', 'email'],
+                form: ['testForm1', 'testForm2', 'testForm3']
+            });
 
+            PostFilters.clearFilter('status', 'archived');
+            PostFilters.clearFilter('tags', 4);
+            PostFilters.clearFilter('source', 'twitter');
+            PostFilters.clearFilter('form', 'testForm1');
+            var filters = PostFilters.getFilters();
+            expect(filters.status).toEqual(['draft']);
+            expect(filters.tags).toEqual([1, 3]);
+            expect(filters.source).toEqual(['sms', 'web', 'email']);
+            expect(filters.form).toEqual(['testForm2', 'testForm3']);
+        });
+        it ('if filter is not represented by an array, the selected filter should be reset to default ', function () {
+            var defaultFilters = PostFilters.getDefaults();
+
+            PostFilters.setFilters({
+                date_before: 'Feb 17, 2016',
+                within_km: '5',
+                order_unlocked_on_top: false
+            });
+
+            PostFilters.clearFilter('date_before', 'Feb 17, 2016');
+            PostFilters.clearFilter('within_km', 5);
+            PostFilters.clearFilter('order_unlocked_on_top', false);
+
+            var filters = PostFilters.getFilters();
+            expect(filters.date_before).toEqual(defaultFilters.date_before);
+            expect(filters.within_km).toEqual(defaultFilters.within_km);
+            expect(filters.order_unlocked_on_top).toEqual(defaultFilters.order_unlocked_on_top);
+        });
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- When you remove a filter by clicking on the bug-icon, it just removes that filter

Testing checklist:
- [ ] Go to the filter dropdown
- [ ] Select a series of filter, especially surveys, datasources and categories with many choices
- [ ] try remove one filter at the time from the bug-icons, only the removed filter should be removed, the other ones should stay


Fixes ushahidi/platform#2183 .

Ping @ushahidi/platform
