### PR TITLE
ModeActive fix for mode context bar with ui-sref-active=active

### DIFF
--- a/app/common/directives/mode-bar/mode-bar.html
+++ b/app/common/directives/mode-bar/mode-bar.html
@@ -4,7 +4,7 @@
     <nav>
         <!-- main menu -->
         <ul class="deployment-menu">
-            <li ng-class="{ active: activeMode === 'map' }">
+            <li ui-sref-active="active">
                 <a ui-sref="list.map" ui-sref-opts="{reload:true}" class="view-map">
                     <svg class="iconic">
                         <use xlink:href="/img/iconic-sprite.svg#map-marker"></use>
@@ -13,7 +13,7 @@
                 </a>
             </li>
 
-            <li ng-class="{ active: activeMode === 'data' }">
+            <li ui-sref-active="active">
                 <a ui-sref="list.data" ui-sref-opts="{reload:true}" class="view-data">
                     <svg class="iconic">
                         <use xlink:href="/img/iconic-sprite.svg#list-rich"></use>
@@ -22,7 +22,7 @@
                 </a>
             </li>
 
-            <li ng-if="isActivityAvailable || hasManageSettingsPermission()" ng-class="{ active: activeMode === 'activity' }" data-message="customize">
+            <li ng-if="isActivityAvailable || hasManageSettingsPermission()" ui-sref-active="active" data-message="customize">
                 <a ui-sref="activity">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#pulse"></use>
@@ -39,7 +39,7 @@
                     <translate>nav.more</translate>
                 </a>
                 <ul>
-                    <li data-message="customize" ng-show="hasManageSettingsPermission()" ng-class="{ active: activeMode === 'settings' }">
+                    <li data-message="customize" ng-show="hasManageSettingsPermission()" ui-sref-active="active">
                         <a ui-sref="settings">
                             <svg class="iconic">
                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#cog"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- ModeActive fix for mode context bar with ui-sref-active=active

Testing checklist:
- [x] Click on each link in the mode bar and check that the active mode changes as you navigate (map, data, activity and settings) . Modals will be addressed in a modal PR 
- [x] Enter a saved search or collection data mode, check the data mode is highlighted (map mode is not enabled for either at the moment ) 
- [x] Enter edit mode directly from the edit url of a post, make sure the data mode is highlighted in mode bar. 
- [x] Enter detail mode directly from the url of a post, make sure the data mode is highlighted in mode bar. 

 
Fixes ushahidi/platform# .

Ping @ushahidi/platform