### PR TITLE
Client changes for new pl release

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -76,6 +76,7 @@
         "fields" : "Fields",
         "no_results": "No results found.",
         "filter_by" :"Filter by...",
+        "sort_filter": "Sort & filter",
         "apply_filters" : "Apply filters",
         "show_more_less" : "Show more/less",
         "filters" : "Filters",

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -17,7 +17,6 @@
           type="button"
           class="searchbar-options-filter button"
         >
-        <!-- DEVNOTE translate -->
             <sort-and-filter-counter></sort-and-filter-counter>
         </a>
     </div>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -12,17 +12,12 @@
     <filter-searchbar model="filters.q"></filter-searchbar>
     <!-- Toggle Filters show/hide -->
     <div uib-dropdown-toggle class="searchbar-options">
-        <a class="button" ng-click="openSavedModal()">
-            <svg class="iconic">
-                <use xlink:href="/img/iconic-sprite.svg#star"></use>
-            </svg>
-            <span class="button-label hidden" translate>app.saved</span>
-        </a>
-        <a     ng-click="toggleDropdown($event)"
-                   type="button"
-                   class="searchbar-options-filter button"
-                   >
-            <!-- DEVNOTE translate -->
+        <a 
+          ng-click="toggleDropdown($event)"
+          type="button"
+          class="searchbar-options-filter button"
+        >
+        <!-- DEVNOTE translate -->
             <sort-and-filter-counter></sort-and-filter-counter>
         </a>
     </div>

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -44,10 +44,8 @@
     <filter-date date-after-model="filtersVar.date_after" date-before-model="filtersVar.date_before"></filter-date>
     <filter-location center-point-model="filtersVar.center_point" within-km-model="filtersVar.within_km"></filter-location>
     <!-- end: filter options -->
-    <div class="modal-actions">
-        <div class="form-field">
-            <button type="button" class="button-link" ng-click="clearFilters()" translate>global_filter.clear_filters</button>
-            <button type="submit" class="button-alpha" translate ng-click="applyFiltersLocked()">app.apply_filters</button>
-        </div>
-    </div>
+</div>
+<div class="form-field filter-actions">
+    <button type="button" class="button-link" ng-click="clearFilters()" translate>global_filter.clear_filters</button>
+    <button type="submit" class="button-alpha" translate ng-click="applyFiltersLocked()">app.apply_filters</button>
 </div>

--- a/app/main/posts/views/filters/sort-and-filter-counter.html
+++ b/app/main/posts/views/filters/sort-and-filter-counter.html
@@ -1,5 +1,6 @@
 <span class="button-label-d">
-    <span class="badge iconic">{{filtersCount}}</span>Sort & filter
+    <span class="badge iconic">{{filtersCount}}</span>
+    <span translate>app.sort_filter</span>
 </span>
 <svg class="iconic">
     <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,8 +1,8 @@
 <div class="flex-container">
     <post-toolbar saving-post="savingPost" is-loading="isLoading" current-view="currentView" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
     <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
-        <div class="button-group" ng-show="newPostsCount > 0">
-            <button class="button-flat full-width" ng-click="addNewestPosts()">
+        <div class="load-more"  ng-show="newPostsCount > 0">
+            <button class="button-flat button-gamma full-width" ng-click="addNewestPosts()">
                 <span ng-switch on="newPostsCount">
                     <span ng-switch-default translate="post.see_more_plural" translate-values="{ newPostsCount }">See new posts</span>
                     <span ng-switch-when="1" translate="post.see_more_singular" translate-values="{ newPostsCount }">See new post</span>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.2-rc.22",
+    "ushahidi-platform-pattern-library": "v3.7.2-rc.23",
     "socket.io-client": "2.0.3"
   },
   "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- Class and markup-changes to match new pattern-library release.

Testing checklist:
ushahidi/platform#2266:
- [x] Go to data-view
- [x] The FAB-button should be on the bottom right corner
- [x] Check smaller and bigger screen-sizes, it should behave the same

ushahidi/platform#2267 and #2268:
- [x] Go to data-view
- [x] Open the filter-dropdown
- [x] The height of the dropdown should be the same as the window
- [x] The width of the dropdown should be the same as the filter-pane
- [x] The "Apply-filters" and "Clear Filters" buttons should stick to the bottom of the filter
- [x] The buttons should stay at bottom when scrolling the filters
- [x] Repeat on map-view, it should behave the same
- [x] Repeat on smaller screen-sizes, it should behave the same

ushahidi/platform#2270:
- [x] Go to dataview in one tab
- [x] Add a new post from another tab
- [x] Wait for the 'load new posts' button to appear in the first tab
- [x] The button should be white and have the same margins and shadows as the postcards below
- [x] The button should remain at the same place when scrolling down
- [x] The button should behave like this for all screen-sizes

ushahidi/platform#2275:
- [x] Go to data-view
- [x] Select a post and start editing
- [x] Click on any text-input-box
- [x] You should not see this white box around the input-box:
<img width="1021" alt="screen shot 2017-11-01 at 1 30 41 pm" src="https://user-images.githubusercontent.com/29209303/32293572-2f6a3e30-bf09-11e7-9e26-5cd153d240d2.png">
- [ ] The box should still be highlighted around the input-field:
<img width="590" alt="screen shot 2017-11-01 at 1 32 34 pm" src="https://user-images.githubusercontent.com/29209303/32293607-49d03202-bf09-11e7-9886-87e359ff7034.png">

Fixes:
ushahidi/platform#2266:
ushahidi/platform#2267
ushahidi/platform#2268
ushahidi/platform#2270
ushahidi/platform#2275

Ping @ushahidi/platform