### PR TITLE
Adding trailing slash support to settings, common routes, activities

### DIFF
--- a/app/common/common-routes.js
+++ b/app/common/common-routes.js
@@ -1,4 +1,6 @@
-module.exports = ['$stateProvider', function ($stateProvider) {
+module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($stateProvider, $urlMatcherFactoryProvider) {
+
+    $urlMatcherFactoryProvider.strictMode(false);
 
     $stateProvider
         .state(

--- a/app/main/activity/activity-routes.js
+++ b/app/main/activity/activity-routes.js
@@ -1,8 +1,11 @@
 module.exports = [
     '$stateProvider',
+    '$urlMatcherFactoryProvider',
 function (
-    $stateProvider
+    $stateProvider,
+    $urlMatcherFactoryProvider
 ) {
+    $urlMatcherFactoryProvider.strictMode(false);
 
     $stateProvider
     .state({

--- a/app/settings/settings.routes.js
+++ b/app/settings/settings.routes.js
@@ -1,8 +1,11 @@
 module.exports = [
     '$stateProvider',
+    '$urlMatcherFactoryProvider',
 function (
-    $stateProvider
+    $stateProvider,
+    $urlMatcherFactoryProvider
 ) {
+    $urlMatcherFactoryProvider.strictMode(false);
     /* todo: these routes should only exist when the user is admin! */
     $stateProvider
     .state(


### PR DESCRIPTION
This pull request makes the following changes:
- Adding trailing slash support to settings, common routes, activities

Testing checklist:
- [x] Go to /settings and /settings/ . Check that both work. 
- [x] Go to /settings/surveys and /settings/surveys/ . Check that both work. 
- [x] Go to /activity and /activity/ . Check that both work
- [x] Go to /login and /login/ . Check that both work
This can be tested for all routes in common, activity and settings. 
For post routes , savedsearches and collections, the slash fix is in the collections branch so it should not be teste dhere. 
Fixes ushahidi/platform# .

Ping @ushahidi/platform