### PR TITLE
Uirouter migration bug fix - Remove unused false path in logout and add the logout redirect

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -52,7 +52,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
                 $location.url(redirect);
             }
 
-            $state.go($state.$current.name ? $state.$current : 'map', null, { reload: true });
+            $state.go('posts.map');
         });
     }
 

--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -11,7 +11,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
         if (Authentication.getLoginStatus()) {
             doLogin(false, true);
         } else {
-            doLogout(false);
+            doLogout();
         }
     }
 
@@ -42,16 +42,12 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
             });
     }
 
-    function doLogout(redirect) {
+    function doLogout() {
         $rootScope.currentUser = null;
         $rootScope.loggedin = false;
         // we don' wat to reload until after filters are correctly set with the backend default that the user
         // would get when logged out
         PostFilters.resetDefaults().then(function () {
-            if (redirect) {
-                $location.url(redirect);
-            }
-
             $state.go('posts.map');
         });
     }


### PR DESCRIPTION
This pull request makes the following changes:
- Add the logout redirect to map
- Remove path that never happens 

Testing checklist:
- [ ] Logout
- [ ] Check that you are redirected to the map after logging out

Fixes ushahidi/platform# .

Ping @ushahidi/platform