### PR TITLE
Send user to data view with that post selected after saving

### DIFF
--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -309,7 +309,7 @@ function PostEditorController(
                     $scope.saving_post = false;
                     $scope.post.id = response.id;
                     Notify.notify(success_message, { name: $scope.post.title });
-                    $state.go('postDetail', {postId: response.id});
+                    $state.go('posts.data.detail', {postId: response.id});
                 } else {
                     Notify.notify(success_message, { name: $scope.post.title });
                     $state.go('posts.map');


### PR DESCRIPTION
This pull request makes the following changes:
- Send user to data view with that post selected after saving

Testing checklist:
Test 1 
- [ ] Create a new post 
- Check that you are redirected to data view with that post seleced after saving

Test 2
- Edit a post in detail mode (not edit in data view) 
- Check that you are redirected to data view with that post seleced after saving
Fixes ushahidi/platform# .

Ping @ushahidi/platform