### PR TITLE
Simplify editMode checks by relying on state instead

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -24,9 +24,7 @@ function PostActionsDirective(
         restrict: 'E',
         replace: true,
         scope: {
-            post: '=',
-            selectedPost: '=',
-            editMode: '='
+            post: '='
         },
         template: require('./post-actions.html'),
         link: PostActionsLink

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -7,7 +7,6 @@ function PostDetailData() {
         replace: true,
         scope: {
             isLoading: '=',
-            editMode: '=', // @todo remove
             post: '<'
         },
         controller: PostDetailDataController,

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -10,7 +10,7 @@
 
             <div class="postcard-header">
                 <post-metadata post="post" hide-date-this-week="true"></post-metadata>
-                <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
+                <post-actions post="post"></post-actions>
             </div>
             <div
               ng-repeat="(key,value) in post.values"

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -8,7 +8,7 @@
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>
         <!-- this is used in the map view card and the sidebar card in the data view-->
-        <post-actions selected-post="selectedPost" edit-mode="editMode" post="post"></post-actions>
+        <post-actions post="post"></post-actions>
       </header>
         <div class="postcard-overflow" ng-click="clickAction(post)">
             <div class="postcard-title">

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -11,7 +11,6 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
             selectedPosts: '=',
             shortContent: '@',
             clickAction: '=',
-            editMode: '=',
             selectedPost: '='
         },
         template: require('./card.html'),

--- a/app/main/posts/views/post-toolbar.directive.js
+++ b/app/main/posts/views/post-toolbar.directive.js
@@ -7,7 +7,6 @@ function PostToolbarDirective() {
         scope: {
             isLoading: '=',
             filters: '=',
-            editMode: '=',
             selectedPost: '=',
             savingPost: '='
         },
@@ -22,26 +21,32 @@ function PostToolbarController($scope, $rootScope, Notify, PostLockService, $sta
     $scope.savePost = savePost;
     $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
     $scope.editEnabled = editEnabled;
-    $scope.saveButtonEnabled = saveButtonEnabled;
+    $scope.editMode = editMode;
+    $scope.cancel = cancel;
+
     function editEnabled() {
+        if (!$scope.selectedPost || !$scope.hasPermission) {
+            return false;
+        }
+
         return $scope.selectedPost ? !PostLockService.isPostLockedForCurrentUser($scope.selectedPost) : false;
     }
 
     function savePost() {
         $rootScope.$broadcast('event:edit:post:data:mode:save');
     }
-    function saveButtonEnabled() {
+
+    function editMode() {
         return $state.$current.name === 'posts.data.edit';
     }
 
     function setEditMode() {
         if (editEnabled()) {
-            if ($scope.editMode.editing) {
-                $state.go('posts.data.detail', {postId: $scope.selectedPost.id});
-            } else {
-                $state.go('posts.data.edit', {postId: $scope.selectedPost.id});
-                $scope.editMode.editing = true;
-            }
+            $state.go('posts.data.edit', {postId: $scope.selectedPost.id});
         }
+    }
+
+    function cancel() {
+        $state.go('posts.data.detail', {postId: $scope.selectedPost.id});
     }
 }

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -6,36 +6,45 @@
 
     <filter-posts filters="filters" embed-only="false"></filter-posts>
 
-    <div class="button-group" embed-only="false" ng-switch="editMode.editing">
-        <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
-        <button ng-switch-when="false" ng-if="selectedPost && hasPermission && editEnabled()" class="button button-alpha" ng-click="setEditMode()"translate>app.edit</button>
-        <button ng-switch-when="true" ng-if="hasPermission" class="button" ng-click="setEditMode()" translate>app.cancel</button>
-        <button ng-switch-when="true" ng-if="hasPermission && !savingPost.saving" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
-        <button ng-switch-when="true" class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
-            <div class="loading">
-                <div class="line"></div>
-                <div class="line"></div>
-                <div class="line"></div>
-            </div>
-          </button>
+    <div class="button-group" embed-only="false">
+        <div ng-if="!editMode()">
+            <post-share filters="filters" button="true"></post-share>
+            <button ng-if="editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>
+        </div>
 
+        <div ng-if="editMode()">
+            <button ng-if="hasPermission" class="button" ng-click="cancel()" translate>app.cancel</button>
+            <button ng-if="hasPermission && !savingPost.saving" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
+            <button class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
+                <div class="loading">
+                    <div class="line"></div>
+                    <div class="line"></div>
+                    <div class="line"></div>
+                </div>
+            </button>
+        </div>
     </div>
 
 
     <filter-by-survey></filter-by-survey>
 
-    <div class="button-group hide-until-medium" ng-switch="editMode.editing" embed-only="true">
-        <post-share ng-switch-when="false" filters="filters" button="true"></post-share>
-        <button ng-switch-when="false" ng-if="selectedPost && hasPermission && editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>
-        <button ng-switch-when="true" ng-if="hasPermission" class="button" ng-click="setEditMode()" translate>app.cancel</button>
-        <button ng-switch-when="true" ng-if="hasPermission && saveButtonEnabled()" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
-        <button ng-switch-when="true" class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
-            <div class="loading">
-                <div class="line"></div>
-                <div class="line"></div>
-                <div class="line"></div>
-            </div>
-        </button>
+    <div class="button-group hide-until-medium" embed-only="true">
+        <div ng-if="!editMode()">
+            <post-share filters="filters" button="true"></post-share>
+            <button ng-if="editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>
+        </div>
+
+        <div ng-if="editMode()">
+            <button ng-if="hasPermission" class="button" ng-click="cancel()" translate>app.cancel</button>
+            <button ng-if="hasPermission" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
+            <button class="button-alpha" disabled ng-if="savingPost.saving" translate>app.saving
+                <div class="loading">
+                    <div class="line"></div>
+                    <div class="line"></div>
+                    <div class="line"></div>
+                </div>
+            </button>
+        </div>
     </div>
 
     <!-- toolbar -->

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -67,7 +67,6 @@ function PostViewDataController(
     $scope.newPostsCount = 0;
     var recentPosts = [];
     $scope.addNewestPosts = addNewestPosts;
-    $scope.editMode = {editing: false};
     $scope.selectBulkActions = selectBulkActions;
     $scope.bulkActionsSelected = '';
     $scope.closeBulkActions = closeBulkActions;
@@ -199,7 +198,6 @@ function PostViewDataController(
             if (!_.isEmpty($scope.selectedPost.next)) {
                 $scope.selectedPost.post = $scope.selectedPost.next;
                 $scope.selectedPost.next = {};
-                $scope.editMode.editing = true;
                 $rootScope.$broadcast('event:edit:post:reactivate');
             }
         });
@@ -214,24 +212,26 @@ function PostViewDataController(
             }
         });
 
-        $scope.$watch(function () {
-            return $location.path();
-        }, function (newValue, oldValue) {
-            if ($scope.editMode.editing) {
-                var postId = newValue.match(/^\/posts\/([0-9]+)(\/|$)/);
-                var locationUrlMatch = $location.path().match(/^\/posts\/([0-9]+)(\/|$)/);
-                if (postId && postId.length > 1 && !locationUrlMatch) {
-                    var tmpPost = _.filter($scope.posts, function (postItm) {
-                        return postItm.id === parseInt(postId[1]);
-                    });
-                    if (tmpPost.length > 0) {
-                        $scope.selectedPost.post = tmpPost[0];
-                        $scope.selectedPostId = tmpPost[0].id;
-                        $scope.editMode.editing = false;
-                    }
-                }
-            }
-        });
+        // I don't know what this does but its terrifying
+        //
+        // $scope.$watch(function () {
+        //     return $location.path();
+        // }, function (newValue, oldValue) {
+        //     if ($scope.editMode.editing) {
+        //         var postId = newValue.match(/^\/posts\/([0-9]+)(\/|$)/);
+        //         var locationUrlMatch = $location.path().match(/^\/posts\/([0-9]+)(\/|$)/);
+        //         if (postId && postId.length > 1 && !locationUrlMatch) {
+        //             var tmpPost = _.filter($scope.posts, function (postItm) {
+        //                 return postItm.id === parseInt(postId[1]);
+        //             });
+        //             if (tmpPost.length > 0) {
+        //                 $scope.selectedPost.post = tmpPost[0];
+        //                 $scope.selectedPostId = tmpPost[0].id;
+        //                 $scope.editMode.editing = false;
+        //             }
+        //         }
+        //     }
+        // });
         checkForNewPosts(30000);
     }
 
@@ -244,23 +244,20 @@ function PostViewDataController(
 
     function confirmEditingExit() {
         var deferred = $q.defer();
-        if (!$scope.editMode.editing) {
+        if ($state.$current.name !== 'posts.data.edit') {
             deferred.resolve();
         } else if ($scope.formData.form && !$scope.formData.form.$dirty) {
-            $scope.editMode.editing = false;
             $scope.isLoading.state = false;
             $scope.savingPost.saving = false;
             deferred.resolve();
         } else {
             Notify.confirmLeave('notify.post.leave_without_save').then(function () {
                 //PostLockService.unlockSilent($scope.selectedPost);
-                $scope.editMode.editing = false;
                 $scope.isLoading.state = false;
                 $scope.savingPost.saving = false;
                 deferred.resolve();
             }, function (reject) {
                 deferred.reject();
-                $scope.editMode.editing = true;
                 $scope.isLoading.state = false;
                 $scope.savingPost.saving = false;
             });

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,7 +1,7 @@
 <main role="main">
 <div class="flex-container">
     <layout-class layout="d"></layout-class>
-    <post-toolbar saving-post="savingPost" is-loading="isLoading" selected-post="selectedPost.post" edit-mode="editMode" filters="filters"></post-toolbar>
+    <post-toolbar saving-post="savingPost" is-loading="isLoading" selected-post="selectedPost.post" filters="filters"></post-toolbar>
     <div id="post-data-view-top" class="timeline-col" ng-class="{'toolbar-active': bulkActionsSelected}">
         <div class="load-more"  ng-show="newPostsCount > 0">
             <button class="button-flat button-gamma full-width" ng-click="addNewestPosts()">
@@ -67,7 +67,6 @@
                 post="post"
                 selected-posts="selectedPosts"
                 click-action="showPost"
-                edit-mode="editMode"
                 selected-post="selectedPost"
             >
             </post-card>
@@ -97,7 +96,7 @@
     </div>
     <div class="post-col">
         <!-- Verify if we need all these bindings ie. parentForm savingPost -->
-        <div ui-view edit-mode="editMode" filters="filters" is-loading="isLoading" saving-post="savingPost" ></post-detail-data>
+        <div ui-view filters="filters" is-loading="isLoading" saving-post="savingPost" ></post-detail-data>
         <!-- @uirouter-refactor: need to move this -->
         <post-messages post="selectedPost.post" ng-if="selectedPost.post && selectedPost.post.contact.id && !editMode.editing"></post-messages>
     </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Rip out editMode wherever I could
- Use $state.$current to check where we are instead

Relies on https://github.com/ushahidi/platform-client/pull/927
