### PR TITLE
Removing onEnter block to keep user filters as they navigate the app

### DIFF
--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -121,10 +121,6 @@ function (
             name: 'posts.map.all',
             views: {
                 'mode-context': 'modeContext'
-            },
-            onEnter: function ($state, $transition$, PostFilters, savedSearch) {
-                PostFilters.setMode('all');
-                PostFilters.resetDefaults();
             }
         }
     )


### PR DESCRIPTION
We cannot do resetDefaults and setMode here because the user needs to be able to move around and keep their filters.

This pull request makes the following changes:
- Remove onEnter block with setMode/reset filters

Testing checklist:
- [ ] Add filters in data or map view
-  [ ] change to the "opposite " view
- [ ] verify your filters travel across

Test with saved search :
- [ ]  Select a saved search in data mode
- [ ] Change to map mode and verifiy that you see the mode context bar with update search button there. 

Fixes ushahidi/platform# .

Ping @ushahidi/platform