### PR TITLE
Ensure sidebar and dropdown filters stay in sync

### DIFF
--- a/app/main/posts/views/filter-by-datasource.directive.js
+++ b/app/main/posts/views/filter-by-datasource.directive.js
@@ -64,23 +64,27 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
             .compact()
             .uniq()
             .value();
-        // if user is logged in and is allowed to see the configs, we add all enabled datasources, even if there are 0 posts
+
+        // if user is logged in and is allowed to see the configs,
+        // we add all enabled datasources, even if there are 0 posts
         if ($scope.dataSources) {
-            var smsProviders = ['nexmo', 'twilio','frontlinesms', 'smssync'];
+            var smsProviders = ['nexmo', 'twilio', 'frontlinesms', 'smssync'];
             _.each($scope.dataSources, function (source, key) {
                     if (source) {
                         var type = _.contains(smsProviders, key) ? 'SMS' : key.substr(0, 1).toUpperCase() + key.substr(1);
-                        var exists = _.filter($scope.providers, {label: type});
+                        var exists = _.filter($scope.providers, { label: type });
                         if (exists.length < 1) {
                             var obj = {};
                             obj.label = type;
                             obj.heading = formatHeading(obj.label);
-                            obj.total = getTotals(key);
+                            obj.total = getTotals(key); // Isn't this always 0?
                             $scope.providers.push(obj);
                         }
                     }
                 });
         }
+
+        $scope.providers = _.sortBy($scope.providers, 'label');
     }
 
     function getTotals(source) {

--- a/app/main/posts/views/filter-by-datasource.directive.js
+++ b/app/main/posts/views/filter-by-datasource.directive.js
@@ -137,6 +137,6 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
     }
 
     function featureEnabled() {
-        return $rootScope.hasPermission('Manage Posts');
+        return $rootScope.isAdmin();
     }
 }

--- a/app/main/posts/views/filter-by-datasource.directive.js
+++ b/app/main/posts/views/filter-by-datasource.directive.js
@@ -53,12 +53,10 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
     function assignStatsToProviders() {
         $scope.providers = _.map($scope.postStats, function (provider) {
                 var obj = {};
-                if (provider.type !== 'web') {
-                    obj.label = provider.type === 'sms' ? 'SMS' : provider.type.substr(0, 1).toUpperCase() + provider.type.substr(1);
-                    obj.heading = formatHeading(obj.label);
-                    obj.total = getTotals(provider.type);
-                    return obj;
-                }
+                obj.label = provider.type === 'sms' ? 'SMS' : provider.type.substr(0, 1).toUpperCase() + provider.type.substr(1);
+                obj.heading = formatHeading(obj.label);
+                obj.total = getTotals(provider.type);
+                return obj;
             });
 
         // removing duplicates and null-values
@@ -102,6 +100,8 @@ function FilterByDatasourceController($scope, $rootScope, ConfigEndpoint, _, $lo
                 return 'SMS';
             case 'Email':
                 return 'Emails';
+            case 'Web':
+                return 'Web';
             default:
                 return ' ';
         }

--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -50,6 +50,7 @@ function CategorySelectDirective(TagEndpoint, _) {
             });
 
             scope.$watch('selectedCategories', saveValueToView, true);
+            scope.$watch(() => ngModel.$viewValue, renderModelValue, true);
             ngModel.$render = renderModelValue;
         }
         function renderModelValue() {

--- a/app/main/posts/views/filters/filter-form.directive.js
+++ b/app/main/posts/views/filters/filter-form.directive.js
@@ -26,6 +26,7 @@ function FormSelectDirective(FormEndpoint) {
             scope.forms = FormEndpoint.query();
 
             scope.$watch('selectedForms', saveValueToView, true);
+            scope.$watch(() => ngModel.$viewValue, renderModelValue, true);
             ngModel.$render = renderModelValue;
         }
         function renderModelValue() {

--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -16,10 +16,7 @@ function FilterPostsDirective() {
 FilterPostsController.$inject = ['$scope', '$timeout','ModalService', 'PostFilters', '$state'];
 function FilterPostsController($scope, $timeout, ModalService, PostFilters, $state) {
     $scope.searchSavedToggle = false;
-    $scope.cancel = cancel;
-    $scope.applyFilters = applyFilters;
     $scope.qFilter = '';
-    $scope.openSavedModal = openSavedModal;
     $scope.view = $state.params.view;
     activate();
 
@@ -35,22 +32,5 @@ function FilterPostsController($scope, $timeout, ModalService, PostFilters, $sta
     function activate() {
         // @todo define initial filter values
         // $scope.$watch('filters', handleFilterChange, true);
-    }
-
-    function cancel() {
-        // Reset filters
-        rollbackForm();
-        // .. and close the dropdown
-        ModalService.close();
-    }
-
-    function applyFilters(event) {
-    }
-
-    function rollbackForm() {
-        PostFilters.clearFilters();
-    }
-    function openSavedModal() {
-        ModalService.openTemplate('<saved-search-modal></saved-search-modal>', 'nav.saved_searches', '/img/iconic-sprite.svg#star', $scope, true, true);
     }
 }

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -20,5 +20,5 @@
         </a>
     </div>
 
-    <filters-dropdown view="view" uib-dropdown-menu class="dropdown-menu" dropdown-status="status" filters-var="filters" ng-model="filters" cancel="cancel" apply-filters="applyFilters"></filters-dropdown>
+    <filters-dropdown view="view" uib-dropdown-menu class="dropdown-menu" dropdown-status="status" filters="filters" ng-model="filters" cancel="cancel" apply-filters="applyFilters"></filters-dropdown>
 </form>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -20,5 +20,5 @@
         </a>
     </div>
 
-    <filters-dropdown view="view" uib-dropdown-menu class="dropdown-menu" dropdown-status="status" filters="filters" ng-model="filters" cancel="cancel" apply-filters="applyFilters"></filters-dropdown>
+    <filters-dropdown view="view" uib-dropdown-menu class="dropdown-menu" dropdown-status="status" filters="filters"></filters-dropdown>
 </form>

--- a/app/main/posts/views/filters/filter-source.directive.js
+++ b/app/main/posts/views/filters/filter-source.directive.js
@@ -19,6 +19,7 @@ function SourceSelectDirective($rootScope) {
 
         function activate() {
             scope.$watch('selectedSources', saveValueToView, true);
+            scope.$watch(() => ngModel.$viewValue, renderModelValue, true);
             ngModel.$render = renderModelValue;
         }
 

--- a/app/main/posts/views/filters/filter-source.html
+++ b/app/main/posts/views/filters/filter-source.html
@@ -3,6 +3,12 @@
 
     <div class="form-field checkbox icon-input">
         <label>
+            <input type="checkbox" ng-model="source" checklist-model="selectedSources" checklist-value="'email'" name="selectedSources">
+            <span>Email</span>
+        </label>
+    </div>
+    <div class="form-field checkbox icon-input">
+        <label>
             <input type="checkbox" ng-model="source" checklist-model="selectedSources" checklist-value="'sms'" name="selectedSources">
             <span>SMS</span>
         </label>
@@ -11,12 +17,6 @@
         <label>
             <input type="checkbox" ng-model="source" checklist-model="selectedSources" checklist-value="'twitter'" name="selectedSources">
             <span>Twitter</span>
-        </label>
-    </div>
-    <div class="form-field checkbox icon-input">
-        <label>
-            <input type="checkbox" ng-model="source" checklist-model="selectedSources" checklist-value="'email'" name="selectedSources">
-            <span>Email</span>
         </label>
     </div>
     <div class="form-field checkbox icon-input">

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -4,18 +4,15 @@ FiltersDropdown.$inject = ['PostFilters', 'ModalService', '$rootScope', '_', '$l
 function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, SavedSearchEndpoint) {
     return {
         restrict: 'E',
-        require: 'ngModel',
         scope: {
             dropdownStatus: '=',
-            applyFilters: '=',
             filters: '=',
-            cancel: '=',
             view: '<'
         },
         link: FiltersDropdownLink,
         template: require('./filters-dropdown.html')
     };
-    function FiltersDropdownLink($scope, $element, $attrs, ngModel) {
+    function FiltersDropdownLink($scope, $element, $attrs) {
         $scope.canUpdateSavedSearch;
         PostFilters.reactiveFilters = false;
         $scope.$watch(PostFilters.getModeId, function (newValue, oldValue) {
@@ -50,7 +47,6 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
             $scope.dropdownStatus.isopen = !$scope.dropdownStatus.isopen;
             PostFilters.reactiveFilters = true;
             $scope.canUpdateSavedSearch = false;
-
         };
         $scope.enableQuery = function () {
             PostFilters.qEnabled = true;

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -8,7 +8,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
         scope: {
             dropdownStatus: '=',
             applyFilters: '=',
-            filtersVar: '=',
+            filters: '=',
             cancel: '=',
             view: '<'
         },
@@ -46,7 +46,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
                 var viewParam = $scope.view ? $scope.view : 'data';
                 $location.url('/views/' + viewParam);
             }
-            $scope.filtersVar = PostFilters.clearFilters();
+            $scope.filters = PostFilters.clearFilters();
             $scope.dropdownStatus.isopen = !$scope.dropdownStatus.isopen;
             PostFilters.reactiveFilters = true;
             $scope.canUpdateSavedSearch = false;
@@ -56,7 +56,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
             PostFilters.qEnabled = true;
         };
         $scope.saveSavedSearchModal = function () {
-            $scope.savedSearch.filter = $scope.filtersVar;
+            $scope.savedSearch.filter = $scope.filters;
             // @TODO Prevent the user from creating one if they somehow manage to get to this point without being logged in
             $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
             ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', 'set.create_savedsearch', 'star', $scope, false, false);
@@ -64,7 +64,7 @@ function FiltersDropdown(PostFilters, ModalService, $rootScope, _, $location, Sa
         $scope.editSavedSearchModal = function (editOrUpdate) {
             let modalHeaderText = editOrUpdate === 'edit' ? 'set.edit_savedsearch' : 'set.update_savedsearch';
             $scope.savedSearch = PostFilters.getModeEntity();
-            $scope.savedSearch.filter = PostFilters.getActiveFilters($scope.filtersVar);
+            $scope.savedSearch.filter = PostFilters.getActiveFilters($scope.filters);
             // @TODO Prevent the user from creating one if they somehow manage to get to this point without being logged in
             $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
             ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', modalHeaderText, 'star', $scope, false, false);

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -1,41 +1,41 @@
 <div class="dropdown-menu-body">
     <div class="form-field filter-buttons">
-        <div ng-show="filtersVar.q.length > 0" ng-class="{active: (filtersVar.q.length > 0) }">
-            <div ng-class="{active: (filtersVar.q.length > 0) , 'form-field': 'form-field'}">
+        <div ng-show="filters.q.length > 0" ng-class="{active: (filters.q.length > 0) }">
+            <div ng-class="{active: (filters.q.length > 0) , 'form-field': 'form-field'}">
                 <button class="button-plain" ng-click="enableQuery()">
                     <span class="button-label">
                         <span translate-values="{ entity: entityType }" translate>
                             toolbar.searchbar.search_all_entities_for
                         </span>
-                        "<em>{{ filtersVar.q }}</em>"
+                        "<em>{{ filters.q }}</em>"
                     </span>
                 </button>
             </div>
         </div>
     </div>
     <div class="form-field filter-buttons">
-        <post-active-search-filters ng-model="filtersVar" filters-var="filtersVar"></post-active-search-filters>
+        <post-active-search-filters ng-model="filters" filters-var="filters"></post-active-search-filters>
     </div>
     <div class="divider"></div>
     <!-- sorting options -->
     <h4 class="dropdown-menu-title" translate="app.sort_by"></h4>
 
-    <filter-post-sorting-options ng-model="filtersVar.orderby"></filter-post-sorting-options>
+    <filter-post-sorting-options ng-model="filters.orderby"></filter-post-sorting-options>
     <fieldset>
-        <filter-post-order-asc-desc ng-model="filtersVar.order"></filter-post-order-asc-desc>
-        <filter-unlocked-on-top ng-model="filtersVar.order_unlocked_on_top"></filter-unlocked-on-top>
+        <filter-post-order-asc-desc ng-model="filters.order"></filter-post-order-asc-desc>
+        <filter-unlocked-on-top ng-model="filters.order_unlocked_on_top"></filter-unlocked-on-top>
     </fieldset>
     <!-- end: sorting options -->
 
     <!-- filter options -->
     <h4 class="dropdown-menu-title" translate="app.filter_by"></h4>
-    <filter-saved-search ng-model="filtersVar.saved_search"></filter-saved-search>
-    <filter-status ng-model="filtersVar.status"></filter-status>
-    <filter-category ng-model="filtersVar.tags"></filter-category>
-    <filter-form ng-model="filtersVar.form"></filter-form>
-    <filter-source ng-model="filtersVar.source"></filter-source>
-    <filter-date date-after-model="filtersVar.date_after" date-before-model="filtersVar.date_before"></filter-date>
-    <filter-location center-point-model="filtersVar.center_point" within-km-model="filtersVar.within_km"></filter-location>
+    <filter-saved-search ng-model="filters.saved_search"></filter-saved-search>
+    <filter-status ng-model="filters.status"></filter-status>
+    <filter-category ng-model="filters.tags"></filter-category>
+    <filter-form ng-model="filters.form"></filter-form>
+    <filter-source ng-model="filters.source"></filter-source>
+    <filter-date date-after-model="filters.date_after" date-before-model="filters.date_before"></filter-date>
+    <filter-location center-point-model="filters.center_point" within-km-model="filters.within_km"></filter-location>
     <!-- end: filter options -->
 </div>
 <div class="form-field filter-actions">

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -159,7 +159,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
 
     function getSourceStats(stats) {
         var sourceStats = [];
-        var providers = ['email', 'sms', 'twitter'];
+        var providers = ['email', 'sms', 'twitter', 'web'];
         // calculating stats for each datasource, based on the current form-filter
         _.each(providers, function (provider) {
             var posts = _.filter(stats.totals[0].values, function (value) {

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -174,7 +174,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
                     if (post.total) {
                         return count + post.total;
                     }
-                    return 0;
+                    return count;
                 }, sourceStat.total);
                 sourceStat.type = provider;
                 sourceStats.push(sourceStat);

--- a/app/main/posts/views/mode-context.directive.js
+++ b/app/main/posts/views/mode-context.directive.js
@@ -23,6 +23,6 @@ function ModeContextController(
     activate();
 
     function activate() {
-        console.log($scope);
+
     }
 }

--- a/test/unit/main/post/views/filter-by-datasource.spec.js
+++ b/test/unit/main/post/views/filter-by-datasource.spec.js
@@ -4,7 +4,7 @@ describe('filter by datasource directive', function () {
         isolateScope,
         element,
         ConfigEndpoint,
-        hasPermission,
+        isAdmin,
         $location;
 
     beforeEach(function () {
@@ -31,9 +31,9 @@ describe('filter by datasource directive', function () {
                 {total: 2, type: 'sms'}
             ];
 
-        hasPermission = true;
-        $rootScope.hasPermission = function () {
-            return hasPermission;
+        isAdmin = true;
+        $rootScope.isAdmin = function () {
+            return isAdmin;
         };
         element = '<filter-by-datasource filters="filters" post-stats="postStats"></filter-by-datasource>';
         element = $compile(element)($scope);

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -73,7 +73,7 @@ describe('post active search filters directive', function () {
         });
         it('should clear PostFilters when calling clearFilters', function () {
             isolateScope.clearFilters();
-            expect(isolateScope.filtersVar).toEqual(PostFilters.getDefaults());
+            expect(isolateScope.filters).toEqual(PostFilters.getDefaults());
         });
         it('should set qEnabled true when I call enableQuery', function () {
             isolateScope.enableQuery();


### PR DESCRIPTION
This pull request makes the following changes:
- Fix bug where data source filter changes in sidebar weren't applied to dropdown
- Fix bug where category filter changes in sidebar weren't applied to dropdown
- Fix bug where survey filter changes in sidebar weren't applied to dropdown
- Show 'Web' datasource in sidebar
- Fix minor issues with data source totals in sidebar (miscounting in edgecases)
- Sort data sources alphabetically
- Remove dead code. 

Testing 
- https://ushahidi.ontestpad.com/script/2#223//
- https://ushahidi.ontestpad.com/script/2#235//
- https://ushahidi.ontestpad.com/script/2#253//
- https://ushahidi.ontestpad.com/script/2#245//

- [ ] I certify that I ran my checklist ... _I've run it about a million times, I'm now test-blind_

Fixes ushahidi/platform#2107

Ping @ushahidi/platform
