### PR TITLE
Allow background of postcards to be tappable

### DIFF
--- a/app/main/posts/common/post-actions.html
+++ b/app/main/posts/common/post-actions.html
@@ -1,5 +1,5 @@
 <div class="postcard-actions" dropdown >
-  <button class="button-gamma button-flat init" data-toggle="dropdown-menu" dropdown-toggle>
+  <button class="button-gamma button-flat init" data-toggle="dropdown-menu" dropdown-toggle ng-click="$event.stopPropagation()">
       <svg class="iconic">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#ellipses"></use>
       </svg>

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -3,14 +3,14 @@
     <div class="listing-item-select">
         <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts" ng-click="stopClickPropagation($event)">
     </div>
-    <div class="postcard-body">
+    <div class="postcard-body" ng-click="clickAction(post)">
       <header class="postcard-header">
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>
         <!-- this is used in the map view card and the sidebar card in the data view-->
         <post-actions post="post"></post-actions>
       </header>
-        <div class="postcard-overflow" ng-click="clickAction(post)">
+        <div class="postcard-overflow">
             <div class="postcard-title">
                 <div class="postcard-field">
                 {{ post.title || post.content | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}


### PR DESCRIPTION
Per discussion with @justinscherer , everything but the dropdown ellipses should be clickable in order to select the post. The only complication is that clicking the dropdown toggle shouldn't select the post.

This pull request makes the following changes:
Moved `clickAction()` to the whole postcard body.
Stops propagation if the ellipses is clicked.

Testing checklist:
- [ ] Click anywhere in the `postcard-body` except the ellipses. That post should get selected.
- [ ] Click the ellipses on the selected card. This should still toggle the dropdown menu.
- [ ] Click the ellipses on an _unselected_ card. This should still toggle the dropdown menu, but not select the post.
 
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2273 .

Ping @ushahidi/platform
