### PR TITLE
fix(post-view-data): Fix issue trying to get to post edit from actions dropdown

### DIFF
--- a/app/main/posts/common/post-actions.directive.js
+++ b/app/main/posts/common/post-actions.directive.js
@@ -21,7 +21,7 @@ function PostActionsDirective(
     _) {
     return {
         restrict: 'E',
-        replace: true,
+        replace: false,
         scope: {
             post: '='
         },

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -3,7 +3,7 @@
     <div class="listing-item-select">
         <input ng-show="canSelect" type="checkbox" checklist-value="post.id" checklist-model="selectedPosts" ng-click="stopClickPropagation($event)">
     </div>
-    <div class="postcard-body" ng-click="clickAction(post)">
+    <div class="postcard-body" ng-click="clickAction($event)">
       <header class="postcard-header">
 
         <post-metadata post="post" hide-date-this-week="true"></post-metadata>

--- a/app/main/posts/views/post-card.directive.js
+++ b/app/main/posts/views/post-card.directive.js
@@ -10,12 +10,13 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
             canSelect: '=',
             selectedPosts: '=',
             shortContent: '@',
-            clickAction: '=',
+            externalClickAction: '=clickAction',
             selectedPost: '='
         },
         template: require('./card.html'),
-        link: function ($scope) {
+        link: function ($scope, $element) {
             $scope.isPostLocked = isPostLocked;
+            $scope.clickAction = clickAction;
             activate();
 
             $scope.stopClickPropagation = function ($event) {
@@ -37,6 +38,17 @@ function PostCardDirective(FormEndpoint, PostLockService, $rootScope) {
                         $scope.post.form = form;
                     });
                 }
+            }
+
+            function clickAction(evt) {
+                let postActions = $element.find('post-actions')[0];
+                // If the click was inside post-actions
+                if (evt && $element && postActions.contains(evt.target)) {
+                    // But ignore the action
+                    return;
+                }
+
+                $scope.externalClickAction($scope.post);
             }
         }
     };

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -117,6 +117,12 @@ function PostViewDataController(
         $scope.activeCol = $state.params.activeCol;
     }));
 
+    unbindFns.push($transitions.onSuccess({
+        to: 'posts.data.*'
+    }, () => {
+        $scope.selectedPost.post = _.findWhere($scope.posts, { id: parseInt($state.params.postId, 10) });
+    }));
+
     // Cleanup and remove all listeners
     $scope.$on('$destroy', () => {
         unbindFns.forEach(Function.prototype.call, Function.prototype.call);


### PR DESCRIPTION
Click action for whole post card was overriding the post edit action.
Updated to skip click action if target is inside post-actions. Then
add watcher on state change to set selected posts since that was only
happening as a side effect before

Testing checklist:
- [x] Select the ... on a postcard
- [x] then select 'Edit'.
- [x] Edit view opens.
- [x] Post is shown as selected in the post list


- [x] I certify that I ran my checklist

Fixes https://github.com/ushahidi/platform-client/issues/940

Ping @ushahidi/platform
