### PR TITLE
2324  - 

### DIFF
--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -123,8 +123,12 @@ function (
                 savedSearch: resolveSavedSearch
             },
             onEnter: ['PostFilters', '$state', 'savedSearch', function (PostFilters, $state, savedSearch) {
-                PostFilters.setMode('savedsearch', savedSearch);
-                PostFilters.setFilters(savedSearch.filter);
+                if (!PostFilters.getModeId() && savedSearch) {
+                    PostFilters.setMode('savedsearch', savedSearch);
+                    PostFilters.setFilters(savedSearch.filter);
+                } else {
+                    savedSearch = PostFilters.getModeEntity('savedsearch');
+                }
             }]
         }
     )


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes https://github.com/ushahidi/platform/issues/2324  . 
-  - Add the same check as in saved search map when we are moving to data. We should not override the filters when there is an active modeid and a savedsearch already


Testing checklist (https://ushahidi.ontestpad.com/script/2#60/18/)
`Specific checklist for this fix: `
- [ ] Go to map-view
- [ ] Select a saved search
- [ ] Add extra filters that don't belong to the saved search
- [ ] Go to data-view
- [ ] The saved search + the filters you added should be active in the data mode 

Relevant checklists in testpad that are fixed here: 
- [ ] https://ushahidi.ontestpad.com/script/2#60//
- [ ] https://ushahidi.ontestpad.com/script/2#60/18/

General checklists that need to be run afterwards to verify nothing new is broken: 
- [ ] Full Filtering and saved searches testpad script :  https://ushahidi.ontestpad.com/script/2



- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2324 .

Ping @ushahidi/platform