### PR TITLE
separating forgot-password and confirm routes

### DIFF
--- a/app/common/common-routes.js
+++ b/app/common/common-routes.js
@@ -37,7 +37,7 @@ module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($sta
         )
         .state(
             {
-                name: 'forgotpassword.confirm',
+                name: 'confirm',
                 url: '/forgotpassword/confirm',
                 controller: require('./auth/password-reset-confirm.controller.js'),
                 template: ''
@@ -45,8 +45,8 @@ module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($sta
         )
         .state(
             {
-                name: 'forgotpassword.confirm.token',
-                url: '/forgotpassword/confirm/:token',
+                name: 'confirm.token',
+                url: '/:token',
                 controller: require('./auth/password-reset-confirm.controller.js'),
                 template: ''
             }


### PR DESCRIPTION
This pull request makes the following changes:
- removes the 'forgot password' as parent to the confirm-routes (they have nothing to do with each-other ?)

Testing checklist:
- [ ] go to /forgotpassword, you should be prompted with this modal:
![screen shot 2017-12-04 at 11 07 30](https://user-images.githubusercontent.com/8624777/33547143-5d2608ce-d8e3-11e7-9b54-b92bc9817b77.png)
- Reset your password
- [ ] you should be prompted with this modal:
![screen shot 2017-12-04 at 11 08 22](https://user-images.githubusercontent.com/8624777/33547169-782e02b6-d8e3-11e7-9865-a63e769dc485.png)
wait for email, click on link, you should be prompted with this modal: 
![screen shot 2017-12-04 at 11 09 32](https://user-images.githubusercontent.com/8624777/33547293-ee581418-d8e3-11e7-938e-3ebd5a4e1037.png)

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2337 .

Ping @ushahidi/platform