### PR TITLE
Update UI to display contact info for user

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -968,6 +968,8 @@
         "which_survey" : "which survey?"
     },
     "user": {
+        "role_display" : "Role: {{role}}",
+        "contact" : "{{type}}: {{contact}}",
         "add_user" : "Add User",
         "edit_user" : "Edit User",
         "update_password" : "Update Password",

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -40,6 +40,7 @@ function (
             $scope.totalItems = $scope.itemsPerPage;
             $scope.pageChanged = getMessagesForPagination;
             $scope.showPagination = false;
+            $scope.getContactDisplay = getContactDisplay;
 
             function activate() {
                 // Can't activate if we don't have a contact
@@ -51,10 +52,14 @@ function (
                 // Initialize
                 if ($scope.post.contact.contact) {
                     $scope.contact = $scope.post.contact;
+                    // Set contact user is available
+                    setContactUser($scope.contact);
                 } else {
                     ContactEndpoint.get({ id: $scope.post.contact.id })
                         .$promise.then(function (contact) {
                             $scope.contact = contact;
+                            // Set contact user is available
+                            setContactUser($scope.contact);
                         });
                 }
 
@@ -62,6 +67,23 @@ function (
             }
 
             activate();
+
+            function getContactDisplay() {
+                if ($scope.contact.user && $scope.contact.user.realname) {
+                    return $scope.contact.user.realname;
+                }
+
+                return $scope.contact.contact;
+            }
+
+            function setContactUser(contact) {
+                if ($scope.contact.user) {
+                    UserEndpoint.get({ id: $scope.contact.user.id })
+                        .$promise.then(function (user) {
+                            $scope.contact.user = user;
+                        });
+                }
+            }
 
             function getMessagesForPagination() {
 

--- a/app/main/posts/detail/post-messages.directive.js
+++ b/app/main/posts/detail/post-messages.directive.js
@@ -50,7 +50,7 @@ function (
 
                 $scope.messages = []; // init to blank
                 // Initialize
-                if ($scope.post.contact.contact) {
+                if ($scope.post.contact && $scope.post.contact.contact) {
                     $scope.contact = $scope.post.contact;
                     // Set contact user is available
                     setContactUser($scope.contact);

--- a/app/main/posts/detail/post-messages.html
+++ b/app/main/posts/detail/post-messages.html
@@ -11,7 +11,7 @@
         </div>
       <h2 class="listing-item-title">
 
-        <span ng-if="message.direction == 'incoming'">{{ contact.contact }}</span>
+        <span ng-if="message.direction == 'incoming'">{{ getContactDisplay() }}</span>
         <span ng-if="message.direction == 'outgoing' && message.user.realname">{{ message.user.realname }}</span>
       </h2>
       <!--

--- a/app/settings/users/users-edit.html
+++ b/app/settings/users/users-edit.html
@@ -110,7 +110,7 @@
 
                 </div>
 
-                <div class="form-sheet" ng-show="user.id">
+                <div class="form-sheet" ng-show="user.id && user.contacts.length">
                     <div class="form-sheet-summary">
                         <h3 class="form-sheet-title" translate>Contacts</h3>
                     </div>

--- a/app/settings/users/users-edit.html
+++ b/app/settings/users/users-edit.html
@@ -111,6 +111,18 @@
                 </div>
 
                 <div class="form-sheet" ng-show="user.id">
+                    <div class="form-sheet-summary">
+                        <h3 class="form-sheet-title" translate>Contacts</h3>
+                    </div>
+                    <div class="form-field" ng-repeat="contact in user.contacts">
+                        <div class="form-field-addon" style="text-transform: capitalize">
+                            <span class="addon before">{{contact.type}}</span>
+                            <input type="text" value="{{contact.contact}}" disabled="">
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-sheet" ng-show="user.id">
                    <div class="form-sheet-summary">
                        <h3 class="form-sheet-title" translate>user.delete_user</h3>
                    </div>

--- a/app/settings/users/users.html
+++ b/app/settings/users/users.html
@@ -59,7 +59,19 @@
                         </div>
 
                         <h2 class="listing-item-title"><a ui-sref="settings.users.edit({id: user.id})">{{user.realname}}</a></h2>
-                        <p class="listing-item-secondary">{{ roles[user.role].display_name }}</p>
+                        <p class="listing-item-secondary" 
+                            translate-values="{role: roles[user.role].display_name}" 
+                            translate="user.role_display">
+                            Role: role_name
+                        </p>
+                        <p class="listing-item-secondary" style="text-transform: capitalize" ng-repeat="contact in user.contacts"
+                            translate-values="{
+                                type: contact.type,
+                                contact: contact.contact
+                            }" 
+                            translate="user.contact">
+                            Contact_Type: contact
+                        </p>
                     </div>
                 </div>
                 <listing-toolbar entities="users" selected-set="selectedUsers">


### PR DESCRIPTION
…nd messages

This pull request makes the following changes:
- Adds contact info to user
- Displays contact info for posts metadata
- Displays contact info for "Conversation with Author" section
- Display contact info on User list page
- Displays contact info on User edit page

Testing checklist:
## User section
- [x] On the User list view, beneath the User's name you should see their Role and any Contacts they have displayed in a vertical column
<img width="1233" alt="screen shot 2017-12-13 at 10 38 35" src="https://user-images.githubusercontent.com/2694405/33947216-d196c198-dff1-11e7-8e56-f95f1e7850e7.png">

- [x] On the User list view it should be possible to search via contact; for example phone number

- [x] On the User edit page you should see a new section called Contacts that shows any available contacts
<img width="1304" alt="screen shot 2017-12-13 at 10 48 18" src="https://user-images.githubusercontent.com/2694405/33947723-2aa95b0a-dff3-11e7-8e78-d3a95eee29b9.png">

- [x] The contact field should not be editable
- [x] You can update and save the User without issue
- [x] The contact section should not appear for users you have no contacts
- [x] The contact section should not appear when creating a new User

## Map view/Data Mode
- [x] For Posts created from inbound data sent to the Platform from the User's contact
  - [x] The author meta data on the Post Cards should show the User's name

## Post detail view
- [x] On a Post created from inbound data sent to the Platform from the user's contact
  - [x] The User's name should appear on the Conversation with Author section *not* the contact number

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Relies on [ushahidi/platform/pull/2359](https://github.com/ushahidi/platform/pull/2359)

Ping @ushahidi/platform
