### PR TITLE
adjusting client to embed-changes ushahidi/platform#2457

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -42,7 +42,7 @@
         </div>
         <div id="bootstrap-app" class="hidden">
 
-            <mode-bar embed-only=false current-user="currentUser"></mode-bar>
+            <mode-bar current-user="currentUser"></mode-bar>
             <ui-view></ui-view>
 
             <!-- TODO: fix and uncomment

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -61,8 +61,11 @@ function PostDetailDataController(
     $scope.$watch('post', function (post) {
         activate();
     });
+    /* need to check for embed here to set the correct class
+    * if coming from map to detail-view in embed */
+    var isEmbed = ($window.self !== $window.top) ? true : false;
+    isEmbed ? $rootScope.setLayout('layout-d layout-embed') : $rootScope.setLayout('layout-d');
 
-    $rootScope.setLayout('layout-d');
     $scope.post = $scope.post;
     $scope.post_task = {};
     $scope.hasPermission = $rootScope.hasPermission;

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -62,7 +62,7 @@ function PostDetailDataController(
         activate();
     });
     /* need to check for embed here to set the correct class
-    * if coming from map to detail-view in embed */
+    * if coming from map to detail-view in embed, TODO: should go to a service! */
     var isEmbed = ($window.self !== $window.top) ? true : false;
     isEmbed ? $rootScope.setLayout('layout-d layout-embed') : $rootScope.setLayout('layout-d');
 

--- a/app/main/posts/views/filter-by-survey.html
+++ b/app/main/posts/views/filter-by-survey.html
@@ -1,3 +1,3 @@
-<div embed-only="true" class="toolbox hide-when-medium">
+<div class="embed-survey-filter" embed-only="true" class="toolbox hide-when-medium">
     <button ng-click="openFilters()" class="button-beta button-plain mode-context-trigger" translate="app.filter_by_survey">Filter by survey</button>
 </div>

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -19,18 +19,22 @@
         </div>
     </div>
 
-    <filter-by-survey></filter-by-survey>
-    <div class="button-group hide-until-medium" embed-only="true" ng-hide="filtersActive">
-        <div ng-if="!editMode()">
-            <post-share filters="filters" button="true"></post-share>
-            <button ng-if="editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>
-        </div>
+    <div embed-only="true" class="hide-until-medium">
+        <filter-posts filters="filters" on-open="hideOtherActions()" on-close="showOtherActions()"></filter-posts>
+        <div class="button-group">
+            <div class="button" ng-hide="filtersActive">
+                <div ng-if="!editMode()">
+                    <post-share filters="filters" button="true"></post-share>
+                    <button ng-if="editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>
+                </div>
 
-        <div ng-if="editMode()">
-            <button ng-if="hasPermission" class="button" ng-click="cancel()" translate>app.cancel</button>
-             <button ng-if="hasPermission && !isSaving()" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
-            <loading-dots button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots>
+                <div ng-if="editMode()">
+                    <button ng-if="hasPermission" class="button" ng-click="cancel()" translate>app.cancel</button>
+                    <button ng-if="hasPermission && !isSaving()" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
+                </div>
+            </div>
         </div>
+        <loading-dots button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots>
     </div>
 
     <!-- toolbar -->

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -22,7 +22,7 @@
     <div embed-only="true" class="hide-until-medium">
         <filter-posts filters="filters" on-open="hideOtherActions()" on-close="showOtherActions()"></filter-posts>
         <div class="button-group">
-            <div class="button" ng-hide="filtersActive">
+            <div ng-hide="filtersActive">
                 <div ng-if="!editMode()">
                     <post-share filters="filters" button="true"></post-share>
                     <button ng-if="editEnabled()" class="button button-alpha" ng-click="setEditMode()" translate>app.edit</button>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,4 +1,11 @@
+<div class="mode-context init" embed-only="true" ng-controller="navigation as nav" dropdown>
+    <header class="mode-context-header" ng-class="{ 'has-logo' : nav.site.image_header }">
+      <h1 class="mode-context-title"><a href="/" ng-bind="nav.site.name"></a></h1>
+      <img ng-if="nav.site.image_header" ng-src="{{ nav.site.image_header }}" class="deployment-logo" />
+    </header>
+</div>
 <main role="main">
+
 <div class="flex-container">
     <layout-class layout="d"></layout-class>
     <post-toolbar selected-post="selectedPost.post" filters="filters"></post-toolbar>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -1,3 +1,4 @@
+<!-- Below code is used to get the header to embeds -->
 <div class="mode-context init" embed-only="true" ng-controller="navigation as nav" dropdown>
     <header class="mode-context-header" ng-class="{ 'has-logo' : nav.site.image_header }">
       <h1 class="mode-context-title"><a href="/" ng-bind="nav.site.name"></a></h1>

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nvd3": "^1.8.4",
     "socket.io-client": "2.0.3",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "git://github.com/ushahidi/platform-pattern-library.git#2454-embeds"
+    "ushahidi-platform-pattern-library": "3.7.2-rc.29"
   },
   "engines": {
     "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nvd3": "^1.8.4",
     "socket.io-client": "2.0.3",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.2-rc.30"
+    "ushahidi-platform-pattern-library": "3.7.2-rc.31"
   },
   "engines": {
     "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nvd3": "^1.8.4",
     "socket.io-client": "2.0.3",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.2-rc.24"
+    "ushahidi-platform-pattern-library": "git://github.com/ushahidi/platform-pattern-library.git#2454-embeds"
   },
   "engines": {
     "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nvd3": "^1.8.4",
     "socket.io-client": "2.0.3",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.2-rc.29"
+    "ushahidi-platform-pattern-library": "3.7.2-rc.30"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the mode-bar and filter-bar to embeds that are bigger than 1023px
- Fixes problems with data-view and embeds

Testing checklist:
-  Look at the client as an embed for /views/map with a width smaller than 1023px
- [ ] No modebar or the 'normal' filter-bar should be visible
-  Click on a post to get to the detailed view
- [ ] You should see the post with a x in the upper right corner
- [ ] Still no modebar or filter-bar
- Click on the x
- [ ] You should be directed back to the map-view
-  Look at the client as an embed for /views/data with a width smaller than 1023px
- [ ] No modebar or the 'normal' filter-bar should be visible
- [ ] You should see the postlist only
- Click on a post
- [ ] You should see the post with a x in the upper right corner
- [ ] Still no modebar or filter-bar
- [ ] Click on the x
- [ ] You should be directed back to the post-list

-  Look at the client as an embed for /views/map with a width larger than 1023px
- [ ] the modebar and the 'normal' filter-bar should be visible
-  Click on a post to get to the detailed view
- [ ] You should see the post-list to the left and the post on the right
- [ ] Modebar and filter-bar is visible

Click on data in the navigation
- [ ] You should see the post-list to the left and the post on the right
- [ ] Modebar and filter-bar is visible

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
