### PR TITLE
removing category-related code from mode-context-survey-filters #2435

### DIFF
--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -9,11 +9,10 @@ function ModeContextFormFilterDirective() {
         template: require('./mode-context-form-filter.html')
     };
 }
-ModeContextFormFilter.$inject = ['$scope', 'FormEndpoint', 'PostEndpoint', 'TagEndpoint', '$q', '_', '$rootScope', 'PostSurveyService', 'PostFilters', '$timeout', '$location'];
-function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, $q, _, $rootScope, PostSurveyService, PostFilters, $timeout, $location) {
+ModeContextFormFilter.$inject = ['$scope', 'FormEndpoint', 'PostEndpoint', '$q', '_', '$rootScope', 'PostSurveyService', 'PostFilters', '$timeout', '$location'];
+function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, $q, _, $rootScope, PostSurveyService, PostFilters, $timeout, $location) {
     $scope.forms = [];
     $scope.showOnly = showOnly;
-    $scope.selectParent = selectParent;
     $scope.hide = hide;
     $scope.hasManageSettingsPermission = $rootScope.hasManageSettingsPermission;
     $scope.canAddToSurvey = PostSurveyService.canCreatePostInSurvey;
@@ -23,7 +22,6 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
     $scope.location = $location;
     $scope.goToUnmapped = goToUnmapped;
     $scope.getUnmapped = getUnmapped;
-    $scope.changeForms = changeForms;
     $scope.unknown = [];
 
     activate();
@@ -45,47 +43,12 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
     function activate() {
         // Load forms
         $scope.forms = FormEndpoint.query();
-        $scope.tags = TagEndpoint.query();
+
         var postCountRequest = getPostStats($scope.filters);
-        $q.all([$scope.forms.$promise, postCountRequest.$promise, $scope.tags.$promise]).then(function (responses) {
+        $q.all([$scope.forms.$promise, postCountRequest.$promise]).then(function (responses) {
             if (!responses[1] || !responses[1].totals || !responses[1].totals[0]) {
                 return;
             }
-            var tags = responses[2];
-
-            // adding children to tags
-            _.each(_.where(tags, { parent_id: null }), function (tag) {
-                if (tag && tag.children) {
-                    tag.children = _.filter(_.map(tag.children, function (child) {
-                        return _.findWhere(tags, {id: parseInt(child.id)});
-                    }));
-                }
-            });
-
-            angular.forEach($scope.forms, function (form, index) {
-                var formTagIds = _.pluck(form.tags, 'id');
-                // assigning whole tag-object to forms
-                $scope.forms[index].tags = _.filter(_.map(tags, function (tag) {
-                    // Remove children
-                    if (tag.parent_id === null) {
-                        tag = _.clone(tag);
-                        tag.children = _.clone(tag.children);
-
-                        // Grab the tags selected for this form
-                        if (_.contains(formTagIds, tag.id)) {
-                            // Filter the children based on form.tags
-                            tag.children = _.filter(tag.children, function (child) {
-                                return _.contains(formTagIds, child.id);
-                            });
-
-                            return tag;
-                        }
-                    }
-
-                    return false;
-                }));
-            });
-
             updateCounts(responses[1]);
         });
     }
@@ -101,11 +64,7 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
         if (queryParams.form) {
             delete queryParams.form;
         }
-        // deleting categories and sources since they are
-        // selected in the sidebar and not in the filter-modal = might get confusing
-        if (queryParams.tags) {
-            delete queryParams.tags;
-        }
+
         // deleting source, we want stats for all datasources to keep the datasource-bucket-stats unaffected by data-source-filters
         if (queryParams.source) {
             delete queryParams.source;
@@ -163,28 +122,6 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
         });
         return sourceStats;
     }
-    function selectParent(parent, formId) {
-        // If we've just selected the tag
-        if (_.contains($scope.filters.tags, parent.id)) {
-            // ... then select its children too
-            _.each(parent.children, function (child) {
-                $scope.filters.tags.push(child.id);
-            });
-
-            // Also filter to just this form
-            $scope.filters.form.splice(0, $scope.filters.form.length, formId);
-        // Or if we're deselecting the parent
-        } else {
-            // Deselect the children too
-            _.each(parent.children, function (child) {
-                // Remove each child without replacing the tags array
-                var index = $scope.filters.tags.indexOf(child.id);
-                if (index !== -1) {
-                    $scope.filters.tags.splice(index, 1);
-                }
-            });
-        }
-    }
 
     function languageToggle() {
         $scope.showLanguage = !$scope.showLanguage;
@@ -192,15 +129,6 @@ function ModeContextFormFilter($scope, FormEndpoint, PostEndpoint, TagEndpoint, 
 
     function showOnly(formId) {
         $scope.filters.form.splice(0, $scope.filters.form.length, formId);
-        // Remove tags filter
-        $scope.filters.tags.splice(0, $scope.filters.tags.length);
-    }
-
-    function changeForms() {
-        if ($scope.forms.length > 1) {
-            // Remove tags filter
-            $scope.filters.tags.splice(0, $scope.filters.tags.length);
-        }
     }
 
     function getUnmapped() {

--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -2,125 +2,71 @@
 
     <div class="survey-filter-checkbox init" ng-class="{ checked : (filters.form.indexOf(form.id) !== -1) }" ng-repeat="form in forms" dropdown>
         <div class="survey-filter-parent">
-        <div class="survey-filter-label">
-            <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
-            <label class="checked">
-                <input type="checkbox" checklist-value="form.id" checklist-model="filters.form" ng-change="changeForms()">
-                {{ ::form.name }}
-            </label>
-        </div>
-         <span class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
-            <!-- todo! show count -->
-            {{ form.post_count }}
-            <svg class="iconic">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-            </svg>
-        </span>
-        <ul class="dropdown-menu init" dropdown-menu>
-            <li ng-show="canAddToSurvey(form)">
-                <a ui-sref="postCreate({id: form.id })">
-                    <svg class="iconic">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#plus"></use>
-                    </svg>
-                    <span class="label" translate="post.add_to_form" translate-values="{ form: form.name }">Add to</span>
-                </a>
-            </li>
-            <!-- <li>
-                <a href="">
-                <svg class="iconic">
-                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#task"></use>
-                </svg>
-                <span class="label">Assign someone to add to Getting around</span>
-                </a>
-            </li> -->
-            <div class="divider"></div>
-            <li><a translate="post.show_only_form" translate-values="{ form: form.name }" ng-click="showOnly(form.id)">Show only </a></li>
-            <li><a translate="post.hide_form" translate-values="{ form: form.name }" ng-click="hide(form.id)">Hide</a></li>
-            <div class="divider"></div>
-            <li ng-show="hasManageSettingsPermission()">
-                <a ui-sref="settings.surveys.id({id: form.id, action: 'edit'})">
-                    <svg class="iconic">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#cog"></use>
-                    </svg>
-                    <span class="label" translate="nav.survey_settings">Survey settings</span>
-                </a>
-            </li>
-        </ul>
-        </div>
-
-        <fieldset
-            class="survey-filter-children"
-            dropdown
-            auto-close="outsideClick"
-            ng-show="form.tags.length > 0 && form.post_count > 0"
-            >
-            <legend class="init" data-toggle="form-fieldgroup" dropdown-toggle ng-class="{ selected : filters.tags.length }" translate="app.categories_count" translate-values="{ count: form.tags.length }">
-            </legend>
-
-            <div class="form-fieldgroup init" dropdown-menu>
-                <div
-                    class="form-field checkbox"
-                    ng-repeat="tag in form.tags"
-                    ng-class="{'checked': filters.tags.indexOf(tag.id) > -1}"
-                >
-                    <label ng-click="selectParent(tag, form.id)">
-                        <input
-                            type="checkbox"
-                            checklist-value="tag.id"
-                            checklist-model="filters.tags"
-                        />
-                        {{tag.tag}}
-                    </label>
-                    <div class="form-fieldgroup active">
-                        <div
-                            class="form-field checkbox"
-                            ng-repeat="child in tag.children"
-                            ng-class="{'checked': filters.tags.indexOf(child.id) !== -1}"
-                        >
-                            <label>
-                                <input
-                                    type="checkbox"
-                                    checklist-value="child.id"
-                                    checklist-model="filters.tags"
-                                />
-                                {{child.tag}}
-                            </label>
-                        </div>
-                    </div>
-                </div>
+            <div class="survey-filter-label">
+                <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
+                <label class="checked">
+                    <input type="checkbox" checklist-value="form.id" checklist-model="filters.form">
+                    {{ ::form.name }}
+                </label>
             </div>
-        </fieldset>
+             <span class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
+                <!-- todo! show count -->
+                {{ form.post_count }}
+                <svg class="iconic">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
+                </svg>
+            </span>
+            <ul class="dropdown-menu init" dropdown-menu>
+                <li ng-show="canAddToSurvey(form)">
+                    <a ui-sref="postCreate({id: form.id })">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#plus"></use>
+                        </svg>
+                        <span class="label" translate="post.add_to_form" translate-values="{ form: form.name }">Add to</span>
+                    </a>
+                </li>
+                <div class="divider"></div>
+                <li><a translate="post.show_only_form" translate-values="{ form: form.name }" ng-click="showOnly(form.id)">Show only </a></li>
+                <li><a translate="post.hide_form" translate-values="{ form: form.name }" ng-click="hide(form.id)">Hide</a></li>
+                <div class="divider"></div>
+                <li ng-show="hasManageSettingsPermission()">
+                    <a ui-sref="settings.surveys.id({id: form.id, action: 'edit'})">
+                        <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#cog"></use>
+                        </svg>
+                        <span class="label" translate="nav.survey_settings">Survey settings</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
     </div>
 </form>
 <div class="tool" ng-show="unmapped > 0">
-<p>There are
-    <a ng-click="goToUnmapped()"><strong>{{getUnmapped()}}</strong></a> not shown here because they don't include location information.</p>
+    <p>There are
+        <a ng-click="goToUnmapped()"><strong>{{getUnmapped()}}</strong></a> not shown here because they don't include location information.
+    </p>
 </div>
 <div class="form-field" ng-show="hasManageSettingsPermission()">
-        <a ui-sref="settings.surveys.create" class="button button-link">
-            <svg class="iconic">
-                <use xlink:href="/img/iconic-sprite.svg#plus"></use>
-            </svg>
-            <span class="button-label" translate="app.create_new_survey">Create new survey</span>
-        </a>
-    </div>
-</form>
+    <a ui-sref="settings.surveys.create" class="button button-link">
+        <svg class="iconic">
+            <use xlink:href="/img/iconic-sprite.svg#plus"></use>
+        </svg>
+        <span class="button-label" translate="app.create_new_survey">Create new survey</span>
+    </a>
+</div>
 <div class="tool">
     <h6 class="tool-heading" translate="app.data_sources"></h6>
     <filter-by-datasource post-stats="sourceStats" filters="filters"></filter-by-datasource>
 </div>
- <div class="tool">
-            <h6 class="tool-heading">Language</h6>
-            <span class="tool-trigger init" ng-class="{'active': showLanguage}" ng-click="languageToggle()">
-                <svg class="iconic">
-                    <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-                </svg>
-                <span class="label hidden">Show/hide</span>
-            </span>
-            <div
-                class="toggle-content"
-                ng-class="{'active': showLanguage}"
-                >
-            <language-switch></language-switch>
-            </div>
+<div class="tool">
+    <h6 class="tool-heading">Language</h6>
+    <span class="tool-trigger init" ng-class="{'active': showLanguage}" ng-click="languageToggle()">
+        <svg class="iconic">
+            <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
+        </svg>
+        <span class="label hidden">Show/hide</span>
+    </span>
+    <div class="toggle-content" ng-class="{'active': showLanguage}">
+        <language-switch></language-switch>
     </div>
+</div>

--- a/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
+++ b/test/unit/main/post/views/mode-context-form-filter.directive.spec.js
@@ -5,7 +5,6 @@ describe('mode-context-form-filter directive', function () {
         isolateScope,
         PostEndpoint,
         FormEndpoint,
-        TagEndpoint,
         $location,
         PostSurveyService,
         PostFilters;
@@ -17,17 +16,15 @@ describe('mode-context-form-filter directive', function () {
         angular.mock.module('testApp');
     });
 
-    beforeEach(inject(function (_$rootScope_, $compile, _FormEndpoint_, _PostEndpoint_, _TagEndpoint_, _PostSurveyService_, _PostFilters_, _$location_) {
+    beforeEach(inject(function (_$rootScope_, $compile, _FormEndpoint_, _PostEndpoint_, _PostSurveyService_, _PostFilters_, _$location_) {
         $rootScope = _$rootScope_;
         $scope = _$rootScope_.$new();
         PostEndpoint = _PostEndpoint_;
         FormEndpoint = _FormEndpoint_;
-        TagEndpoint = _TagEndpoint_;
         PostSurveyService = _PostSurveyService_;
         PostFilters = _PostFilters_;
         $location = _$location_;
         spyOn(FormEndpoint, 'query').and.callThrough();
-        spyOn(TagEndpoint, 'query').and.callThrough();
         spyOn(PostEndpoint, 'stats').and.callThrough();
         spyOn(PostFilters, 'getQueryParams').and.callThrough();
 
@@ -42,9 +39,6 @@ describe('mode-context-form-filter directive', function () {
     describe('test directive-functions', function () {
         it('should fetch forms from endpoint', function () {
             expect(FormEndpoint.query).toHaveBeenCalled();
-        });
-        it('should fetch tags from endpoint', function () {
-            expect(TagEndpoint.query).toHaveBeenCalled();
         });
         it('should fetch queryParams from service', function () {
             expect(PostFilters.getQueryParams).toHaveBeenCalled();
@@ -63,12 +57,6 @@ describe('mode-context-form-filter directive', function () {
             expect(isolateScope.showLanguage).toEqual(false);
             isolateScope.languageToggle();
             expect(isolateScope.showLanguage).toEqual(true);
-        });
-        it('should change form if a category is selected on a new form', function () {
-            isolateScope.forms = [{id: 1}, {id: 2}];
-            isolateScope.filters.tags = [1,2];
-            isolateScope.changeForms();
-            expect(isolateScope.filters.tags).toEqual([]);
         });
         it('should change filters when selecting show only', function () {
             isolateScope.showOnly(2);


### PR DESCRIPTION
This pull request makes the following changes:
- Removes category-filters from mode-context-bar

Testing checklist is here:
https://app.zenhub.com/workspace/o/ushahidi/platform/issues/2435
Test-deployment is found here: http://qa.2435-remove-mc-categories.ushahidilab.com/views/map

- [x] I certify that I ran my checklist


Fixes ushahidi/platform#2435 .

Ping @ushahidi/platform