### PR TITLE
 2436 - Filters dropdown: Top Level categories with children should behave as "Select all"

### DIFF
--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -45,11 +45,11 @@ function CategorySelectDirective(TagEndpoint, _, PostFilters) {
                     }
                 });
                 // separating parents from children
-                scope.setParents(_.filter(scope.categories, function (category) {
+                scope.parents = _.filter(scope.categories, function (category) {
                     if (category.parent_id === null) {
                         return category;
                     }
-                }));
+                });
                 // setting only the ids in the selectedCategories array
                 if (!scope.selectedCategories || scope.selectedCategories.length === 0) {
                     scope.selectedCategories = _.pluck(scope.categories, 'id');

--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -16,6 +16,7 @@ function CategorySelectDirective(TagEndpoint, _, PostFilters) {
             return;
         }
 
+        scope.handleParents = handleParents;
         scope.categories = [];
         scope.parents = [];
         scope.selectedCategories = [];
@@ -44,11 +45,11 @@ function CategorySelectDirective(TagEndpoint, _, PostFilters) {
                     }
                 });
                 // separating parents from children
-                scope.parents = _.filter(scope.categories, function (category) {
+                scope.setParents(_.filter(scope.categories, function (category) {
                     if (category.parent_id === null) {
                         return category;
                     }
-                });
+                }));
                 // setting only the ids in the selectedCategories array
                 if (!scope.selectedCategories || scope.selectedCategories.length === 0) {
                     scope.selectedCategories = _.pluck(scope.categories, 'id');

--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -18,6 +18,11 @@ function CategorySelectDirective(TagEndpoint, _) {
         scope.categories = [];
         scope.parents = [];
         scope.selectedCategories = [];
+        scope.internallyModified = false;
+        scope.internal = function () {
+            scope.internallyModified = false;
+        };
+
         activate();
 
         function activate() {
@@ -67,8 +72,8 @@ function CategorySelectDirective(TagEndpoint, _) {
             }
         }
 
-        function saveValueToView(selectedCategories) {
-            selectedCategories = handleParents(selectedCategories);
+        function saveValueToView(selectedCategories, oldSelection) {
+            selectedCategories = handleParents(selectedCategories, oldSelection);
             ngModel.$setViewValue(angular.copy(selectedCategories), ngModel.$viewValue);
         }
         // unselect children when parent is unselected and all children are selected
@@ -78,28 +83,95 @@ function CategorySelectDirective(TagEndpoint, _) {
         // ngModel.$viewValue > [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         // current results in this after processing >  [1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12]
         // SHOULD be:  [1, 2, 3, 5, 6, 9, 10, 11, 12] (which means, unselect children [7, 8]
-        function handleParents(newSelection, old) {
+        function handleParents(newSelection, oldSelection) {
             let result = angular.copy(newSelection);
-            const findRemoved = _.difference(ngModel.$viewValue, newSelection);
-            const findAdded = _.difference(newSelection, ngModel.$viewValue);
-            const parentsRemoved = _.filter(findRemoved, (category) => { // return parents that were removed
-                return isParent(category);
-            });
+            if (!scope.internallyModified) {
+                result = childrenRemovedResult(newSelection, oldSelection, result);
+            }
+            if (!scope.internallyModified) {
+                result = parentsRemovedResult(newSelection, oldSelection, result);
+            }
+            if (!scope.internallyModified) {
+                result = parentsAddedResult(newSelection, oldSelection, result);
+            }
+            if (!scope.internallyModified) {
+                result = childrenAllSelectedResult(newSelection, oldSelection, result);
+            }
+            return result;
+        }
 
-            if (findRemoved.length > 0 && parentsRemoved.length > 0) {
-                _.each(parentsRemoved, (parent) => {
-                    const toReject = allChildrenToUnselect(parent);
-                    result = _.without(result, ...toReject);
+        // unselect parent if child was removed
+        function childrenRemovedResult(newSelection, oldSelection, result) {
+            const findRemoved = _.difference(oldSelection, newSelection);
+            const childRemoved = _.filter(findRemoved, (category) => { // return parents that were removed
+                return !isParent(category);
+            });
+            if (childRemoved.length > 0) {
+                result = _.filter(result, (categoryId) => {
+                    return categoryId !== parentToUnSelect(childRemoved[0]);
                 });
-            } else if (findAdded.length > 0) {
+                scope.internallyModified = true;
+            }
+            return result;
+        }
+
+        function parentsAddedResult(newSelection, oldSelection, result) {
+            const findAdded = _.difference(newSelection, oldSelection);
+            if (findAdded.length > 0) {
                 _.each(newSelection, (any) => {
                     const toAdd = childrenToReSelect(any);
                     if (toAdd.length > 0) {
-                        result = result.concat(toAdd);
+                        result = _.uniq(result.concat(toAdd));
+                        scope.internallyModified = true;
                     }
                 });
             }
             return result;
+        }
+
+        function childrenAllSelectedResult(newSelection, oldSelection, result) {
+            const findAdded = _.difference(newSelection, oldSelection);
+            if (findAdded.length > 0) {
+                // for each parent in scope.parents, check if ALL their children are selected if a parent is unselected
+                _.each(scope.parents, (parentCategory) => {
+                    const findParent = _.find(newSelection, (itm) => itm === parentCategory.id);
+                    if (!findParent) {
+                        const contained = _.every(_.pluck(parentCategory.children, 'id'), (childId) => {
+                            return _.find(newSelection, (itm) => itm === childId);
+                        });
+                        if (contained) {
+                            result = _.uniq(result.concat(parentCategory.id));
+                            scope.internallyModified = true;
+                        }
+                    }
+                });
+            }
+            return result;
+        }
+
+        function parentsRemovedResult(newSelection, oldSelection, result) {
+            const findRemoved = _.difference(oldSelection, newSelection);
+            const parentsRemoved = _.filter(findRemoved, (category) => { // return parents that were removed
+                return isParent(category);
+            });
+            if (findRemoved.length > 0 && parentsRemoved.length > 0) {
+                _.each(parentsRemoved, (parent) => {
+                    const toReject = allChildrenToUnselect(parent);
+                    result = _.without(result, ...toReject);
+                    scope.internallyModified = true;
+                });
+            }
+            return result;
+        }
+
+        function parentToUnSelect(childId) {
+            const parent = _.filter(scope.parents, (parent) => {
+                const childFound = _.find(parent.children, (child) => {
+                    return child.id === childId;
+                });
+                return !!childFound;
+            });
+            return parent ? parent[0].id : null;
         }
 
         function childrenToReSelect(parentId) {

--- a/app/main/posts/views/filters/filter-category.directive.js
+++ b/app/main/posts/views/filters/filter-category.directive.js
@@ -117,7 +117,7 @@ function CategorySelectDirective(TagEndpoint, _) {
 
         function parentsAddedResult(newSelection, oldSelection, result) {
             const findAdded = _.difference(newSelection, oldSelection);
-            if (findAdded.length > 0) {
+            if (findAdded.length > 0 && isParent(findAdded[0])) {
                 _.each(newSelection, (any) => {
                     const toAdd = childrenToReSelect(any);
                     if (toAdd.length > 0) {

--- a/app/main/posts/views/filters/filter-category.html
+++ b/app/main/posts/views/filters/filter-category.html
@@ -4,7 +4,6 @@
     <div class="form-field checkbox" ng-repeat="(index, category) in categories" ng-class="{ overflow : ($index > 1) }" ng-if="category.parent_id === null">
         <label>
             <input
-                ng-click="internal()"
                 type="checkbox"
                 checklist-value="category.id"
                 value="category.id"
@@ -18,7 +17,6 @@
         >
           <label>
           <input
-            ng-click="internal()"
             type="checkbox"
             checklist-model="selectedCategories"
             checklist-value="child.id"

--- a/app/main/posts/views/filters/filter-category.html
+++ b/app/main/posts/views/filters/filter-category.html
@@ -4,6 +4,7 @@
     <div class="form-field checkbox" ng-repeat="(index, category) in categories" ng-class="{ overflow : ($index > 1) }" ng-if="category.parent_id === null">
         <label>
             <input
+                ng-click="internal()"
                 type="checkbox"
                 checklist-value="category.id"
                 value="category.id"
@@ -16,7 +17,8 @@
           ng-repeat="child in category.children"
         >
           <label>
-          <input 
+          <input
+            ng-click="internal()"
             type="checkbox"
             checklist-model="selectedCategories"
             checklist-value="child.id"

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -33,7 +33,8 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         cleanUIFilters: cleanUIFilters,
         cleanRemovedValuesFromObject: cleanRemovedValuesFromObject,
         addIfCurrentObjectMatchesOriginal: addIfCurrentObjectMatchesOriginal,
-        reactiveFilters: true
+        reactiveFilters: true,
+        filtersInternalChange: true
     };
 
     /**
@@ -152,6 +153,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
     }
 
     function clearFilters() {
+        this.filtersInternalChange = false;
         // Replace filterState with defaults
         angular.copy(getDefaults(), filterState);
         // Trigger reactive filters
@@ -163,6 +165,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         filterState = this.clearFilterFromArray(filterKey, value, filterState);
     }
     function clearFilterFromArray(filterKey, value, from) {
+        this.filtersInternalChange = false;
         /*
          * if filter is in an array, we only want to remove that specific value
          * if all filter-values are removed from array, we want to reset to default

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -34,6 +34,12 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         cleanRemovedValuesFromObject: cleanRemovedValuesFromObject,
         addIfCurrentObjectMatchesOriginal: addIfCurrentObjectMatchesOriginal,
         reactiveFilters: true,
+        /**
+         * This flag is used to syncronize the "internalChange" state globally
+         * (useful between filters bug icons and checkboxes).
+         * Since we use ngmodel all our changes in filter-category to selectecategories trigger changes
+         * and we want to keep a state to know if the user did the change or our handleParents category
+         */
         filtersInternalChange: true
     };
 

--- a/test/unit/main/post/views/filters/filter-category.directive.spec.js
+++ b/test/unit/main/post/views/filters/filter-category.directive.spec.js
@@ -1,0 +1,132 @@
+describe('Category Directive', function () {
+    var $rootScope,
+        $scope,
+        directiveScope,
+        PostFilters,
+        Notify,
+        element,
+        $compile;
+    beforeEach(function () {
+        fixture.setBase('mocked_backend/api/v3');
+
+
+        var testApp = makeTestApp();
+
+        testApp.directive('filterCategory', require('app/main/posts/views/filters/filter-category.directive'))
+            .service('PostFilters', require('app/main/posts/views/post-filters.service.js'));
+        angular.mock.module('testApp');
+    });
+
+    var defaults = {
+        q: '',
+        date_after: '',
+        date_before: '',
+        status: ['published', 'draft'],
+        published_to: '',
+        center_point: '',
+        has_location: 'all',
+        within_km: '1',
+        current_stage: [],
+        tags: [1, 2, 3, 4, 5],
+        saved_search: '',
+        orderby: 'created',
+        order: 'desc',
+        order_unlocked_on_top: 'true',
+        form: [1, 2, 3, 4],
+        set: [],
+        user: false,
+        source: ['sms', 'twitter','web', 'email']
+    };
+
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$compile_, _Notify_, _PostFilters_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $scope = _$rootScope_.$new();
+        PostFilters = _PostFilters_;
+        Notify = _Notify_;
+        $rootScope.filters = defaults;
+        $scope.filters = defaults;
+        $scope.parents = [{id: 1, children: [{id: 2}, {id: 4}, {id: 5}]}, {id: 3, children: []}];
+        element = '<filter-category ng-model="$scope.filters.tags"></filter-category>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+        $rootScope.$digest();
+        directiveScope = element.isolateScope();
+        directiveScope.parents = [{id: 1, children: [{id: 2}, {id: 4}, {id: 5}]}, {id: 3, children: []}];
+    }));
+
+    describe('test internallyModified flag', function () {
+        it('should return the same result as the newSelection variable when internallyModified==true', function () {
+            PostFilters.filtersInternalChange = true;
+            directiveScope.parents = [{id: 1, children: [{id: 2}, {id: 4}, {id: 5}]}, {id: 3, children: []}];
+            $scope.filters.tags = [1,2,3];
+            const result = directiveScope.handleParents([1,2,3], [1,2]);
+            expect(result).toEqual([1, 2, 3]);
+        });
+    });
+
+    describe('selecting and unselecting parents with no children works when internallyModified==false', function () {
+        it('should return the same result as the newSelection var when I unselect a parent', function () {
+            PostFilters.filtersInternalChange = false;
+            let newSelection = [1, 2];
+            let oldSelection = [1, 2, 3];
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([1, 2]);
+        });
+        it('should return the same result as the newSelection var when I select a parent', function () {
+            PostFilters.filtersInternalChange = false;
+            let newSelection = [1, 2, 3];
+            let oldSelection = [1, 2];
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([1, 2, 3]);
+        });
+    });
+    describe('selecting and unselecting children works when internallyModified==false', function () {
+        it('should unselect the parent when I unselect a child', function () {
+            let newSelection = [1, 3];
+            let oldSelection = [1, 2, 3];
+            PostFilters.filtersInternalChange = false;
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([3]);
+        });
+        it('should select the parent when I select all its children', function () {
+            let newSelection = [2, 3, 4, 5];
+            let oldSelection = [3, 4, 5];
+            PostFilters.filtersInternalChange = false;
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([2, 3, 4, 5, 1]); // order changed because we pushed the '1'
+        });
+
+        it('should not select the parent when I select only one of its children', function () {
+            PostFilters.filtersInternalChange = false;
+            let newSelection = [3, 4, 5];
+            let oldSelection = [3, 4, 5];
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([3, 4, 5]);
+        });
+    });
+    describe('selecting and unselecting parents with children works when internallyModified==false', function () {
+        it('should unselect the children when I unselect the parent', function () {
+            PostFilters.filtersInternalChange = false;
+            let newSelection = [2, 3, 4, 5];
+            let oldSelection = [1, 2, 3, 4, 5];
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([3]);
+        });
+        it('should select all the children when I select the parent', function () {
+            PostFilters.filtersInternalChange = false;
+            let newSelection = [1, 3];
+            let oldSelection = [3];
+            $scope.filters.tags = newSelection;
+            const result = directiveScope.handleParents(newSelection, oldSelection);
+            expect(result).toEqual([1, 3, 2, 4, 5]);
+        });
+    });
+
+});


### PR DESCRIPTION
### TODO: Still need to run my code review, update with develop and re-run checklist after some changes.
This pull request makes the following changes:
- Added logic to remove/add parents or children depending on state of categories object

Testing checklist:
- [x] Follow the test script at https://github.com/ushahidi/platform/issues/2436 
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2436 .

Ping @ushahidi/platform
