### PR TITLE
Data layout fix embeds

### DIFF
--- a/app/common/directives/layout-class.directive.js
+++ b/app/common/directives/layout-class.directive.js
@@ -14,13 +14,8 @@ function LayoutClassDirective() {
 LayoutClassController.$inject = ['$scope', '$rootScope', '$window', 'Util'];
 function LayoutClassController($scope, $rootScope, $window, Util) {
     var isEmbed = ($window.self !== $window.top) ? true : false;
-    // In the case of map we omit the layout-a class
-    var isMap = (Util.currentUrl()) ? Util.currentUrl().indexOf('map') > 0 : false;
-
     if (!isEmbed) {
         $rootScope.setLayout('layout-' + $scope.layout);
-    } else if (isEmbed && isMap) {
-        $rootScope.setLayout('layout-embed');
     } else {
         // If we are in embed mode
         // we must append the layout to the embed layout

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -61,10 +61,10 @@ function PostDetailDataController(
     $scope.$watch('post', function (post) {
         activate();
     });
-    /* need to check for embed here to set the correct class
-    * if coming from map to detail-view in embed, TODO: should go to a service! */
-    var isEmbed = ($window.self !== $window.top) ? true : false;
-    isEmbed ? $rootScope.setLayout('layout-d layout-embed') : $rootScope.setLayout('layout-d');
+    // /* need to check for embed here to set the correct class
+    // * if coming from map to detail-view in embed, TODO: should go to a service! */
+    // var isEmbed = ($window.self !== $window.top) ? true : false;
+    // isEmbed ? $rootScope.setLayout('layout-d layout-embed') : $rootScope.setLayout('layout-d');
 
     $scope.post = $scope.post;
     $scope.post_task = {};

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -1,4 +1,5 @@
 <div>
+  <layout-class layout="d"></layout-class>
   <article class="postcard" role="article">
     <button class="button-beta button-flat postcard-close" ng-click="close()">
         <svg class="iconic">


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the correct layout when using <layout-class>-directive, not matter what the iframe-url is.
- This is needed to switch between data and map-view in embeds

Testing checklist:
- [ ] Go to an embedded version with larger screen than 1023 px
- [ ] Click on map in the modebar
- [ ] Click on 'data' in the modebar
- [ ] The layout-class set should be "layout-embed layout-d"
- [ ] Go to the same deployment as the embedded version uses
- [ ] Click on map in the modebar
- [ ] Click on data in the modebar
- [ ] "Layout-d" should be set

- [x ] I certify that I ran my checklist

Fixes ushahidi/platform#2454 .

Ping @ushahidi/platform
