### PR TITLE
fix(csv-export-button) make the export button available in data mode always

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -11,7 +11,7 @@
         "collection": "Collection",
         "collections" : "Collections",
         "create_collection" : "Create collection",
-        "export_to_csv" : "Export to CSV",
+        "export_to_csv" : "Export filtered data",
         "create_new" : "Create new",
         "create_new_survey" : "Create new survey",
         "created_by" : "Created by {{author}}",

--- a/app/main/posts/views/share/post-export.html
+++ b/app/main/posts/views/share/post-export.html
@@ -1,1 +1,1 @@
-<a ng-click="exportPostsConfirmation()" translate="app.export_to_csv">Export to CSV</a>
+<a ng-click="exportPostsConfirmation()" translate="app.export_to_csv">Export filtered data</a>

--- a/app/main/posts/views/share/share-menu.directive.js
+++ b/app/main/posts/views/share/share-menu.directive.js
@@ -47,11 +47,8 @@ function ShareMenuController(
 
         $scope.shareUrlEncoded = encodeURIComponent($scope.shareUrl);
     }
-    // Check if current view is exportable based on URI
+    // Check if current view is exportable
     function isExportable() {
-        if ($window.location.href.indexOf('post') > 0) {
-            return false;
-        }
         return true;
     }
 }


### PR DESCRIPTION
fix(csv-export-button) make the export button available in data mode even if there are posts selected and change CTA #2475

This pull request makes the following changes:
- Makes the CSV Export button in the share modal available in all views where the share modal exists ushahidi/platform#2475 

Testing checklist:
- [ ] Follow test checklist here ushahidi/platform#2475 

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
