### PR TITLE
Reload categories after new one added

### DIFF
--- a/app/settings/categories/edit.controller.js
+++ b/app/settings/categories/edit.controller.js
@@ -11,6 +11,7 @@ module.exports = [
     'Util',
     '$transition$',
     '$q',
+    '$state',
 function (
     $scope,
     $rootScope,
@@ -23,7 +24,8 @@ function (
     _,
     Util,
     $transition$,
-    $q
+    $q,
+    $state
 ) {
 
     // Redirect to home if not authorized
@@ -150,7 +152,7 @@ function (
                 { name: $scope.category.tag }
             );
             // Redirect to categories list
-            $location.path('/settings/categories');
+            $state.go('settings.categories', {}, { reload: true });
         })
         // Catch and handle errors
         .catch(handleResponseErrors);


### PR DESCRIPTION
This pull request makes the following changes:
- replaced location.path with .go and reload so that categories are reloaded after adding a new one


Testing checklist:
- [ ] Navigate to settings
- [ ] create new category and hit save
- [ ] when categories page reloads, it should have new category you just created listed

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2332

Ping @ushahidi/platform
