### PR TITLE
Category reload

### DIFF
--- a/app/settings/categories/edit.controller.js
+++ b/app/settings/categories/edit.controller.js
@@ -11,6 +11,7 @@ module.exports = [
     'Util',
     '$transition$',
     '$q',
+    '$state',
 function (
     $scope,
     $rootScope,
@@ -23,7 +24,8 @@ function (
     _,
     Util,
     $transition$,
-    $q
+    $q,
+    $state
 ) {
 
     // Redirect to home if not authorized
@@ -150,7 +152,7 @@ function (
                 { name: $scope.category.tag }
             );
             // Redirect to categories list
-            $location.path('/settings/categories');
+            $state.go('settings.categories', {}, { reload: true });
         })
         // Catch and handle errors
         .catch(handleResponseErrors);

--- a/app/settings/users/create.controller.js
+++ b/app/settings/users/create.controller.js
@@ -35,9 +35,8 @@ function (
     $scope.save = $translate.instant('app.save');
     $scope.saving = $translate.instant('app.saving');
     $scope.saving_user = false;
-    $scope.saveUser = function (user, addAnother) {
+    $scope.saveUser = function (user) {
         $scope.saving_user = true;
-        var whereToNext = '/settings/users';
 
         UserEndpoint.saveCache(user).$promise.then(function (response) {
             if (response.id) {
@@ -46,7 +45,7 @@ function (
                 $scope.userSavedUser = true;
                 $scope.user.id = response.id;
                 // in favor of $route.reload();
-                addAnother ? $state.go($state.$current, null, { reload: true }) : $location.path(whereToNext);
+                $state.go('settings.users', null, { reload: true });
             }
         }, function (errorResponse) { // error
             var validationErrors = [],

--- a/app/settings/users/edit.controller.js
+++ b/app/settings/users/edit.controller.js
@@ -9,6 +9,7 @@ module.exports = [
     '_',
     'RoleEndpoint',
     'Session',
+    '$state',
 function (
     $scope,
     $rootScope,
@@ -19,7 +20,8 @@ function (
     Notify,
     _,
     RoleEndpoint,
-    Session
+    Session,
+    $state
 ) {
 
     // Redirect to home if not authorized
@@ -56,7 +58,7 @@ function (
                 $scope.userSavedUser = true;
                 $scope.user.id = response.id;
             }
-            $location.path('/settings/users');
+            $state.go('settings.users', null, { reload: true });
         }, function (errorResponse) { // error
             var validationErrors = [],
                 limitError = false;


### PR DESCRIPTION
This pull request makes the following changes:
- Changes $location.path() to use $state.go()

Testing checklist:
- [ ] Navigate to settings > users
- [ ] create new user and hit save
- [ ] when user page reloads, it should have new user you just created listed
- [ ] edit a user and hit save
- [ ] when user page reloads, it should have the updated user

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2332

Ping @ushahidi/platform
