### PR TITLE
Adding notification-messages

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1231,7 +1231,7 @@
         },
         "export" : {
             "in_progress" : "We are preparing your CSV file. This may take a few moments. You can leave this page if you want. We will let you know when we're done.",
-            "complete" : "Your CSV export is complete.",
+            "complete" : "Export done. You should see your CSV-file in your downloads.",
             "complete_data_found_message" : "The data from your export can be found in your browser's downloads"
         }
     },

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -991,7 +991,8 @@
         "select_fields_desc": "If you don't want to export all of your data at once, you can select specific fields from each survey for export.",
         "export_selected": "Export selected fields",
         "cancel": "Cancel",
-        "export_progress": "Export in progress..."
+        "export_progress": "Export in progress...",
+        "no_fields": "Uh oh... you need to select some fields to export first."
     },
     "user": {
         "role_display" : "Role: {{role}}",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1232,7 +1232,9 @@
         "export" : {
             "in_progress" : "We are preparing your CSV file. This may take a few moments. You can leave this page if you want. We will let you know when we're done.",
             "complete" : "Export done. You should see your CSV-file in your downloads.",
-            "complete_data_found_message" : "The data from your export can be found in your browser's downloads"
+            "complete_data_found_message" : "The data from your export can be found in your browser's downloads",
+            "confirmation": "Got it",
+            "cancel_export": "Cancel export" 
         }
     },
     "empty": {

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -22,9 +22,9 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         confirmLeave: confirmLeave
     };
 
-    function notify(message, translateValues) {
+    function notify(message, translateValues, icon, iconClass, dismiss) {
         function showSlider(message) {
-            SliderService.openTemplate('<p>' + message + '</p>');
+            SliderService.openTemplate(message, icon, iconClass, null, false, dismiss);
         }
 
         $translate(message, translateValues).then(showSlider, showSlider);

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -6,6 +6,7 @@ Notify.$inject = ['_', '$q', '$rootScope', '$translate', 'SliderService', 'Modal
 function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
     return {
         notify: notify,
+        exportNotifications,
         notifyProgress: notifyProgress,
         error: error,
         errors: errors,
@@ -22,22 +23,49 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         confirmLeave: confirmLeave
     };
 
-    function notify(message, translateValues, icon, iconClass, dismiss) {
+    function notify(message, translateValues) {
         function showSlider(message) {
-            SliderService.openTemplate(message, icon, iconClass, null, false, dismiss);
+            SliderService.openTemplate('<p>' + message + '</p>');
         }
 
         $translate(message, translateValues).then(showSlider, showSlider);
     }
 
-    function notifyProgress(message, translateValues, icon, iconClass) {
+    function notifyProgress(message, translateValues) {
         function showSlider(message) {
-            SliderService.openTemplate(message, icon, iconClass, null, false, false, true, true);
+            SliderService.openTemplate(message, null, null, null, false, true, true, true);
         }
 
         $translate(message, translateValues).then(showSlider, showSlider);
     }
 
+    function exportNotifications(message, translateValues, loading, icon, iconClass, action) {
+        var buttons, cancelButton, actionButton, scope;
+        // action is an object with the properties callback, text, actionClass
+        actionButton = '';
+        scope = getScope();
+        // closes the slider without action
+        scope.cancel = function () {
+            SliderService.close();
+        };
+        // html for the cancel-button
+        cancelButton = `<button class="button" ng-click="$parent.cancel()" translate="notify.export.confirmation"></button>`;
+
+        // adding html for the action-button, if its supposed to be there
+        if (action) {
+            scope.actionCallback = action.callback;
+            actionButton = `<button class="${action.actionClass}" ng-click="$parent.actionCallback()" translate=${action.text}></button>`;
+        }
+        // concatinating button and message html
+        buttons = `<div class="buttons-export">${actionButton + cancelButton}</div>`;
+        message += buttons;
+
+        function showSlider(successText) {
+            SliderService.openTemplate(message, icon, iconClass, scope, true, false, true, loading);
+        }
+        // translates the text and shows the slider
+        $translate(message, translateValues).then(showSlider, showSlider);
+    }
     function error(errorText, translateValues) {
         function showSlider(errorText) {
             SliderService.openTemplate('<p>' + errorText + '</p>', 'warning', 'error', null, false);
@@ -161,6 +189,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
 
         return deferred.promise;
     }
+
 
     function confirmDelete(confirmText, confirmWarningText, translateValues) {
         var deferred = $q.defer();

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -30,9 +30,9 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         $translate(message, translateValues).then(showSlider, showSlider);
     }
 
-    function notifyProgress(message, translateValues) {
+    function notifyProgress(message, translateValues, icon, iconClass) {
         function showSlider(message) {
-            SliderService.openTemplate(message, null, null, null, false, true, true, true);
+            SliderService.openTemplate(message, icon, iconClass, null, false, false, true, true);
         }
 
         $translate(message, translateValues).then(showSlider, showSlider);

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -87,7 +87,9 @@ function DataExport($rootScope, ConfigEndpoint, ExportJobEndpoint, $q, _, $windo
             Notify.apiErrors(err);
         } else {
             if (status === true) {
-                Notify.notifyProgress('<p translate="notify.export.in_progress"></p>');
+                //TODO: Need to add cancel-job-event on button!
+                var message = '<p translate="notify.export.in_progress"></p><div class="buttons-export"><button class="button">Got it</button><button class="button-destructive">Cancel export</button>';
+                Notify.notifyProgress(message, null, 'ellipses', 'circle-icon confirmation');
             } else {
                 Notify.notify('<h3 translate="notify.export.complete">Your CSV export is complete.</h3><p translate="notify.export.complete_data_found_message">The data from your export can be found in your browser\'s downloads<p>');
             }

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -26,6 +26,10 @@ function DataExport($rootScope, ConfigEndpoint, ExportJobEndpoint, $q, _, $windo
             loadingStatus(false, err);
         });
     }
+    function cancelExport(jobId) {
+        //TODO: Add cancel-job
+        console.log('canceling job');
+    }
 
     function showCSVResults(response, format) {
         // Save export data to file
@@ -83,19 +87,30 @@ function DataExport($rootScope, ConfigEndpoint, ExportJobEndpoint, $q, _, $windo
     }
 
     function loadingStatus(status, err) {
-        var message;
+        var message, // holds the message to the user
+            action, // holds info for the action-button
+            icon, // holds info about icon to use in the notification
+            loading; // show loading-slider or not
+
         if (err) {
             Notify.apiErrors(err);
         } else {
             if (status === true) {
-                //TODO: Need to add cancel-job-event on button!
-                message = '<p translate="notify.export.in_progress"></p><div class="buttons-export"><button class="button">Got it</button><button class="button-destructive">Cancel export</button>';
-                Notify.notifyProgress(message, null, 'ellipses', 'circle-icon confirmation');
+                message = '<p translate="notify.export.in_progress">';
+                action = {
+                    callback: cancelExport,
+                    text: 'notify.export.cancel_export',
+                    actionClass: 'button-destructive'
+                };
+                icon = 'ellipses';
+                loading = true;
             } else {
-                // TODO: Need to close when clickin on 'Got it'-button
-                message = '<p translate="notify.export.complete"></p><div class="buttons-export"><button class="button">Got it</button></div>';
-                Notify.notify(message, null, 'thumb-up', 'cirle-icon confirmation', false);
+                message = '<p translate="notify.export.complete"></p>';
+                icon = 'thumb-up';
+                loading = false;
             }
+
+            Notify.exportNotifications(message, null, loading, icon, 'circle-icon confirmation', action);
         }
     }
 

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -83,15 +83,18 @@ function DataExport($rootScope, ConfigEndpoint, ExportJobEndpoint, $q, _, $windo
     }
 
     function loadingStatus(status, err) {
+        var message;
         if (err) {
             Notify.apiErrors(err);
         } else {
             if (status === true) {
                 //TODO: Need to add cancel-job-event on button!
-                var message = '<p translate="notify.export.in_progress"></p><div class="buttons-export"><button class="button">Got it</button><button class="button-destructive">Cancel export</button>';
+                message = '<p translate="notify.export.in_progress"></p><div class="buttons-export"><button class="button">Got it</button><button class="button-destructive">Cancel export</button>';
                 Notify.notifyProgress(message, null, 'ellipses', 'circle-icon confirmation');
             } else {
-                Notify.notify('<h3 translate="notify.export.complete">Your CSV export is complete.</h3><p translate="notify.export.complete_data_found_message">The data from your export can be found in your browser\'s downloads<p>');
+                // TODO: Need to close when clickin on 'Got it'-button
+                message = '<p translate="notify.export.complete"></p><div class="buttons-export"><button class="button">Got it</button></div>';
+                Notify.notify(message, null, 'thumb-up', 'cirle-icon confirmation', false);
             }
         }
     }

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -85,8 +85,8 @@ function (
 
         if (attributes.length === 0) {
             // displaying notification if no fields are selected
-            var message =  '<p>Uh oh... you need to select some fields to export first.</p><div class="buttons-export"><button class="button">Got it</button></div>';
-            Notify.notify(message, null, 'warning', 'error', false);
+            var message =  '<p translate="data_export.no_fields"></p>';
+            Notify.exportNotifications(message, null, false, 'warning', 'error');
         } else {
             DataExport.prepareExport({attributes: attributes, format: 'csv'});
         }

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -83,7 +83,13 @@ function (
             .compact() // removing nulls
             .value(); // output
 
-        DataExport.prepareExport({attributes: attributes, format: 'csv'});
+        if (attributes.length === 0) {
+            // displaying notification if no fields are selected
+            var message =  '<p>Uh oh... you need to select some fields to export first.</p><div class="buttons-export"><button class="button">Got it</button></div>';
+            Notify.notify(message, null, 'warning', 'error', false);
+        } else {
+            DataExport.prepareExport({attributes: attributes, format: 'csv'});
+        }
     }
 
     function selectAll(form) {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nvd3": "^1.8.4",
     "socket.io-client": "2.0.3",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "3.7.2-rc.31"
+    "ushahidi-platform-pattern-library": "3.7.2-rc.32"
   },
   "engines": {
     "node": ">=4.0"

--- a/test/unit/common/notifications/notify.service.spec.js
+++ b/test/unit/common/notifications/notify.service.spec.js
@@ -90,7 +90,7 @@ describe('Notify', function () {
         });
 
         it('calls $rootScope.$on with the combined alert messages', function () {
-            expect(mockSliderService.openTemplate).toHaveBeenCalledWith('<p>Test message</p>');
+            expect(mockSliderService.openTemplate).toHaveBeenCalledWith('Test message', undefined, undefined, null, false, undefined);
         });
     });
 

--- a/test/unit/common/notifications/notify.service.spec.js
+++ b/test/unit/common/notifications/notify.service.spec.js
@@ -90,7 +90,7 @@ describe('Notify', function () {
         });
 
         it('calls $rootScope.$on with the combined alert messages', function () {
-            expect(mockSliderService.openTemplate).toHaveBeenCalledWith('Test message', undefined, undefined, null, false, undefined);
+            expect(mockSliderService.openTemplate).toHaveBeenCalledWith('<p>Test message</p>');
         });
     });
 

--- a/test/unit/mock/services/notify.js
+++ b/test/unit/mock/services/notify.js
@@ -76,6 +76,13 @@ module.exports = [function () {
                     successCallback();
                 }
             };
+        },
+        exportNotifications: function () {
+            return {
+                then: function (successCallback) {
+                    successCallback();
+                }
+            };
         }
     };
 }];

--- a/test/unit/settings/data-export/data-export.controller.spec.js
+++ b/test/unit/settings/data-export/data-export.controller.spec.js
@@ -84,9 +84,9 @@ describe('data-export-controller', function () {
     describe('exportSelected-function', function () {
         it('should notify user if no fields are selected', function () {
             $scope.selectedFields = [];
-            spyOn(Notify, 'notify');
+            spyOn(Notify, 'exportNotifications');
             $scope.exportSelected();
-            expect(Notify.notify).toHaveBeenCalled();
+            expect(Notify.exportNotifications).toHaveBeenCalled();
         });
         it('should call prepareExport with the selectedFields', function () {
             $scope.selectedFields = [1, 4, 7, 8, 10];

--- a/test/unit/settings/data-export/data-export.controller.spec.js
+++ b/test/unit/settings/data-export/data-export.controller.spec.js
@@ -82,6 +82,12 @@ describe('data-export-controller', function () {
         });
     });
     describe('exportSelected-function', function () {
+        it('should notify user if no fields are selected', function () {
+            $scope.selectedFields = [];
+            spyOn(Notify, 'notify');
+            $scope.exportSelected();
+            expect(Notify.notify).toHaveBeenCalled();
+        });
         it('should call prepareExport with the selectedFields', function () {
             $scope.selectedFields = [1, 4, 7, 8, 10];
             spyOn(DataExport, 'prepareExport');


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a new notification-function for export-notifications (they look different than other notifications)
- Adds notifications for Export-start (#2429), export-done (#2428) and if user has selected no fields

Export-start-notification:
![screen shot 2018-02-16 at 14 55 56](https://user-images.githubusercontent.com/8624777/36310849-92f8236c-1329-11e8-837a-64257b4e4b72.png)

Export-done-notification:
![screen shot 2018-02-16 at 14 56 56](https://user-images.githubusercontent.com/8624777/36310875-a97805e4-1329-11e8-9ae6-167ae0a20811.png)

No fields-selected-notification:
![screen shot 2018-02-16 at 14 57 19](https://user-images.githubusercontent.com/8624777/36310895-b4e492f8-1329-11e8-92e3-f618294cd7bf.png)


Testing checklist:
- [ ] Click on share-button on data or map-view, select 'export fields'
- [ ] You get prompted with a question if you want to export. Select yes
- [ ] Do the steps for  "Notifications for export" below
- [ ] Go to settings-list
- [ ] Select "Data-export"
- [ ] Select "Export all data"
- [ ] Do the steps for  "Notifications for export" below
- [ ] Select "Select Fields"
- [ ] Click on "export selected fields" without any fields selected
- [ ] The "No fields-selected-notification" should be visible
- [ ] Click on "got it"
- [ ] Notification is closed
- [ ] Select a few fields
- [ ] Click on "export selected fields"
- [ ] Do the steps for  "Notifications for export" below

*Notifications for export:*
- [ ] When export is started, the "Export start" notification is visible
- [ ] Clicking on "Cancel job" loggs "canceling export" (this function is not implemented yet)
- [ ] Clicking on "Got it" hides the notification
- [ ] When export is done, the "Export done" notification is visible


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2428, #2429  .

Ping @ushahidi/platform