### PR TITLE
2410 - fixing bugs

### DIFF
--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -94,9 +94,7 @@ function CategorySelectorController($scope, _) {
 
             // If children are selected, add to disabled categories
             if (selectedChildren.length > 0) {
-                if ($scope.enableParents === false) {
-                    $scope.disabledCategories[category.id] = true;
-                }
+                $scope.disabledCategories[category.id] = true;
                 // ... and ensure this category is selected
                 if (!_.contains($scope.selectedParents, category.id)) {
                     $scope.selectedParents.push.apply($scope.selectedParents, [category.id]);
@@ -108,8 +106,13 @@ function CategorySelectorController($scope, _) {
                 var parentIndex = _.findIndex($scope.selectedParents, function (parentId) {
                     return parentId === category.id;
                 });
+                var parentIndexSelected = _.findIndex($scope.selected, function (parentId) {
+                    return parentId === category.id;
+                });
+
                 if (parentIndex >= 0) {
                     $scope.selectedParents.splice(parentIndex, 1);
+                    $scope.selected.splice(parentIndexSelected, 1);
                     // or, if no children are selected
                     // remove from disabled categories
                 }

--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -24,7 +24,15 @@ function CategorySelectorController($scope, _) {
     $scope.selectedParents = [];
     $scope.disabledCategories = [];
     $scope.changeCategories = changeCategories;
+
     activate();
+    $scope.selectAllEnabled = function () {
+        if ($scope.enableParents) {
+            return $scope.selected.length === $scope.available.length;
+        } else {
+            return ($scope.selected.length + $scope.selectedParents.length) === $scope.available.length;
+        }
+    };
 
     function activate() {
         // remove default null value when creating a new post
@@ -44,12 +52,16 @@ function CategorySelectorController($scope, _) {
             $scope.form.$setDirty();
         }
 
-        if ($scope.available.length === $scope.selected.length) {
+        if ($scope.selectAllEnabled()) {
             $scope.selected.splice(0, $scope.selected.length);
+            $scope.selectedParents.splice(0, $scope.selectedParents.length);
         } else {
             _.each($scope.available, function (category) {
-                if (!_.contains($scope.selected, category.id)) {
-                    $scope.selected.push(category.id);
+                var isParentWithChildren = !category.parent_id && category.children.length > 0;
+                if (!_.contains($scope.selected, category.id) && !isParentWithChildren) {
+                    $scope.selected.push.apply($scope.selected, [category.id]);
+                } else if (isParentWithChildren && !_.contains($scope.selectedParents, category.id)) {
+                    $scope.selectedParents.push.apply($scope.selectedParents, [category.id]);
                 }
             });
         }
@@ -91,6 +103,7 @@ function CategorySelectorController($scope, _) {
                 .pluck('id')
                 .intersection($scope.selected)
                 .value();
+            var parentIndexSelected = -1;
             var isParentWithChildren = !category.parent_id && category.children.length > 0;
             // If children are selected, add to disabled categories
             if (selectedChildren.length > 0) {
@@ -106,22 +119,29 @@ function CategorySelectorController($scope, _) {
                 var parentIndex = _.findIndex($scope.selectedParents, function (parentId) {
                     return parentId === category.id;
                 });
-                var parentIndexSelected = _.findIndex($scope.selected, function (parentId) {
+                parentIndexSelected = _.findIndex($scope.selected, function (parentId) {
                     return parentId === category.id;
                 });
-
                 if (parentIndex >= 0) {
                     $scope.selectedParents.splice(parentIndex, 1);
-                    $scope.selected.splice(parentIndexSelected, 1);
-                    // or, if no children are selected
-                    // remove from disabled categories
+                    if ($scope.enableParents === true) {
+                        $scope.selected.splice(parentIndexSelected, 1);
+                    }
                 }
                 if (isParentWithChildren) {
                     $scope.disabledCategories[category.id] = true;
                 } else {
                     $scope.disabledCategories[category.id] = false;
                 }
+            }
 
+            if ($scope.enableParents === false && isParentWithChildren) {
+                parentIndexSelected = _.findIndex($scope.selected, function (parentId) {
+                    return parentId === category.id;
+                });
+                if (parentIndexSelected >= 0) {
+                    $scope.selected.splice(parentIndexSelected, 1);
+                }
             }
         });
 

--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -91,7 +91,7 @@ function CategorySelectorController($scope, _) {
                 .pluck('id')
                 .intersection($scope.selected)
                 .value();
-
+            var isParentWithChildren = !category.parent_id && category.children.length > 0;
             // If children are selected, add to disabled categories
             if (selectedChildren.length > 0) {
                 $scope.disabledCategories[category.id] = true;
@@ -116,8 +116,12 @@ function CategorySelectorController($scope, _) {
                     // or, if no children are selected
                     // remove from disabled categories
                 }
+                if (isParentWithChildren) {
+                    $scope.disabledCategories[category.id] = true;
+                } else {
+                    $scope.disabledCategories[category.id] = false;
+                }
 
-                $scope.disabledCategories[category.id] = false;
             }
         });
 

--- a/app/common/directives/category-selector.html
+++ b/app/common/directives/category-selector.html
@@ -3,7 +3,7 @@
         <label>
             <input
                   type="checkbox"
-                  ng-checked="available.length === selected.length"
+                  ng-checked="selectAllEnabled()"
                   ng-click="selectAll()"
             >
             <em><span translate="category.select_all"></span></em>

--- a/app/main/posts/common/post-actions.service.js
+++ b/app/main/posts/common/post-actions.service.js
@@ -31,6 +31,26 @@ function (
         },
         getStatuses: function () {
             return ['published', 'draft', 'archived'];
+        },
+        filterPostEditorCategories: function (attributeOptions, categories) {
+            // adding category-objects attribute-options
+            return _.chain(attributeOptions)
+                .map((category) => {
+                    const ret = angular.copy(_.findWhere(categories, {id: category}));
+                    if (ret && ret.children.length > 0) {
+                        ret.children = _.chain(ret.children)
+                            .map((child) => {
+                                if (attributeOptions.find((o) => o === child.id)) {
+                                    return _.findWhere(categories, {id: child.id});
+                                }
+                            })
+                            .filter()
+                            .value();
+                    }
+                    return ret;
+                })
+                .filter()
+                .value();
         }
     };
 

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -270,23 +270,7 @@ function PostDataEditorController(
                 }
                 if (attr.input === 'tags') {
                     // adding category-objects attribute-options
-                    attr.options = _.chain(attr.options)
-                        .map(function (category) {
-                            const ret = _.findWhere(categories, {id: category});
-                            if (ret && ret.children.length > 0) {
-                                ret.children = _.chain(ret.children)
-                                    .map(function (child) {
-                                        return _.findWhere(categories, {id: child.id});
-                                    })
-                                    .filter()
-                                    .value();
-                            }
-                            return ret;
-                        })
-                        .filter()
-                        .value();
-
-
+                    attr.options = PostActionsService.filterPostEditorCategories(attr.options, categories);
                 }
 
                 // @todo don't assign default when editing? or do something more sane

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -170,23 +170,7 @@ function PostEditorController(
                 }
                 if (attr.input === 'tags') {
                     // adding category-objects attribute-options
-                    attr.options = _.chain(attr.options)
-                        .map(function (category) {
-                            const ret = _.findWhere(categories, {id: category});
-                            if (ret && ret.children.length > 0) {
-                                ret.children = _.chain(ret.children)
-                                    .map(function (child) {
-                                        return _.findWhere(categories, {id: child.id});
-                                    })
-                                    .filter()
-                                    .value();
-                            }
-                            return ret;
-                        })
-                        .filter()
-                        .value();
-
-
+                    attr.options = PostActionsService.filterPostEditorCategories(attr.options, categories);
                 }
                 // @todo don't assign default when editing? or do something more sane
                 if (!$scope.post.values[attr.key]) {

--- a/test/unit/common/directives/category-selector.parentsEnabled.directive.spec.js
+++ b/test/unit/common/directives/category-selector.parentsEnabled.directive.spec.js
@@ -65,7 +65,7 @@ describe('category-selector directive with enableParents=true', function () {
         expect(isolateScope.selectedParents.length).toBe(1);
         expect(isolateScope.selected.length).toBe(2);
         // the parent should be disabled
-        expect(isolateScope.disabledCategories[1]).toBe(false);
+        expect(isolateScope.disabledCategories[1]).toBe(true);
     });
 
     it ('should unselect the selectedParent in scope.selectedParents, if I unselect the child and call changeCategories', function () {


### PR DESCRIPTION
This pull request makes the following changes:
- fixes behavior in survey editor and add post. Two new test cases are added to the test script. 

Testing checklist:

## Addition to TESTING Script (devphase)
#### Parent categories are disabled/cannot be selected if they have children  in the survey creation/survey edition screens when adding a category field
- [x] Open the "Add new post"  screen as an admin. 
- [x] Fill out required info
- [x] Try to select a parent category (that has children) 
- [x] You should NOT be able to select the parent category

## Addition to TESTING Script (devphase)
#### When I only select 1 child out of many in the Survey Editor for a category field, I only see that child and its parent when I open the "Add new post" screen for that type.
Screenshots as example:
survey editor screen
<img width="592" alt="screen shot 2018-02-19 at 12 40 02 pm" src="https://user-images.githubusercontent.com/2434401/36385715-1825ce64-1572-11e8-944c-3e7778a7f29a.png">

add new post screen
<img width="547" alt="screen shot 2018-02-19 at 12 40 09 pm" src="https://user-images.githubusercontent.com/2434401/36385713-17fb17aa-1572-11e8-9954-56e3bc2560c6.png">

- [x] Open the "Survey editor" for a survey, and add a category field with only 1 child selected for a parent category
- [x] Fill out required info, and save. 
- [x] Open the "add new post" screen
- [x] Verify that you do not see other child categories besides the one you made available for that category field

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2410 .

Ping @ushahidi/platform
