### PR TITLE
Hotfix for twitter sharing

### DIFF
--- a/app/main/posts/views/share/share-menu.html
+++ b/app/main/posts/views/share/share-menu.html
@@ -31,7 +31,7 @@
                 <div class="listing-item-image">
                     <img class="icon" src="/img/twitter.png" alt="">
                 </div>
-                <h2 class="listing-item-title"><a ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
+                <h2 class="listing-item-title"><a target="_blank" ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
             </div>
         </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- adds target=_blank to a tag for sharing via twitter. Allows share to open in new tab which won't break embeded instances.

Testing checklist:
- [ ] Click on post; select share; select twitter; should open twitter share in new tab

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2489

Ping @ushahidi/platform
