### PR TITLE
Fixes #1006 - reload list of surveys on save.

### DIFF
--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -18,6 +18,7 @@ SurveyEditorController.$inject = [
     '$q',
     '$location',
     '$translate',
+    '$state',
     'FormEndpoint',
     'FormRoleEndpoint',
     'FormStageEndpoint',
@@ -35,6 +36,7 @@ function SurveyEditorController(
     $q,
     $location,
     $translate,
+    $state,
     FormEndpoint,
     FormRoleEndpoint,
     FormStageEndpoint,
@@ -588,8 +590,9 @@ function SurveyEditorController(
                 { name: $scope.survey.name },
                 { formId: $scope.survey.id }
             );
+
             // Redirect to survey list
-            $location.url('settings/surveys');
+            $state.go('settings.surveys', {}, { reload: true });
         })
         // Catch and handle errors
         .catch(handleResponseErrors);

--- a/test/unit/settings/surveys/settings-survey-editor.directive.spec.js
+++ b/test/unit/settings/surveys/settings-survey-editor.directive.spec.js
@@ -23,6 +23,14 @@ describe('setting survey editor directive', function () {
             return mockFeatures;
         });
 
+        testApp.service('$state', function () {
+            return {
+                'go': function () {
+                    return {};
+                }
+            };
+        });
+
         angular.mock.module('testApp');
     });
 


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes #1006 - Survey list now refreshes after new survey is saved.

Testing checklist:
- [ ]

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
