### PR TITLE
Update export job states

### DIFF
--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -20,7 +20,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
         var queries = [];
         ExportJobEndpoint.queryFresh({user: 'me'}).$promise.then(function (response) {
             _.each(response, function (job) {
-                if (job.status !== 'done') {
+                if (job.status !== 'SUCCESS' && job.status !== 'FAILED') {
                     queries.push(ExportJobEndpoint.getFresh({id: job.id}));
                 }
             });
@@ -33,11 +33,17 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
         $timeout(function () {
             $q.all(queries).then(function (response) {
                 _.each(response, function (job) {
-                    if (job.status === 'done') {
-                        // when job is done, we stop the polling...
+                    if (job.status === 'SUCCESS') {
+                        // when job is successful, we stop the polling...
                         $rootScope.$broadcast('event:export_job:stopped');
                         // ..and download the file
                         downloadFile(job.url);
+                    } else if (job.status === 'FAILED') {
+                        // when job is failed, we stop the polling...
+                        $rootScope.$broadcast('event:export_job:stopped');
+                        // ..and notify user that it has failed
+                        var error_message = 'Export job has failed.';
+                        loadingStatus(true, error_message);
                     } else {
                         // add the job to the poll until job is done
                         nextQuery.push(ExportJobEndpoint.getFresh({id: job.id}));

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -43,7 +43,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
                         $rootScope.$broadcast('event:export_job:stopped');
                         // ..and notify user that it has failed
                         var error_message = 'Export job has failed.';
-                        loadingStatus(true, error_message);
+                        loadingStatus(false, error_message);
                     } else {
                         // add the job to the poll until job is done
                         nextQuery.push(ExportJobEndpoint.getFresh({id: job.id}));


### PR DESCRIPTION
This pull request makes the following changes:
-updates the status flags that the poller looks for in export_jobs to include a 'FAILED' state
-changes name of 'done' to 'SUCCESS' to differentiate between a done state and a done state that is successful

Testing checklist:
- [ ] Create an export job

Success Condition:
- [ ] Set the status of that job in the 'export_job' table to 'SUCCESS' and add a URL to a file in 'url'
- [ ] An alert should appear to let the user know that an export was successful
- [ ] A download should be initiated to whatever the url points to 

Failure Condition:
- [ ] Set the status of that job in the 'export_job' table to 'FAILED'
- [ ] An ApiError notification should appear
