### PR TITLE
Added form validation for each step in directive; added show/hide on …

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1206,7 +1206,16 @@
             "destroy_stage_success" : "Survey task {{name}} deleted",
             "delete_attribute_confirm" : "Are you sure you want to delete this field?",
             "delete_attribute_confirm_desc" : "This action cannot be undone. Deleting this field will remove its data from all existing posts.",
-            "destroy_attribute_success" : "Field {{name}} deleted"
+            "destroy_attribute_success" : "Field {{name}} deleted",
+            "validation": {
+                "name": {
+                    "required": "A survey-name is needed",
+                    "minlength": "Name is too short"
+                },
+                "description":{
+                    "required": "Description cannot be empty"
+                }
+            }
         },
         "collection" : {
             "delete_collection_confirm" : "Are you sure you want to delete this collection?",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1210,7 +1210,8 @@
             "validation": {
                 "name": {
                     "required": "A survey-name is needed",
-                    "minlength": "Name is too short"
+                    "minlength": "Name is too short",
+                    "maxlength": "Name is too long"
                 },
                 "description":{
                     "required": "Description cannot be empty"

--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -3,10 +3,12 @@ module.exports = [
     '$scope',
     'Features',
     '$state',
+    '_',
 function (
     $scope,
     Features,
-    $state
+    $state,
+    _
 ) {
     $scope.isActiveStep = isActiveStep;
     $scope.isStepComplete = isStepComplete;
@@ -33,12 +35,10 @@ function (
     }
 
     function isStepComplete(step) {
-        // todo: check if form-parts of this step is dirty, then return false, else return true.
-        return true;
+        return step.$valid;
     }
 
     function completeStepOne() {
-        // Insert validation for step 1 here
         $scope.activeStep = 2;
     }
 

--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -39,28 +39,49 @@
                         <span class="stepper-badge">1</span>
                         Name your survey
                     </h2>
-                    <div ng-show="isActiveStep(1)">
-                        <div class="form-field">
-                            <div class="button-group">
-                                <button class="button-alpha" ng-disabled="!isStepComplete(1)" ng-click="completeStepOne()">Continue</button>
+                    <form name="stepOne">
+                        <div class="form-field" ng-show="isActiveStep(1)">
+                            <label>Survey name</label>
+                            <input type="text" name="name" ng-minlength="2" ng-model="name" required placeholder="Name...">
+                        </div>
+                        <div ng-hide="isActiveStep(1)">
+                            <h2 class=form-label>Survey Name</h2>
+                            <p>{{name}}</p>  
+                        </div>
+                                          
+                        <div class="form-field" ng-show="isActiveStep(1)">
+                            <label>Survey description</label>
+                            <textarea name="description" ng-model="description" required placeholder="Describe your survey..."></textarea>  
+                        </div>
+                        <div ng-hide="isActiveStep(1)">
+                            <h2 class=form-label>Survey Description</h2>
+                            <p>{{description}}</p>
+                        </div>
+                        <div ng-show="isActiveStep(1)">
+                            <div class="form-field">
+                                <div class="button-group">
+                                    <button class="button-alpha" ng-disabled="!isStepComplete(stepOne)" ng-click="completeStepOne()">Continue</button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </form>    
                 </div>
 
                 <div class="stepper-item" ng-class="{'active': isActiveStep(2), 'disabled': !isActiveStep(2)}">
                     <h2 class="stepper-heading">
                             <span class="stepper-badge">2</span>
                                 Choose your audience
-                        </h2>
-                       <div ng-show="isActiveStep(2)">
-                        <div class="form-field">
-                            <div class="button-group">
-                                  <button class="button-alpha" ng-disabled="!isStepComplete(2)" ng-click="completeStepTwo()">Continue</button>
-                                <button class="button" ng-click="previousStep()">Back</button>
+                    </h2>
+                    <form name="stepTwo">
+                        <div ng-show="isActiveStep(2)">
+                            <div class="form-field">
+                                <div class="button-group">
+                                      <button class="button-alpha" ng-disabled="!isStepComplete(stepTwo)" ng-click="completeStepTwo()">Continue</button>
+                                    <button class="button" ng-click="previousStep()">Back</button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </form>    
                 </div>
 
                 <div class="stepper-item" ng-class="{'active': isActiveStep(3), 'disabled': !isActiveStep(3)}">
@@ -68,14 +89,16 @@
                             <span class="stepper-badge">3</span>
                                 Add your questions
                     </h2>
-                    <div ng-show="isActiveStep(3)">
-                         <div class="form-field">
-                            <div class="button-group">
-                                <button class="button-alpha" ng-disabled="!isStepComplete(3)" ng-click="completeStepThree()">Continue</button>
-                                <button class="button" ng-click="previousStep()">Back</button>
+                    <form name="stepThree">
+                        <div ng-show="isActiveStep(3)">
+                             <div class="form-field">
+                                <div class="button-group">
+                                    <button class="button-alpha" ng-disabled="!isStepComplete(stepThree)" ng-click="completeStepThree()">Continue</button>
+                                    <button class="button" ng-click="previousStep()">Back</button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </form>
                 </div>
 
                 <div class="stepper-item" ng-class="{'active': isActiveStep(4), 'disabled': !isActiveStep(4)}">

--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -27,94 +27,122 @@
     </div>
 
     <div class="main-col">
-        <div ng-show="targetedSurveysEnabled" class="form-sheet">
-            <div class="form-sheet-summary">
-                <h2 class="form-sheet-title">Create a new targeted survey</h2>
-                <p>Send questions via SMS to a list of those phone numbers.</p>
-            </div>
+        <form name="targetedSurvey">
+            <div ng-show="targetedSurveysEnabled" class="form-sheet">
+                <div class="form-sheet-summary">
+                    <h2 class="form-sheet-title">Create a new targeted survey</h2>
+                    <p>Send questions via SMS to a list of those phone numbers.</p>
+                </div>
 
-            <div class="stepper">
-                <div class="stepper-item" ng-class="{'active': isActiveStep(1), 'disabled': !isActiveStep(1)}">
-                    <h2 class="stepper-heading" data-accordion-trigger>
-                        <span class="stepper-badge">1</span>
-                        Name your survey
-                    </h2>
-                    <form name="stepOne">
-                        <div class="form-field" ng-show="isActiveStep(1)">
-                            <label>Survey name</label>
-                            <input type="text" name="name" ng-minlength="2" ng-model="name" required placeholder="Name...">
-                        </div>
-                        <div ng-hide="isActiveStep(1)">
-                            <h2 class=form-label>Survey Name</h2>
-                            <p>{{name}}</p>  
-                        </div>
-                                          
-                        <div class="form-field" ng-show="isActiveStep(1)">
-                            <label>Survey description</label>
-                            <textarea name="description" ng-model="description" required placeholder="Describe your survey..."></textarea>  
-                        </div>
-                        <div ng-hide="isActiveStep(1)">
-                            <h2 class=form-label>Survey Description</h2>
-                            <p>{{description}}</p>
-                        </div>
-                        <div ng-show="isActiveStep(1)">
-                            <div class="form-field">
-                                <div class="button-group">
-                                    <button class="button-alpha" ng-disabled="!isStepComplete(stepOne)" ng-click="completeStepOne()">Continue</button>
+                <div class="stepper">
+                    <ng-form name="stepOne">
+                        <div class="stepper-item" ng-class="{'active': isActiveStep(1), 'disabled': !isActiveStep(1)}">
+                            <h2 class="stepper-heading" data-accordion-trigger>
+                                <span class="stepper-badge">1</span>
+                                Name your survey
+                            </h2>
+                            <div
+                                class="form-field required"
+                                ng-class="{
+                                        'error': stepOne.name.$invalid && targetedSurvey.stepOne.name.$dirty,
+                                        'success': !targetedSurvey.stepOne.name.$invalid && targetedSurvey.stepOne.name.$dirty
+                                        }"
+                                ng-show="isActiveStep(1)"
+                            >
+                                <label for="name">Survey name</label>
+                                <input type="text" name="name"  ng-minlength="2" ng-model="name" required placeholder="Name...">
+                                <div
+                                    class="alert error"
+                                    ng-show="targetedSurvey.stepOne.name.$dirty"
+                                    ng-repeat="(error, value) in targetedSurvey.stepOne.name.$error"
+                                >
+                                    <svg class="iconic">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                    </svg>
+                                    <span translate="{{'notify.form.validation.name.' + error}}"></span>
+                                </div>
+                            </div>
+                            <div ng-hide="isActiveStep(1)">
+                                <h2 class=form-label>Survey Name</h2>
+                                    <p>{{name}}</p>
+                            </div>
+                            <div class="form-field required" ng-show="isActiveStep(1)">
+                                <label for="description">Survey description</label>
+                                <textarea name="description" ng-model="description" required placeholder="Describe your survey..."></textarea>
+                                <div
+                                    class="alert error"
+                                    ng-show="targetedSurvey.stepOne.description.$dirty"
+                                    ng-repeat="(error, value) in targetedSurvey.stepOne.description.$error"
+                                >
+                                    <svg class="iconic">
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                    </svg>
+                                    <span translate="{{'notify.form.validation.description.' + error}}"></span>
+                                </div>
+                            </div>
+                            <div ng-hide="isActiveStep(1)">
+                                <h2 class=form-label>Survey Description</h2>
+                                <p>{{description}}</p>
+                            </div>
+                            <div ng-show="isActiveStep(1)">
+                                <div class="form-field">
+                                    <div class="button-group">
+                                        <button class="button-alpha" ng-disabled="!isStepComplete(targetedSurvey.stepOne)" ng-click="completeStepOne()">Continue</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </form>    
-                </div>
+                    </ng-form>
 
-                <div class="stepper-item" ng-class="{'active': isActiveStep(2), 'disabled': !isActiveStep(2)}">
-                    <h2 class="stepper-heading">
-                            <span class="stepper-badge">2</span>
-                                Choose your audience
-                    </h2>
-                    <form name="stepTwo">
-                        <div ng-show="isActiveStep(2)">
-                            <div class="form-field">
-                                <div class="button-group">
-                                      <button class="button-alpha" ng-disabled="!isStepComplete(stepTwo)" ng-click="completeStepTwo()">Continue</button>
-                                    <button class="button" ng-click="previousStep()">Back</button>
+                    <ng-form name="stepTwo">
+                        <div class="stepper-item" ng-class="{'active': isActiveStep(2), 'disabled': !isActiveStep(2)}">
+                            <h2 class="stepper-heading">
+                                <span class="stepper-badge">2</span>
+                                    Choose your audience
+                            </h2>
+                            <div ng-show="isActiveStep(2)">
+                                <div class="form-field">
+                                    <div class="button-group">
+                                          <button class="button-alpha" ng-disabled="!isStepComplete(targetedSurvey.stepTwo)" ng-click="completeStepTwo()">Continue</button>
+                                        <button class="button" ng-click="previousStep()">Back</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </form>    
-                </div>
+                    </ng-form>
 
-                <div class="stepper-item" ng-class="{'active': isActiveStep(3), 'disabled': !isActiveStep(3)}">
-                    <h2 class="stepper-heading">
-                            <span class="stepper-badge">3</span>
-                                Add your questions
-                    </h2>
-                    <form name="stepThree">
-                        <div ng-show="isActiveStep(3)">
-                             <div class="form-field">
-                                <div class="button-group">
-                                    <button class="button-alpha" ng-disabled="!isStepComplete(stepThree)" ng-click="completeStepThree()">Continue</button>
-                                    <button class="button" ng-click="previousStep()">Back</button>
+                    <ng-form name="stepThree">
+                        <div class="stepper-item" ng-class="{'active': isActiveStep(3), 'disabled': !isActiveStep(3)}">
+                            <h2 class="stepper-heading">
+                                    <span class="stepper-badge">3</span>
+                                        Add your questions
+                            </h2>
+                                <div ng-show="isActiveStep(3)">
+                                     <div class="form-field">
+                                        <div class="button-group">
+                                            <button class="button-alpha" ng-disabled="!isStepComplete(targetedSurvey.stepThree)" ng-click="completeStepThree()">Continue</button>
+                                            <button class="button" ng-click="previousStep()">Back</button>
+                                        </div>
+                                    </div>
                                 </div>
-                            </div>
                         </div>
-                    </form>
-                </div>
-
-                <div class="stepper-item" ng-class="{'active': isActiveStep(4), 'disabled': !isActiveStep(4)}">
-                    <h2 class="stepper-heading">
-                        <span class="stepper-badge">4</span>
-                                Publish
-                    </h2>
-                    <div ng-show="isActiveStep(4)">
-                              <div class="button-group">
-                                <button class="button-alpha"  ng-disabled="!isStepComplete(4)" ng-click="publish()">Publish</button>
+                    </ng-form>
+                    <ng-form name="stepFour">
+                        <div class="stepper-item" ng-class="{'active': isActiveStep(4), 'disabled': !isActiveStep(4)}">
+                        <h2 class="stepper-heading">
+                            <span class="stepper-badge">4</span>
+                                    Publish
+                        </h2>
+                        <div ng-show="isActiveStep(4)">
+                            <div class="button-group">
+                                <button class="button-alpha"  ng-disabled="!isStepComplete(targetedSurvey.stepFour)" ng-click="publish()">Publish</button>
                                 <button class="button" ng-click="previousStep()">Back</button>
+                            </div>
                         </div>
                     </div>
+                </ng-form>
                 </div>
-
             </div>
-        </div>
+        </form>
     </div>
 </main>

--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -50,7 +50,7 @@
                                 ng-show="isActiveStep(1)"
                             >
                                 <label for="name">Survey name</label>
-                                <input type="text" name="name"  ng-minlength="2" ng-model="name" required placeholder="Name...">
+                                <input type="text" name="name"  ng-minlength="2" ng-maxlength="255" ng-model="name" required placeholder="Name...">
                                 <div
                                     class="alert error"
                                     ng-show="targetedSurvey.stepOne.name.$dirty"
@@ -127,6 +127,7 @@
                                 </div>
                         </div>
                     </ng-form>
+
                     <ng-form name="stepFour">
                         <div class="stepper-item" ng-class="{'active': isActiveStep(4), 'disabled': !isActiveStep(4)}">
                         <h2 class="stepper-heading">
@@ -141,6 +142,7 @@
                         </div>
                     </div>
                 </ng-form>
+
                 </div>
             </div>
         </form>

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -43,8 +43,14 @@ describe('setting create targeted survey controller', function () {
             expect($scope.isActiveStep(1)).toEqual(false);
         });
         it('should return false if step is not complete', function () {
-            //defaulting to true right now
-            expect($scope.isStepComplete(2)).toEqual(true);
+            let stepOne = {
+                $valid: true
+            };
+            let stepTwo = {
+                $valid: false
+            };
+            expect($scope.isStepComplete(stepOne)).toEqual(true);
+            expect($scope.isStepComplete(stepTwo)).toEqual(false);
         });
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Adds form validation to targeted survey directive
- adds form html to targeted survey template
- adds test for form validation
- show/displays different "views" of text when proceeding past step 1

Testing checklist:
- [x] Survey Name field is available and user can enter data
- [x] Survey Description field is available and user can enter data
- [x] User can not proceed is one or both of the fields are blank
- [x] User can proceed if both of the fields are filled
- [x] When moving to next step, styles for fields should condense and look neat and nice (ignore light/smokey front in design. Justin told me it's wrong. Just defer to normal <p> font.

- [X] I certify that I ran my checklist

Fixes ushahidi/platform#2527

Ping @ushahidi/platform
