### PR TITLE
Lock perms check

### DIFF
--- a/app/common/auth/authentication.service.js
+++ b/app/common/auth/authentication.service.js
@@ -53,6 +53,13 @@ function (
         loginStatus = true;
     }
 
+    function continueLogout(silent) {
+        setToLogoutState();
+        if (!silent) {
+            $rootScope.$broadcast('event:authentication:logout:succeeded');
+        }
+    }
+
     function setToLogoutState() {
         Session.clearSessionData();
         UserEndpoint.invalidateCache();
@@ -116,12 +123,13 @@ function (
             // TODO: At present releasing locks should not prevent users from logging out
             // in future this should be expanded to include an error state
             // Though ultinately unlocking should be handled solely API side
-            PostLockEndpoint.unlock().$promise.finally(function () {
-                setToLogoutState();
-                if (!silent) {
-                    $rootScope.$broadcast('event:authentication:logout:succeeded');
-                }
-            });
+            if ($rootScope.hasPermission('Manage Posts')) {
+                PostLockEndpoint.unlock().$promise.finally(function () {
+                    continueLogout(silent);
+                });
+            } else {
+                continueLogout(silent);
+            }
         },
 
         getLoginStatus: function () {

--- a/app/main/posts/views/share/share-menu.html
+++ b/app/main/posts/views/share/share-menu.html
@@ -31,7 +31,7 @@
                 <div class="listing-item-image">
                     <img class="icon" src="/img/twitter.png" alt="">
                 </div>
-                <h2 class="listing-item-title"><a ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
+                <h2 class="listing-item-title"><a target="_blank" ng-href="https://twitter.com/home?status={{shareUrlEncoded}}">Twitter</a></h2>
             </div>
         </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Changes log out auth function to check user permissions before attempting to unlock posts

Testing checklist:
- [ ] Signup new users
- [ ] Login
- [ ] Open Console
- [ ] Logout
- [ ] You should not see errors related to locks in the console
- [ ] You should not be directed to the Access Denied view

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2585

Ping @ushahidi/platform
