### PR TITLE
Fixing lock perms log out issue

### DIFF
--- a/app/common/auth/authentication.service.js
+++ b/app/common/auth/authentication.service.js
@@ -53,6 +53,13 @@ function (
         loginStatus = true;
     }
 
+    function continueLogout(silent) {
+        setToLogoutState();
+        if (!silent) {
+            $rootScope.$broadcast('event:authentication:logout:succeeded');
+        }
+    }
+
     function setToLogoutState() {
         Session.clearSessionData();
         UserEndpoint.invalidateCache();
@@ -116,12 +123,13 @@ function (
             // TODO: At present releasing locks should not prevent users from logging out
             // in future this should be expanded to include an error state
             // Though ultinately unlocking should be handled solely API side
-            PostLockEndpoint.unlock().$promise.finally(function () {
-                setToLogoutState();
-                if (!silent) {
-                    $rootScope.$broadcast('event:authentication:logout:succeeded');
-                }
-            });
+            if ($rootScope.hasPermission('Manage Posts')) {
+                PostLockEndpoint.unlock().$promise.finally(function () {
+                    continueLogout(silent);
+                });
+            } else {
+                continueLogout(silent);
+            }
         },
 
         getLoginStatus: function () {

--- a/test/unit/common/auth/authentication.service.spec.js
+++ b/test/unit/common/auth/authentication.service.spec.js
@@ -248,6 +248,7 @@ describe('Authentication', function () {
                 accessToken: 'fooBarAccessToken',
                 grantType: 'password'
             };
+            $rootScope.hasPermission = function () {};
 
             spyOn($rootScope, '$broadcast').and.callThrough();
 


### PR DESCRIPTION
This pull request makes the following changes:
- Changes log out auth function to check user permissions before attempting to unlock posts

Testing checklist:
- [x] Signup new users
- [x] Login
- [x] Open Console
- [x] Logout
- [x] You should not see errors related to locks in the console
- [x] You should not be directed to the Access Denied view

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2585

Ping @ushahidi/platform
