### PR TITLE
BUGFIX(data-export.service.js, data-export.controller.js): export history list is updated when user requests a new job, expiration date is empty when still pending

### DIFF
--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -73,7 +73,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
     function updateExportJobsList(job) {
         var _exportJobs = getExportJobs();
         const foundJob = _.findWhere(_exportJobs, { id: job.id });
-        console.log(DataExport.exportJobs, _exportJobs);
+        
         if (foundJob) {
             setExportJobs(_.extend(foundJob, job));
         } else {

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -73,7 +73,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
     function updateExportJobsList(job) {
         var _exportJobs = getExportJobs();
         const foundJob = _.findWhere(_exportJobs, { id: job.id });
-        
+
         if (foundJob) {
             setExportJobs(_.extend(foundJob, job));
         } else {

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -138,7 +138,6 @@ function (
     }
 
     $scope.$on('exportJobs:updated', (event, data, newData) => {
-        DataExport.setExportJobs(DataExport.processExportJobs(data));
         $scope.exportJobs = DataExport.getExportJobs();
     });
 

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -81,24 +81,6 @@ function (
         angular.element(document.getElementById(tab_li)).addClass('active');
     }
 
-    function loadExportJobs() {
-        $scope.exportJobs = [];
-
-        DataExport.loadExportJobs().then(function (response) {
-            let jobs = _.filter(_.map(response, (job) => {
-                if (job.status) {
-                    job.url_expiration = new Date(job.url_expiration * 1000).toLocaleString();
-                    job.created = new Date(job.created).toLocaleString();
-                    job.status = job.status.toLowerCase();
-                    return job;
-                }
-            }));
-            jobs = _.sortBy(jobs, (job) => {
-                return job.created;
-            }).reverse();
-            $scope.exportJobs = jobs;
-        });
-    }
 
     function attachAttributes() {
         // requesting attributes and attaches them to the correct form
@@ -145,9 +127,22 @@ function (
             DataExport.startExport({attributes: attributes});
             $scope.showFields = false;
             $scope.showProgress = true;
-
         }
     }
+
+    function loadExportJobs() {
+        DataExport.loadExportJobs().then(function (response) {
+            DataExport.setExportJobs(DataExport.processExportJobs(response));
+            $scope.exportJobs = DataExport.getExportJobs();
+        });
+    }
+
+    $scope.$on('exportJobs:updated', (event, data, newData) => {
+        DataExport.setExportJobs(DataExport.processExportJobs(data));
+        $scope.exportJobs = DataExport.getExportJobs();
+    });
+
+
     // start fetching forms to display
     getForms();
 }];


### PR DESCRIPTION

This pull request makes the following changes:
- Export history list is updated when user requests a new job or when a job status changes
- Expiration date is empty when job status is pending

Testing checklist:
- [x] https://github.com/ushahidi/platform/issues/2582 (edited the script and added a new one for updates)

- [x] I certify that I ran my checklist (this depends on https://github.com/ushahidi/platform/pull/2598)

Fixes ushahidi/platform# .

Ping @ushahidi/platform
