### PR TITLE
build: Add --dev flag to transifex-download to output locales to app/

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -187,9 +187,11 @@ gulp.task('jscsfix:test', () => {
  * Task `release` - Build release
  */
 gulp.task('transifex-download', function (done) {
+    let destination = gutil.en.dev ? path.join(__dirname, root) : paths.dest;
+
     // Make sure we have dest dir
     try {
-        fs.mkdirSync(paths.dest);
+        fs.mkdirSync(destination);
     }
     catch (err) {
         if (err.code !== 'EEXIST') {
@@ -197,7 +199,7 @@ gulp.task('transifex-download', function (done) {
         }
     }
 
-    require('./gulp/transifex-download')(paths.dest + '/locales/', done);
+    require('./gulp/transifex-download')(destination + '/locales/', done);
 });
 
 


### PR DESCRIPTION
This pull request makes the following changes:
- Add --dev flag to transifex-download to output locales to app/

Testing checklist:
- [ ] Run `gulp transifex-download` and check locales are saved into server/www/locales
- [ ] Run `gulp transifex-download --dev` and check locales are saved into app/locales

- [x] I certify that I ran my checklist

Ping @ushahidi/platform
