### PR TITLE
Ordering of fields on Post edit respects Survey order

### DIFF
--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -80,8 +80,6 @@ function PostDataEditorController(
     $scope.deletePost = deletePost;
     $scope.canSavePost = canSavePost;
     $scope.savePost = savePost;
-    $scope.postTitleLabel = 'Title';
-    $scope.postDescriptionLabel = 'Description';
     $scope.tagKeys = [];
     $scope.save = $translate.instant('app.save');
     $scope.saving = $translate.instant('app.saving');
@@ -234,29 +232,13 @@ function PostDataEditorController(
 
             var post = $scope.post;
             var tasks = _.sortBy(results[0], 'priority');
-            var attrs = _.chain(results[1])
+            var attributes = _.chain(results[1])
                 .sortBy('priority')
                 .value();
             var categories = results[2];
 
             // Set Post Lock
             $scope.post.lock = results[3];
-
-            var attributes = [];
-            _.each(attrs, function (attr) {
-                if (attr.type === 'title' || attr.type === 'description') {
-                    if (attr.type === 'title') {
-                        $scope.postTitleLabel = attr.label;
-                        $scope.postTitleInstructions = attr.instructions;
-                    }
-                    if (attr.type === 'description') {
-                        $scope.postDescriptionLabel = attr.label;
-                        $scope.postDescriptionInstructions = attr.instructions;
-                    }
-                } else {
-                    attributes.push(attr);
-                }
-            });
 
             // Initialize values on post (helps avoid madness in the template)
             attributes.map(function (attr) {

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -1,51 +1,7 @@
 <form name="editForm" novalidate>
   <div class="form-sheet" role="article">
     <div class="post-band" ng-style="{backgroundColor: form.color}"></div>
-        <div
-          class="form-field init required"
-          adaptive-form
-          ng-class="{'error': editForm.title.$invalid && editForm.title.$dirty, 'success': !editForm.title.$invalid && editForm.title.$dirty}"
-        >
-          <label>{{postTitleLabel}}</label>
-          <p>{{postTitleInstructions}}</p>
-          <input
-            id="title"
-            name="title"
-            type="text"
-            ng-model="post.title"
-            ng-required="true"
-            ng-minlength=2
-            ng-maxlength=150
-            adaptive-input
-          >
-          <div
-            class="alert error"
-            ng-show="editForm.title.$dirty"
-            ng-repeat="(error, value) in editForm.title.$error"
-          >
-            <svg class="iconic">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-            </svg>
-            <span translate="{{'post.valid.title.' + error}}"></span>
-          </div>
-        </div>
-        <!-- Post stage default fields -->
-        <div
-          class="form-field init required"
-          ng-class="{'error': editForm.content.$invalid && editForm.content.$dirty, 'success': !editForm.content.$invalid && editForm.content.$dirty}"
-          adaptive-form
-        >
-          <label>{{postDescriptionLabel}}</label>
-          <p>{{postDescriptionInstructions}}</p>
-          <textarea id="content" name="content" data-min-rows="1" rows="1" ng-model="post.content" ng-required="true" adaptive-input msd-elastic></textarea>
-
-          <div class="alert error" ng-show="editForm.content.$dirty" ng-repeat="(error, value) in editForm.content.$error">
-            <svg class="iconic">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-            </svg>
-            <span translate="{{'post.valid.content.' + error}}"></span>
-          </div>
-        </div>
+        
         <!-- End post stage default fields -->
           <div
             ng-if="!form"

--- a/app/main/posts/modify/post-edit.service.js
+++ b/app/main/posts/modify/post-edit.service.js
@@ -56,22 +56,24 @@ function (
                 var required_attributes = _.where(task.attributes, {required: true});
 
                 _.each(required_attributes, function (attribute) {
-                    if (attribute.input === 'checkbox') {
-                        var checkboxValidity = false;
-                        _.each(attribute.options, function (option) {
-                            if (!_.isUndefined(form['values_' + attribute.id + '_' + option]) && !form['values_' + attribute.id + '_' + option].$invalid) {
-                                checkboxValidity = isPostValid;
-                            }
-                        });
-                        isPostValid = checkboxValidity;
-                    } else {
+                    if (attribute.type !== 'title' && attribute.type !== 'description') {
+                        if (attribute.input === 'checkbox') {
+                            var checkboxValidity = false;
+                            _.each(attribute.options, function (option) {
+                                if (!_.isUndefined(form['values_' + attribute.id + '_' + option]) && !form['values_' + attribute.id + '_' + option].$invalid) {
+                                    checkboxValidity = isPostValid;
+                                }
+                            });
+                            isPostValid = checkboxValidity;
+                        } else {
 
-                        if (_.isUndefined(form['values_' + attribute.id]) || form['values_' + attribute.id].$invalid) {
-                            if (!_.isUndefined(form['values_' + attribute.id])) {
-                                form['values_' + attribute.id].$dirty = true;
-                            }
+                            if (_.isUndefined(form['values_' + attribute.id]) || form['values_' + attribute.id].$invalid) {
+                                if (!_.isUndefined(form['values_' + attribute.id])) {
+                                    form['values_' + attribute.id].$dirty = true;
+                                }
 
-                            isPostValid = false;
+                                isPostValid = false;
+                            }
                         }
                     }
                 });

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -79,8 +79,6 @@ function PostEditorController(
     $scope.canSavePost = canSavePost;
     $scope.savePost = savePost;
     $scope.cancel = cancel;
-    $scope.postTitleLabel = 'Title';
-    $scope.postDescriptionLabel = 'Description';
     $scope.tagKeys = [];
     $scope.save = $translate.instant('app.save');
     $scope.saving = $translate.instant('app.saving');
@@ -138,25 +136,10 @@ function PostEditorController(
 
             var post = $scope.post;
             var tasks = _.sortBy(results[0], 'priority');
-            var attrs = _.chain(results[1])
+            var attributes = _.chain(results[1])
                 .sortBy('priority')
                 .value();
             var categories = results[2];
-            var attributes = [];
-            _.each(attrs, function (attr) {
-                if (attr.type === 'title' || attr.type === 'description') {
-                    if (attr.type === 'title') {
-                        $scope.postTitleLabel = attr.label;
-                        $scope.postTitleInstructions = attr.instructions;
-                    }
-                    if (attr.type === 'description') {
-                        $scope.postDescriptionLabel = attr.label;
-                        $scope.postDescriptionInstructions = attr.instructions;
-                    }
-                } else {
-                    attributes.push(attr);
-                }
-            });
 
             // Initialize values on post (helps avoid madness in the template)
             attributes.map(function (attr) {

--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -52,62 +52,8 @@
 
           <div class="form-sheet">
               <div class="post-band" ng-style="{backgroundColor: form.color}"></div>
-              <div class="form-field init required"
-              adaptive-form
-              ng-class="{
-                'error': postForm.title.$invalid && postForm.title.$dirty,
-                'success': !postForm.title.$invalid && postForm.title.$dirty
-              }">
-                  <label>
-                      {{postTitleLabel}}
-                  </label>
-                  <p>
-                      {{postTitleInstructions}}
-                  </p>
-                  <input id="title"
-                      name="title" type="text" ng-model="post.title" ng-required="true" ng-minlength=2 ng-maxlength=150 adaptive-input>
-
-                  <div
-                      class="alert error"
-                      ng-show="postForm.title.$dirty"
-                      ng-repeat="(error, value) in postForm.title.$error"
-                      >
-                      <svg class="iconic">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-                      </svg>
-                      <span translate="{{'post.valid.title.' + error}}"></span>
-                  </div>
-              </div>
-
-              <!-- Post stage default fields -->
-              <div class="form-field init required"
-                  ng-class="{
-                    'error': postForm.content.$invalid && postForm.content.$dirty,
-                    'success': !postForm.content.$invalid && postForm.content.$dirty
-                  }"
-                  adaptive-form>
-                  <label>
-                      {{postDescriptionLabel}}
-                  </label>
-                  <p>
-                      {{postDescriptionInstructions}}
-                  </p>
-                    <textarea id="content" name="content" data-min-rows="1" rows="1"
-                      ng-model="post.content" ng-required="true" adaptive-input msd-elastic>
-                    </textarea>
-
-                  <div class="alert error" ng-show="postForm.content.$dirty" ng-repeat="(error, value) in postForm.content.$error">
-                      <svg class="iconic">
-                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-                      </svg>
-                      <span translate="{{'post.valid.content.' + error}}"></span>
-                  </div>
-              </div>
-
-              <!-- End post stage default fields -->
-
+              
               <!-- Start Post custom fields -->
-
               <post-value-edit
                   ng-repeat="attribute in tasks[0].attributes | orderBy: 'priority' as filtered_result track by attribute.id"
                   post="post"

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -1,229 +1,286 @@
 <div>
-<!-- Container for form-field structured elements -->
-  <div
-      ng-if="!isFieldSetStructure(attribute)"
-      class="form-field init"
-      adaptive-form
-      ng-class="{
-        'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
-        'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
-        'required': attribute.required,
-        'date' : isDate(attribute) || isDateTime(attribute),
-        'location' : attribute.input === 'location'
-      }">
+    <!-- Container for form-field structured elements -->
+    <div ng-if="attribute.type === 'description' || attribute.type === 'title'">
+        <!-- Split between Title Desc and other values -->
+        <div 
+            ng-if="attribute.type==='title'"
+            class="form-field init required"
+            adaptive-form
+            ng-class="{
+                'error': form.title.$invalid && form.title.$dirty,
+                'success': !form.title.$invalid && form.title.$dirty
+            }"
+        >
+             <label>
+                {{attribute.label}}
+            </label>
+            <p>
+                {{attribute.instructions}}
+            </p>
+            <input id="title"
+                name="title" type="text" ng-model="post.title" ng-required="true" ng-minlength=2 ng-maxlength=150 adaptive-input>
 
-      <!-- Attribute Label -->
-      <label for="values[{{attribute.key}}][0]">
-          <svg ng-show="attribute.response_private" class="iconic">
-            <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
-          </svg>
-          {{attribute.label}}
-      </label>
-      <!-- Attribute Instructions -->
-      <p>{{attribute.instructions}}</p>
+            <div
+                class="alert error"
+                ng-show="form.title.$dirty"
+                ng-repeat="(error, value) in form.title.$error"
+            >
+                <svg class="iconic">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                </svg>
+                <span translate="{{'post.valid.title.' + error}}"></span>
+            </div>
+        </div>
 
-      <!-- attributes which use the form-field structure -->
-      <div ng-repeat="(key, value) in post.values[attribute.key] track by key">
-          <div ng-switch="attribute.input">
-              <!-- Standard fields -->
-              <!-- type: date -->
-              <div ng-switch-when="date" >
-                  <!-- Date icon -->
-                  <div class="input-with-icon">
-                    <svg class="iconic">
-                      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
-                    </svg>
-                    <input
-                        type="date"
-                        pick-a-date="date"
-                        pick-a-date-options="dateFormat"
+        <!-- Post stage default fields -->
+        <div
+            ng-if="attribute.type==='description'"
+            class="form-field init required"
+            ng-class="{
+                'error': form.content.$invalid && form.content.$dirty,
+                'success': !form.content.$invalid && form.content.$dirty
+            }"
+            adaptive-form
+        >
+            <label>
+                {{attribute.label}}
+            </label>
+            <p>
+                {{attribute.instructions}}
+            </p>
+            <textarea id="content" name="content" data-min-rows="1" rows="1"
+                ng-model="post.content" ng-required="true" adaptive-input msd-elastic>
+            </textarea>
 
+            <div class="alert error" ng-show="form.content.$dirty" ng-repeat="(error, value) in form.content.$error">
+                <svg class="iconic">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                </svg>
+                <span translate="{{'post.valid.content.' + error}}"></span>
+            </div>
+        </div>
+    </div>
+    <div ng-if="attribute.type !== 'description' && attribute.type !== 'title'">
+        <div
+            ng-if="!isFieldSetStructure(attribute)"
+            class="form-field init"
+            adaptive-form
+            ng-class="{
+                'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+                'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+                'required': attribute.required,
+                'date' : isDate(attribute) || isDateTime(attribute),
+                'location' : attribute.input === 'location'
+            }"
+        >
+            <!-- Attribute Label -->
+            <label for="values[{{attribute.key}}][0]">
+                <svg ng-show="attribute.response_private" class="iconic">
+                    <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
+                </svg>
+                {{attribute.label}}
+            </label>
+            <!-- Attribute Instructions -->
+            <p>{{attribute.instructions}}</p>
+            <!-- attributes which use the form-field structure -->
+            <div ng-repeat="(key, value) in post.values[attribute.key] track by key">
+                <div ng-switch="attribute.input">
+                    <!-- Standard fields -->
+                    <!-- type: date -->
+                    <div ng-switch-when="date" >
+                        <!-- Date icon -->
+                        <div class="input-with-icon">
+                            <svg class="iconic">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
+                            </svg>
+                            <input
+                                type="date"
+                                pick-a-date="date"
+                                pick-a-date-options="dateFormat"
+
+                                name="values_{{attribute.id}}"
+                                ng-model="post.values[attribute.key][key]"
+                                ng-required="attribute.required"
+                            />
+                        </div>
+                    </div>
+                    <!-- type: datetime -->
+                    <div ng-switch-when="datetime" class="input-with-icon">
+                        <post-datetime
+                            id="values[{{attribute.key}}][{{key}}]"
+                            name="values_{{attribute.id}}"
+                            ng-model="post.values[attribute.key][key]"
+                            ng-required="attribute.required"
+                        ></post-datetime>
+                    </div>
+                    <!-- type: select -->
+                    <select
+                        ng-switch-when="select"
+                        id="values[{{attribute.key}}][{{key}}]"
                         name="values_{{attribute.id}}"
                         ng-model="post.values[attribute.key][key]"
                         ng-required="attribute.required"
-                    />
-                  </div>
-              </div>
-              <!-- type: datetime -->
-              <div ng-switch-when="datetime" class="input-with-icon">
-                  <post-datetime
-                      id="values[{{attribute.key}}][{{key}}]"
-                      name="values_{{attribute.id}}"
-                      ng-model="post.values[attribute.key][key]"
-                      ng-required="attribute.required"
-                  ></post-datetime>
-              </div>
-             <!-- type: select -->
-              <select
-                  ng-switch-when="select"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                >
-                  <option ng-repeat="opt in attribute.options" value="{{opt}}">{{opt}}</option>
-              </select>
-              <!-- type: number -->
-              <input
-                  ng-switch-when="number"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  type="number"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  >
-              <!-- type: text -->
-              <input
-                  ng-switch-when="text"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  type="text"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  adaptive-input
-                  >
-              <!-- type: textarea -->
-              <textarea
-                  ng-switch-when="textarea"
-                  data-min-rows="1"
-                  rows="1"
-                  class="adapt-field"
-                  style="overflow-x: hidden; word-wrap: break-word; height: 55px;"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  adaptive-input
-                  msd-elastic>
-              </textarea>
+                        >
+                        <option ng-repeat="opt in attribute.options" value="{{opt}}">{{opt}}</option>
+                    </select>
+                    <!-- type: number -->
+                    <input
+                        ng-switch-when="number"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        type="number"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        >
+                    <!-- type: text -->
+                    <input
+                        ng-switch-when="text"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        type="text"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        adaptive-input
+                        >
+                    <!-- type: textarea -->
+                    <textarea
+                        ng-switch-when="textarea"
+                        data-min-rows="1"
+                        rows="1"
+                        class="adapt-field"
+                        style="overflow-x: hidden; word-wrap: break-word; height: 55px;"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        adaptive-input
+                        msd-elastic>
+                    </textarea>
 
-              <!-- Non standard fields -->
-              <!-- type: textarea -->
-              <textarea
-                  ng-switch-when="markdown"
-                  data-min-rows="1"
-                  rows="1"
-                  class="adapt-field"
-                  style="overflow-x: hidden; word-wrap: break-word; height: 55px;"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  adaptive-input
-                  msd-elastic>
-              </textarea>
-              <!-- type: relation -->
-              <post-relation
-                  attribute="attribute"
-                  key="key"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  ng-switch-when="relation"></post-relation>
-              <!-- type: location -->
-              <post-location
-                  attribute="attribute"
-                  key="key"
-                  id="values[{{attribute.key}}][{{key}}]"
-                  name="values_{{attribute.id}}"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-                  ng-switch-when="location"></post-location>
-              <!-- type: upload -->
-              <post-media
-                  ng-switch-when="upload"
-                  name="values_{{attribute.id}}"
-                  media-has-caption="attribute.config.hasCaption"
-                  media="medias[attribute.key]"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-              ></post-media>
-              <!-- type: upload -->
-              <post-video-input
-                  ng-switch-when="video"
-                  name="values_{{attribute.id}}"
-                  video-url="post.values[attribute.key][key]"
-                  ng-model="post.values[attribute.key][key]"
-                  ng-required="attribute.required"
-              ></post-video-input>
-          </div>
-      </div>
-      <div class="alert error" ng-show="form['values_' + attribute.id].$dirty && taskIsMarkedCompleted()" ng-repeat="(error, value) in form['values_' + attribute.id].$error">
-          <svg class="iconic">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-          </svg>
-          <span translate="{{'post.valid.values.' + error}}" translate-values="{ label : attribute.label }"></span>
-      </div>
-  </div>
-
-
-  <!-- Container for fieldset structured elements -->
-  <fieldset ng-if="isFieldSetStructure(attribute)">
-
-    <!-- Attribute Label -->
-    <label ng-class="{
-        'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
-        'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
-        'required': attribute.required
-      }">{{attribute.label}}</label>
-    <!-- Attribute Instructions -->
-    <p>{{attribute.instructions}}</p>
-
-    <!-- attributes which use the form-field structure -->
-    <div ng-switch="attribute.input">
-      <!-- type: radio -->
-      <div ng-switch-when="radio">
-        <div ng-repeat="(key, value) in post.values[attribute.key] track by key">
-          <div class="form-field radio" ng-repeat="option in attribute.options">
-            <label>
-                <input
-                    name="values_{{attribute.id}}"
-                    type="radio"
-                    ng-model="post.values[attribute.key][key]"
-                    ng-required="attribute.required"
-                    value="{{option}}"
-                  >
-                  {{option}}
-            </label>
-          </div>
+                    <!-- Non standard fields -->
+                    <!-- type: textarea -->
+                    <textarea
+                        ng-switch-when="markdown"
+                        data-min-rows="1"
+                        rows="1"
+                        class="adapt-field"
+                        style="overflow-x: hidden; word-wrap: break-word; height: 55px;"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        adaptive-input
+                        msd-elastic>
+                    </textarea>
+                    <!-- type: relation -->
+                    <post-relation
+                        attribute="attribute"
+                        key="key"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        ng-switch-when="relation"></post-relation>
+                    <!-- type: location -->
+                    <post-location
+                        attribute="attribute"
+                        key="key"
+                        id="values[{{attribute.key}}][{{key}}]"
+                        name="values_{{attribute.id}}"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                        ng-switch-when="location"></post-location>
+                    <!-- type: upload -->
+                    <post-media
+                        ng-switch-when="upload"
+                        name="values_{{attribute.id}}"
+                        media-has-caption="attribute.config.hasCaption"
+                        media="medias[attribute.key]"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                    ></post-media>
+                    <!-- type: upload -->
+                    <post-video-input
+                        ng-switch-when="video"
+                        name="values_{{attribute.id}}"
+                        video-url="post.values[attribute.key][key]"
+                        ng-model="post.values[attribute.key][key]"
+                        ng-required="attribute.required"
+                    ></post-video-input>
+                </div>
+            </div>
+            <div class="alert error" ng-show="form['values_' + attribute.id].$dirty && taskIsMarkedCompleted()" ng-repeat="(error, value) in form['values_' + attribute.id].$error">
+                <svg class="iconic">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                </svg>
+                <span translate="{{'post.valid.values.' + error}}" translate-values="{ label : attribute.label }"></span>
+            </div>
         </div>
-      </div>
-      <!-- type: checkbox -->
-      <div ng-switch-when="checkbox">
-        <div class="form-field checkbox" ng-repeat="option in attribute.options">
-          <label>
-            <input
-                type="checkbox"
-                checklist-model="post.values[attribute.key]"
-                ng-required="attribute.required"
-                name="values_{{attribute.id}}_{{option}}"
-                checklist-value="option"
-                value="option"
-              >
-                {{option}}
-          </label>
-        </div>
-      </div>
-    <!-- type: categories -->
-    <div ng-switch-when="tags">
-        <category-selector
-            available="attribute.options"
-            selected="post.values[attribute.key]",
-            form="form"
-        ></category-selector>
-        <add-category
-            form-id="post.form.id"
-            attribute="attribute"
-            post-value="post.values[attribute.key]"
-        ></add-category>
-    </div>
-    <div class="alert error" ng-show="form['values_' + attribute.id].$dirty && taskIsMarkedCompleted()" ng-repeat="(error, value) in form['values_' + attribute.id].$error">
-        <svg class="iconic">
-          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-        </svg>
-        <span translate="{{'post.valid.values.' + error}}" translate-values="{ label : attribute.label }"></span>
-    </div>
-  </fieldset>
+        <!-- Container for fieldset structured elements -->
+        <fieldset ng-if="isFieldSetStructure(attribute)">
+            <!-- Attribute Label -->
+            <label ng-class="{
+                'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+                'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
+                'required': attribute.required
+            }">{{attribute.label}}</label>
+            <!-- Attribute Instructions -->
+            <p>{{attribute.instructions}}</p>
 
+            <!-- attributes which use the form-field structure -->
+            <div ng-switch="attribute.input">
+                <!-- type: radio -->
+                <div ng-switch-when="radio">
+                    <div ng-repeat="(key, value) in post.values[attribute.key] track by key">
+                    <div class="form-field radio" ng-repeat="option in attribute.options">
+                        <label>
+                            <input
+                                name="values_{{attribute.id}}"
+                                type="radio"
+                                ng-model="post.values[attribute.key][key]"
+                                ng-required="attribute.required"
+                                value="{{option}}"
+                            >
+                            {{option}}
+                        </label>
+                    </div>
+                    </div>
+                </div>
+                <!-- type: checkbox -->
+                <div ng-switch-when="checkbox">
+                    <div class="form-field checkbox" ng-repeat="option in attribute.options">
+                    <label>
+                        <input
+                            type="checkbox"
+                            checklist-model="post.values[attribute.key]"
+                            ng-required="attribute.required"
+                            name="values_{{attribute.id}}_{{option}}"
+                            checklist-value="option"
+                            value="option"
+                        >
+                            {{option}}
+                    </label>
+                    </div>
+                </div>
+                <!-- type: categories -->
+                <div ng-switch-when="tags">
+                    <category-selector
+                        available="attribute.options"
+                        selected="post.values[attribute.key]",
+                        form="form"
+                    ></category-selector>
+                    <add-category
+                        form-id="post.form.id"
+                        attribute="attribute"
+                        post-value="post.values[attribute.key]"
+                    ></add-category>
+                </div>
+                <div class="alert error" ng-show="form['values_' + attribute.id].$dirty && taskIsMarkedCompleted()" ng-repeat="(error, value) in form['values_' + attribute.id].$error">
+                    <svg class="iconic">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                    </svg>
+                    <span translate="{{'post.valid.values.' + error}}" translate-values="{ label : attribute.label }"></span>
+                </div>
+        </fieldset>
+    </div>
 </div>

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -281,6 +281,7 @@
                     </svg>
                     <span translate="{{'post.valid.values.' + error}}" translate-values="{ label : attribute.label }"></span>
                 </div>
+            </div>
         </fieldset>
     </div>
 </div>

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -85,8 +85,6 @@ function SurveyEditorController(
     $scope.getInterimId = getInterimId;
     $scope.removeInterimIds = removeInterimIds;
 
-    $scope.allowedToggleOrder = allowedToggleOrder;
-
     $scope.switchTab = switchTab;
 
     $scope.loadRoleData = loadRoleData;
@@ -192,10 +190,6 @@ function SurveyEditorController(
         var tab_li = tab + '-li';
         angular.element(document.getElementById(tab)).addClass('active');
         angular.element(document.getElementById(tab_li)).addClass('active');
-    }
-
-    function allowedToggleOrder(attribute) {
-        return attribute.type !== 'title' && attribute.type !== 'description';
     }
 
     function getInterimId() {

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -74,7 +74,7 @@
             <h3 class="listing-heading hidden" translate="survey.post_fields">Fields</h3>
 
             <div class="listing-item" ng-repeat="attribute in survey.tasks[0].attributes track by $index">
-              <div class="listing-item-select" ng-show="allowedToggleOrder(attribute)">
+              <div class="listing-item-select">
                   <div class="buttons-updown">
                      <button type="button" class="button-beta" ng-disabled="isFirstAttribute(survey.tasks[0], attribute)" ng-click="moveAttributeUp(survey.tasks[0], attribute)">
                          <svg class="iconic">


### PR DESCRIPTION
This pull request makes the following changes:
- Allows Title and Description fields to be reordered by adding toggles to those fields
- Ensure Post Edit views(Data and Classic) respect the ordering of the fields

Testing checklist:
- [x] Create a new Survey
- [x] The Title and Description fields should have re-order toggle buttons
- [x] When clicked the toggle buttons should behave as expected
- [x] Save the Survey
- [x] From the Survey List view, click on the newly created Survey
- [x] The order of the Title and Description is correct as previously saved
- [x] Add a new field to the Survey
- [x] Reorder the new field relative to Title and Description
- [x] Save the Survey
- [x] From either the Map or Data view create a new Post from the Survey that was created in the previous steps
- [x] Create a new Post
- [x] The order of the fields - including Title and Description - should be the same as shown in the Survey Editor
- [x] Save the Post
- [x] On the Post detail page click edit
- [x] The order of the fields - including Title and Description - should be the same as shown in the Survey Editor
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
