### PR TITLE
Adding anonymous label when author info hidden/unavailable

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -4,6 +4,7 @@
         "support" : "Ushahidi Support",
         "by" : "by",
         "submit" : "Submit",
+        "anonymous" : "Anonymous",
         "submitting": "Submitting",
         "submit_another" : "Submit & Add Another",
         "submit_response": "Submit a survey response",

--- a/app/main/posts/common/post-metadata.html
+++ b/app/main/posts/common/post-metadata.html
@@ -21,6 +21,7 @@
         <strong class="label" ng-show="post.user && !post.author_realname">{{ post.user.realname }}</strong>
         <strong class="label" ng-show="post.contact && !post.author_realname">{{ post.contact.contact}}</strong>
         <strong class="label" ng-show="post.author_realname">{{ post.author_realname}}</strong>
+        <strong class="label" ng-show="!post.author_realname && !post.contact && !post.user" translate="app.anonymous">Anonymous</strong>
 
     </li>
     <li class="tooltip">


### PR DESCRIPTION
This pull request makes the following changes:
- Adding an Anonymous label instead of blank when Author info unavilable.

Testing checklist:
- [ ] As an admin
  - [ ] Create a new Survey, with a location field
  - [ ] Under configure enable Hide Author Info
  - [ ] Add a Post to this survey, set the location field
  - [ ] Publish the Post
- [ ] Logout
- [ ] Load Data view ensure you do not see the Author Info but instead see Anonymous
- [ ] Load Map  view ensure you do not see the Author Info but instead see Anonymous

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
