### PR TITLE
2523 add feature0flag

### DIFF
--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -111,9 +111,7 @@ function SurveyEditorController(
 
         Features.loadFeatures()
         .then(() => {
-            // WARNING: Add Feature Flag
-            $scope.targetedSurveysEnabled = true;
-            //Features.isFeatureEnabled('targeted-surveys');
+            $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
         });
 
         if ($scope.surveyId) {

--- a/app/settings/surveys/surveys.controller.js
+++ b/app/settings/surveys/surveys.controller.js
@@ -38,9 +38,7 @@ function (
 
     Features.loadFeatures()
     .then(function () {
-        // WARNING: Add Feature Flag
-        $scope.targetedSurveysEnabled = true;
-        //Features.isFeatureEnabled('targeted-surveys');
+        $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
     });
 
     // Get all the forms for display

--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -77,9 +77,7 @@ function (
     $scope.countriesList = [];
     Features.loadFeatures()
            .then(() => {
-            // WARNING: Add Feature Flag
-            $scope.targetedSurveysEnabled = true;
-            // $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
+            $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
 
             // reroute if feature-flag is not turned on
             if (!$scope.targetedSurveysEnabled) {

--- a/test/unit/mock/services/features.js
+++ b/test/unit/mock/services/features.js
@@ -25,6 +25,9 @@ module.exports = [function () {
                         'private': {
                             enabled: true
                         },
+                        'targeted-surveys': {
+                            enabled: true
+                        },
                         roles: {
                             enabled: true
                         },
@@ -66,6 +69,9 @@ module.exports = [function () {
                 enabled: true
             },
             roles: {
+                enabled: true
+            },
+            'targeted-surveys': {
                 enabled: true
             },
             views: {

--- a/test/unit/settings/surveys/settings-survey-editor.directive.spec.js
+++ b/test/unit/settings/surveys/settings-survey-editor.directive.spec.js
@@ -64,6 +64,9 @@ describe('setting survey editor directive', function () {
             },
             getLimit : function () {
                 return this.limit;
+            },
+            isFeatureEnabled: function (feature) {
+                return;
             }
         };
     }));

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -1,7 +1,6 @@
 describe('setting create targeted survey controller', function () {
 
     var $scope,
-        Features,
         $controller,
         ModalService,
         CountryCodeEndpoint;
@@ -30,9 +29,8 @@ describe('setting create targeted survey controller', function () {
         angular.mock.module('testApp');
     });
 
-    beforeEach(angular.mock.inject(function (_$rootScope_, _$controller_, _Features_, _ModalService_, Sortable, _CountryCodeEndpoint_) {
+    beforeEach(angular.mock.inject(function (_$rootScope_, _$controller_, _ModalService_, Sortable, _CountryCodeEndpoint_) {
         $scope = _$rootScope_.$new();
-        Features = _Features_;
         ModalService = _ModalService_;
         $controller = _$controller_;
         CountryCodeEndpoint = _CountryCodeEndpoint_;


### PR DESCRIPTION
This pull request makes the following changes:
- Enabling feature flag functionality for targeted-survey

Testing checklist:
- [x] When combined with related API PR, the following views should not show by default the targeted survey
  - [x] Survey editor, you should not see link on the mode context bar to the targeted survey creation wizard
  - [x] Survey List view, you should not see the text "Create an open or targeted survey to gather information about Ushahidi."
- [x]  When the feature flag is set to true on the API
  - [x] Survey editor, you should see link on the mode context bar to the targeted survey creation wizard
  - [x] Survey List view, you should see the text "Create an open or targeted survey to gather information about Ushahidi."

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2523

Relates to [2634](https://github.com/ushahidi/platform/pull/2634)

Ping @ushahidi/platform
