### PR TITLE
fix: Populate manual lat / lon entry with current location

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1226,7 +1226,9 @@
         "click_map": "<em>You can search or click the area of map where you want to place the marker.</em>",
         "placeholder":"Search for addresses, place names, or coordinates...",
         "search_results": "Search results",
-        "error":"Sorry we could not find a location matching your search"
+        "error":"Sorry we could not find a location matching your search",
+        "update_map":"Update map",
+        "no_matching_locations":"No matching locations"
     },
     "notification": {
         "title": "Notifications",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1227,6 +1227,7 @@
         "placeholder":"Search for addresses, place names, or coordinates...",
         "search_results": "Search results",
         "error":"Sorry we could not find a location matching your search",
+        "my_location_error":"Sorry we could not find your location",
         "update_map":"Update map",
         "no_matching_locations":"No matching locations"
     },

--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -15,6 +15,7 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
         var map;
         $scope.hideMap = false;
         $scope.emptyGeoJSON = false;
+        $scope.geojson = [];
 
         activate();
 
@@ -44,6 +45,10 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
             })
             // Create the map
             .then(addGeoJSONToMap)
+            .then((data) => {
+                // Save points to scope
+                $scope.features = data.geojson.features.filter(f => f.geometry.type === 'Point');
+            })
             ;
 
             // Cleanup leaflet map
@@ -77,6 +82,8 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
             if (map.getZoom() > 15) {
                 map.setZoom(15);
             }
+
+            return data;
         }
     }
 }

--- a/app/main/posts/detail/map.html
+++ b/app/main/posts/detail/map.html
@@ -1,4 +1,5 @@
 <div class="postcard-field" ng-style="{'visibility': hideMap ? 'hidden' : 'visible'}" ng-hide="emptyGeoJSON">
     <h2 class="form-label" translate>post.location</h2>
     <div id="post-map" class="map"></div>
+    <p ng-repeat="feature in features track by $index">{{ feature.geometry.coordinates[1] }}, {{ feature.geometry.coordinates[0] }}</p>
 </div>

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -73,12 +73,14 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         }
 
         function onMapClick(e) {
-            var wrappedLatLng = e.latlng.wrap(),
-                lat = wrappedLatLng.lat,
-                lon = wrappedLatLng.lng;
+            $scope.$apply(() => {
+                var wrappedLatLng = e.latlng.wrap(),
+                    lat = wrappedLatLng.lat,
+                    lon = wrappedLatLng.lng;
 
-            updateMarkerPosition(lat, lon);
-            updateModelLatLon(lat, lon);
+                updateMarkerPosition(lat, lon);
+                updateModelLatLon(lat, lon);
+            });
         }
 
         function renderViewValue() {

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -22,6 +22,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         $scope.processing = false;
         $scope.searchLocationTerm = '';
         $scope.searchLocation = searchLocation;
+        $scope.manualModel = { lat: null, lon: null };
         $scope.searchTimeout;
         $scope.handleActiveSearch = handleActiveSearch;
         $scope.clear = clear;
@@ -87,6 +88,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
             ) {
                 updateMarkerPosition(ngModel.$viewValue.lat, ngModel.$viewValue.lon);
                 centerMapTo(ngModel.$viewValue.lat, ngModel.$viewValue.lon);
+                updateManualLatLon(ngModel.$viewValue.lat, ngModel.$viewValue.lon);
             }
         }
 
@@ -95,6 +97,12 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 lat: lat,
                 lon: lon
             });
+            updateManualLatLon(lat, lon);
+        }
+
+        function updateManualLatLon(lat, lon) {
+            $scope.manualModel.lat = lat;
+            $scope.manualModel.lon = lon;
         }
 
         function manualLatLong(lat, lon) {

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -34,7 +34,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         $scope.chooseCurrentLocation = chooseCurrentLocation;
         $scope.searchResults = [];
         $scope.showCurrentPositionControl = false;
-        $scope.manualLatLong = manualLatLong;
+        $scope.updateMapFromLatLon = updateMapFromLatLon;
         activate();
 
         function activate() {
@@ -113,7 +113,7 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
             $scope.manualModel.lon = lon;
         }
 
-        function manualLatLong(lat, lon) {
+        function updateMapFromLatLon(lat, lon) {
             updateMarkerPosition(lat, lon);
             centerMapTo(lat, lon);
             updateModelLatLon(lat, lon);

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -52,6 +52,8 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 map.on('click', onMapClick);
                 // treat locationfound same as map click
                 map.on('locationfound', onMapClick);
+                // handle failure to find location
+                map.on('locationerror', onLocationError);
                 // Add locate control, but only on https
                 if (window.location.protocol === 'https:' || window.location.hostname === 'localhost') {
                     $scope.showCurrentPositionControl = true;
@@ -81,6 +83,10 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 updateMarkerPosition(lat, lon);
                 updateModelLatLon(lat, lon);
             });
+        }
+
+        function onLocationError() {
+            Notify.error('location.my_location_error');
         }
 
         function renderViewValue() {

--- a/app/main/posts/modify/location.directive.js
+++ b/app/main/posts/modify/location.directive.js
@@ -130,8 +130,10 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
                 marker.addTo(map);
 
                 marker.on('dragend', function (ev) {
-                    var latLng = ev.target.getLatLng();
-                    updateModelLatLon(latLng.lat, latLng.lng);
+                    $scope.$apply(() => {
+                        var latLng = ev.target.getLatLng();
+                        updateModelLatLon(latLng.lat, latLng.lng);
+                    });
                 });
             }
         }

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -65,7 +65,7 @@
       <label>Long</label>
       <input type="text" ng-model="manualModel.lon">
    </div>
-   <button type="button" class="button-primary" ng-click="manualLatLong(manualModel.lat, manualModel.lon)">
+   <button type="button" class="button-primary" ng-click="updateMapFromLatLon(manualModel.lat, manualModel.lon)">
         <svg class="iconic">
        <use
                                 xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -59,16 +59,16 @@
     <p translate>location.click_map</p>
     <div class="form-field">
       <label>Lat</label>
-      <input type="text" ng-model="model.lat">
+      <input type="text" ng-model="manualModel.lat">
    </div>
    <div class="form-field">
       <label>Long</label>
-      <input type="text" ng-model="model.lon">
+      <input type="text" ng-model="manualModel.lon">
    </div>
-   <button type="button" class="button-primary" ng-click="manualLatLong(model.lat, model.lon)">
+   <button type="button" class="button-primary" ng-click="manualLatLong(manualModel.lat, manualModel.lon)">
         <svg class="iconic">
-       <use 
-                                xmlns:xlink="http://www.w3.org/1999/xlink" 
+       <use
+                                xmlns:xlink="http://www.w3.org/1999/xlink"
                                 xlink:href="/img/iconic-sprite.svg#location">
                             </use>
         </svg>

--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -48,7 +48,7 @@
                         </dt>
                     </dl>
                     <dl class="dropdown-menu-body" ng-if="!processing && !searchResults">
-                        <dt class="list-item">
+                        <dt class="list-item" translate="location.no_matching_locations">
                             No matching locations.
                         </dt>
                     </dl>
@@ -72,6 +72,6 @@
                                 xlink:href="/img/iconic-sprite.svg#location">
                             </use>
         </svg>
-        <span class="button-label">Update Map</span>
+        <span class="button-label" translate>location.update_map</span>
     </button>
 </div>


### PR DESCRIPTION
- Populate manual lat / lon entry on load
- Populate manual lat / lon entry when map is clicked
- Populate manual lat / lon entry when search result chosen
- Populate manual lat / lon entry when current location used
- Show location lat/lon entry below the map on post detail view

Refs: https://github.com/ushahidi/platform-sivico/issues/33

Testing checklist:
- [x] Edit a post with a location
- [x] See lat / lon is shown when edit loads
- [x] Click on map. See lat /lon is updated
- [x] Search for a location and chose a result. See lat /lon is updated
- [x] Click in search and select 'use my current location'. See lat /lon is updated
- [x] Edit lat / lon. Click Update Map. See map updates
- [x] View a post. See `lat, lon` displayed below map

Ping @ushahidi/platform
