### PR TITLE
removing targeted-surveys from add-survey-list #2631

### DIFF
--- a/app/main/posts/views/add-post-survey-list.html
+++ b/app/main/posts/views/add-post-survey-list.html
@@ -1,5 +1,5 @@
 <ul>
-    <li ng-repeat="form in forms">
+    <li ng-repeat="form in forms" ng-show="!form.targeted_survey">
         <a ng-click="handleClick(form)">
             <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
             {{form.name}}


### PR DESCRIPTION
This pull request makes the following changes:
- Filtering out targeted surveys from the add-new-post-list

Testing checklist can be found in issue: https://app.zenhub.com/workspace/o/ushahidi/platform/issues/2632


- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2631 .

Ping @ushahidi/platform
