### PR TITLE
Step 4 Stats for Targeted Survey

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -343,14 +343,17 @@
             "phone_number_instructions" : "Please type in the phone numbers you'd like to contact. You must place a comma between each phone number.",
             "targeted_survey": "Targeted Survey",
             "targeted_survey_desc": "We sent this survey via SMS",
-            "published_people": "We sent your survey to {{numbers}} people on {{sentDate}}.",
-            "published_person": "We sent your survey to {{numbers}} person on {{sentDate}}.",
-            "received_responses": "You have received {{responses}} responses ",
-            "received_response": "You have received {{responses}} response ",
+            "sent_messages": "We have sent {{totalSent}} messages, and",
+            "sent_message": "We have sent {{totalSent}} message, and",
+            "received_responses": "you have received {{responses}} responses ",
+            "received_response": "you have received {{responses}} response ",
             "recipients_count": "from {{recipients}} recipients so far.",
             "recipient_count": "from {{recipients}} recipient so far.",
             "error_message" : "An error occurred while trying to save your targeted survey",
-            "error_contacts": "Some of the numbers you provided failed, please check your numbers and try again"
+            "error_contacts": "Some of the numbers you provided failed, please check your numbers and try again",
+            "pending_messages": "We are processing {{totalPending}} messages.",
+            "pending_message": "We are processing {{totalPending}} message."
+
         }
     },
 

--- a/app/common/services/endpoints/form-stats-endpoint.js
+++ b/app/common/services/endpoints/form-stats-endpoint.js
@@ -7,7 +7,7 @@ function (
 ) {
 
     var FormStatsEndpoint = $resource(Util.apiUrl('/forms/:formId/stats/'), {
-        id: '@id'
+        formId: '@formId'
     }, {
         query: {
             method: 'GET',

--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -82,6 +82,8 @@ function (
     $scope.getFormStats = getFormStats;
     $scope.totalResponses = 0;
     $scope.totalRecipients = 0;
+    $scope.totalSent = 0;
+    $scope.totalPending = 0;
     Features.loadFeatures()
            .then(() => {
             $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
@@ -393,11 +395,13 @@ function (
 
     function getFormStats() {
         let recipientRequest = FormContactEndpoint.query({formId: $scope.surveyId}).$promise;
-        let responsesRequest = FormStatsEndpoint.query({id: $scope.surveyId}).$promise;
+        let responsesRequest = FormStatsEndpoint.query({formId: $scope.surveyId}).$promise;
         $q.all([recipientRequest, responsesRequest]).then((results) => {
             $scope.recipientCount = results[0].length;
             $scope.totalResponses = results[1].total_responses;
             $scope.totalRecipients = results[1].total_recipients;
+            $scope.totalSent = results[1].total_messages_sent;
+            $scope.totalPending = results[1].total_messages_pending;
         });
     }
 }];

--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -118,7 +118,7 @@
                                 <p ng-show="!isActiveStep(2) && recipientCount > 1" translate="survey.targeted_survey.send_to_people" translate-values="{recipientCount: recipientCount}">Send this survey to {{recipientCount}} people via SMS.</p>
                                 <p ng-show="!isActiveStep(2) && recipientCount === 1" translate="survey.targeted_survey.send_to_person" translate-values="{recipientCount: recipientCount}">Send this survey to {{recipientCount}} person via SMS.</p>
                             </span>
-                            <span ng-show="surveyId">
+                            <span ng-show="surveyId && recipientCount > 0">
                                 <p ng-show="!isActiveStep(2) && recipientCount > 1" translate="survey.targeted_survey.survey_recipients" translate-values="{recipientCount: recipientCount}">{{recipientCount}} people.</p>
                                 <p ng-show="!isActiveStep(2) && recipientCount === 1" translate="survey.targeted_survey.survey_recipient" translate-values="{recipientCount: recipientCount}">{{recipientCount}} person.</p>
                             </span>
@@ -232,8 +232,11 @@
                                 <span translate="survey.targeted_survey.publish"></span>
                             </h2>
                                 <!-- WARNING! Add actual responses once we get them from API -->
-                                <p ng-show="surveyId && isActiveStep(4)" translate="{{getPublishDescription()}}" translate-values="{numbers: recipientCount, sentDate: '22/22/2222 at 11:11 UTC'}"></p>
-                                <p ng-show="surveyId && isActiveStep(4)">
+                                <p ng-show="surveyId && isActiveStep(4) && totalRecipients > 0">
+                                    <span ng-show="totalPending !== 1" translate="survey.targeted_survey.pending_messages" translate-values="{totalPending: totalPending}"></span>
+                                    <span ng-show="totalPending === 1" translate="survey.targeted_survey.pending_message" translate-values="{totalPending: totalPending}"></span>
+                                    <span ng-show="totalSent !== 1" translate="survey.targeted_survey.sent_messages" translate-values="{totalSent: totalSent}"></span>
+                                    <span ng-show="totalSent === 1" translate="survey.targeted_survey.sent_message" translate-values="{totalSent: totalSent}"></span>
                                     <span ng-show="totalResponses !== 1" translate="survey.targeted_survey.received_responses" translate-values="{responses: totalResponses}"></span>
                                     <span ng-show="totalResponses === 1" translate="survey.targeted_survey.received_response" translate-values="{responses: totalResponses}"></span>
                                     <span ng-show="totalRecipients === 1" translate="survey.targeted_survey.recipient_count" translate-values="{recipients: totalRecipients}"></span>


### PR DESCRIPTION
This pull request makes the following changes:
- adding new stats to scope, html, and en.json

Testing checklist:
- [ ] Create and publish a targeted survey
- [ ] view the targeted survey; confirm that the text under step 2 and step 4 appear with the correct numbers (note that pending will be incorrect until bug is fixed in API)
- [ ] comment out lines 401-404 in targeted-edit.controller.js
- [ ] change:
```
    $scope.totalResponses = 0;
    $scope.totalRecipients = 0;
    $scope.totalSent = 0;
    $scope.totalPending = 0;
```
to 
```
    $scope.totalResponses = 1;
    $scope.totalRecipients = 1;
    $scope.totalSent = 1;
    $scope.totalPending = 1;
```
- [ ] confirm that step 4 text reads: We are processing 1 message. We have sent 1 message, and you have received 1 response from 1 recipient so far.
- [ ] change the scopes above to = 2 
- [ ] confirm that step 4 text reads: We are processing 2 messages. We have sent 2 messages, and you have received 2 responses from 2 recipients so far.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2562

Ping @ushahidi/platform
