### PR TITLE
changing order to priority #2734

### DIFF
--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -142,7 +142,7 @@ function (
         _.each(items, function (item, index) {
             _.each($scope.survey.attributes, function (question) {
                 if (question.label === item.getAttribute('data')) {
-                    question.order = index + 1;
+                    question.priority = index + 1;
                 }
             });
         });
@@ -259,7 +259,7 @@ function (
         }
 
         $scope.editQuestion.input = 'textarea';
-        $scope.editQuestion.order = getPriority($scope.survey.attributes);
+        $scope.editQuestion.priority = getPriority($scope.survey.attributes);
         $scope.editQuestion.type = 'text';
         // This is to avoid the 2-way binding and the label to update while writing in the modal
         $scope.editQuestion.label = angular.copy($scope.editQuestion.question);
@@ -272,7 +272,7 @@ function (
     }
 
     function getPriority(step) {
-        return step && step.length > 0 ? _.last(step).order + 1 : 3;
+        return step && step.length > 0 ? _.last(step).priority + 1 : 1;
     }
 
     function deleteQuestion() {

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -132,26 +132,26 @@ describe('setting create targeted survey controller', function () {
                 };
                 $scope.editQuestion = {question: 'Test question?', input: 'textarea', newQuestion: true};
                 $scope.addNewQuestion();
-                let adjustedQuestion = {question: 'Test question?', input: 'textarea', order: 3, type: 'text', label: 'Test question?'};
+                let adjustedQuestion = {question: 'Test question?', input: 'textarea', priority: 1, type: 'text', label: 'Test question?'};
                 expect($scope.editQuestion).toEqual(adjustedQuestion);
             });
             it('should not add an edited question to the model', function () {
-                let existingQuestion = {question: 'Test question?', input: 'textarea', order: 3, type: 'text', label: 'Test question?'};
+                let existingQuestion = {question: 'Test question?', input: 'textarea', priority: 3, type: 'text', label: 'Test question?'};
                 $scope.survey = {
                     attributes: [existingQuestion]
                 };
-                $scope.editQuestion =  {question: 'Edited question', input: 'textarea', order: 3, type: 'text', label: 'Test question?'};
+                $scope.editQuestion =  {question: 'Edited question', input: 'textarea', priority: 3, type: 'text', label: 'Test question?'};
                 $scope.addNewQuestion();
                 expect($scope.survey.attributes.length).toEqual(1);
             });
-            it('should give a question the correct order based on previous questions', function () {
-                let question = {question: 'Test question?', input: 'textarea', order: 3, type: 'text', label: 'Test question?'};
+            it('should give a question the correct priority based on previous questions', function () {
+                let question = {question: 'Test question?', input: 'textarea', priority: 3, type: 'text', label: 'Test question?'};
                 $scope.survey = {
                     attributes: [question]
                 };
                 $scope.editQuestion =  {question: 'Another question', newQuestion: true};
                 $scope.addNewQuestion();
-                expect($scope.editQuestion.order).toEqual(4);
+                expect($scope.editQuestion.priority).toEqual(4);
                 expect($scope.survey.attributes.length).toEqual(2);
             });
         });


### PR DESCRIPTION
This pull request makes the following changes:
- Changes naming of "order" to "priority"
- Changes first priority to 1
- Updates tests 

Testing checklist:
- Create a new targeted survey with more than 1 question
- Save it
- Check the db, the form_attributes should be set to same priorities as the order they are listed in the targeted survey
- Create another targeted survey with more than 1 question
- change order of the questions by dragging one question to a new place in the list
- [x] Check the db, the priority for each attribute in the survey should reflect the same order thats in the survey after moving the questions around

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
