### PR TITLE
using fields instead of attributes in query #2405

### DIFF
--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -114,17 +114,16 @@ function (
     }
 
     function exportSelected() {
-        var attributes = _.chain($scope.selectedFields)
+        var fields = _.chain($scope.selectedFields)
             .flatten() // concatinating attributes into one array
             .compact() // removing nulls
             .value(); // output
-
-        if (attributes.length === 0) {
+        if (fields.length === 0) {
             // displaying notification if no fields are selected
             var message =  '<p translate="data_export.no_fields"></p>';
             Notify.notifyAction(message, null, false, 'warning', 'error');
         } else {
-            DataExport.startExport({attributes: attributes});
+            DataExport.startExport({fields});
             $scope.showFields = false;
             $scope.showProgress = true;
         }

--- a/test/unit/settings/data-export/data-export.controller.spec.js
+++ b/test/unit/settings/data-export/data-export.controller.spec.js
@@ -90,7 +90,7 @@ describe('data-export-controller', function () {
             $scope.selectedFields = [1, 4, 7, 8, 10];
             spyOn(DataExport, 'startExport');
             $scope.exportSelected();
-            expect(DataExport.startExport).toHaveBeenCalledWith({attributes: $scope.selectedFields});
+            expect(DataExport.startExport).toHaveBeenCalledWith({fields: $scope.selectedFields});
         });
     });
     describe('attachAttributes-function', function () {


### PR DESCRIPTION
This pull request makes the following changes:
- changes "attributes" to "fields" in data-export-query

Testing checklist:
- Go to export in settings
- Select "select fields to export"
- Select a number of fields to export
- Check the db
- [x] the "fields" column should be populated with the form_attribute-ids connected to the selected fields

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2405 .

Ping @ushahidi/platform
