### PR TITLE
adding spacing

### DIFF
--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -46,7 +46,7 @@
                                 </a>
                             </li>
                         </ul>
-                    </nav>    
+                    </nav>
                 <div id="main-export" class="survey-details tabs-target" >
                     <div class="form-field">
                         <button class="button-alpha" translate ng-click="exportAll()" ng-disabled="showProgress">data_export.all</button>
@@ -73,8 +73,7 @@
                     </h2>
                     <p translate>data_export.select_fields_desc</p>
                 </div>
-                <div class="form-field">
-                <div ng-repeat="form in forms">
+                <div class="form-field" ng-repeat="form in forms">
                     <label>{{form.name}}</label>
                     <div class="form-field checkbox" ng-show="form.attributes">
                         <label>
@@ -97,7 +96,6 @@
                         {{attribute.label}}
                     </label>
                     </div>
-                </div>
             </div>
             <div class="form-field">
                 <button class="button-alpha" ng-click="exportSelected()" translate>data_export.export_selected


### PR DESCRIPTION
This pull request makes the following changes:
- Adds spacing between titles and the above fields in the select-fields for data-export

Testing checklist:
- go to settings->data-export->select fields
- [ ] There should be more spacing between the title and the fields above it (that belongs to another survey) than between the fields that belongs to the same survey
![screen shot 2018-04-15 at 15 31 14](https://user-images.githubusercontent.com/8624777/38778986-3b469614-40c2-11e8-92f6-de83c8e7ddc5.png)


- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
