### PR TITLE
Adding form-validation and makes 

### DIFF
--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -16,14 +16,16 @@ function (
              * - What should happen is that we get an empty object literal, or NULL, directly from the backend.
              * - What really happens is that we get an array, add a key on it, and then it cannot be stringified correctly, which prevents the information from getting to the backend.
              */
+            $scope.label = angular.copy($scope.editAttribute.label);
             $scope.editAttribute.config = (!$scope.editAttribute.config || (_.isArray($scope.editAttribute.config) && $scope.editAttribute.config.length === 0)) ? {} : $scope.editAttribute.config;
             $scope.defaultValueToggle = false;
             $scope.descriptionToggle = false;
             $scope.labelError = false;
 
             $scope.save = function (editAttribute, activeTask) {
-                if (!_.isEmpty(editAttribute.label)) {
+                if (!_.isEmpty($scope.label)) {
                     $scope.labelError = false;
+                    $scope.editAttribute.label = $scope.label;
                     $scope.addNewAttribute(editAttribute, activeTask);
                 } else {
                     $scope.labelError = true;

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -23,12 +23,9 @@ function (
             $scope.labelError = false;
 
             $scope.save = function (editAttribute, activeTask) {
-                if (!_.isEmpty($scope.label)) {
-                    $scope.labelError = false;
+                if (!$scope.attributeLabel.$invalid) {
                     $scope.editAttribute.label = $scope.label;
                     $scope.addNewAttribute(editAttribute, activeTask);
-                } else {
-                    $scope.labelError = true;
                 }
             };
 

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -1,19 +1,21 @@
  <div class="modal-body">
   <div class="form-field required"
     ng-class="{
-        'error': labelError
+        'error': attributeLabel.$invalid && attributeLabel.$dirty
     }">
+    <form name="attributeLabel">
       <label translate="app.name">Name</label>
-      <input type="text" ng-model="label" placeholder="{{ 'form.field_name_placeholder' | translate}}">
+      <input type="text" ng-model="label" ng-required="true" placeholder="{{ 'form.field_name_placeholder' | translate}}">
       <div
                 class="alert error"
-                ng-show="labelError"
+                ng-show="attributeLabel.$invalid && attributeLabel.$dirty"
             >
                 <svg class="iconic">
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
                 </svg>
                 <span translate="{{'post.valid.label.required'}}"></span>
             </div>
+    </form>
    </div>
    <div class="form-field switch">
       <label translate="survey.show_field_description">Show field description</label>

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -4,7 +4,7 @@
         'error': labelError
     }">
       <label translate="app.name">Name</label>
-      <input type="text" ng-model="editAttribute.label" placeholder="{{ 'form.field_name_placeholder' | translate}}">
+      <input type="text" ng-model="label" placeholder="{{ 'form.field_name_placeholder' | translate}}">
       <div
                 class="alert error"
                 ng-show="labelError"

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -99,7 +99,7 @@
                   </button>
               </div>
 
-              <div class="listing-item-primary">
+              <div class="listing-item-primary" ng-click="openAttributeEditModal(survey.tasks[0], attribute)">
                   <div class="listing-item-image">
                   <!-- TODO: Set icon based on type -->
                       <svg class="iconic">
@@ -107,9 +107,7 @@
                       </svg>
                   </div>
                   <h2 class="listing-item-title">
-                    <a ng-click="openAttributeEditModal(survey.tasks[0], attribute)">
                       {{attribute.label}}
-                    </a>
                     <span class="listing-item-image tooltip" ng-show="attribute.response_private">
                         <svg class="iconic">
                             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#lock-locked"></use>

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -293,16 +293,14 @@
                       </button>
                   </div>
 
-                  <div class="listing-item-primary">
+                  <div class="listing-item-primary" ng-click="openAttributeEditModal(task, attribute)">
                       <div class="listing-item-image">
                           <svg class="iconic">
                               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#ic_short_text_24px"></use>
                           </svg>
                       </div>
                       <h2 class="listing-item-title">
-                        <a ng-click="openAttributeEditModal(task, attribute)">
                           {{attribute.label}}
-                        </a>
                         <span class="listing-item-image tooltip" ng-show="attribute.response_private">
                             <svg class="iconic">
                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#lock-locked"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- Makes whole area for a form-field clickable, not just the label
- Removes 2-way binding for attribute-modal-label to avoid instantly saving the form-attribute-title.
- Adds form-validation to instantly warn user that they need a title, not only when saving

Testing checklist:
- Go to settings-survey-> edit a survey
- Click on anywhere in the field-list, not on the label of the field
- [ ] The modal should open for the field clicked on
- Close modal
-  Click anywhere in task-field-list
-  [ ] The modal should open for the field clicked on
-  Remove the title
- [ ] There should be a warning that the name cannot be empty
- [ ] try saving, modal should not close and warning should still be there
- Click on "X", the modal should close, and the old title should remain in the list
-  Click on a field again
- Write a new title
- Save
- [ ] The new title should be shown in the list

- [ ] I certify that I ran my checklist

Fixes https://github.com/ushahidi/platform-sivico/issues/16
Ping @ushahidi/platform
