### PR TITLE
adding orderBy:priority when displaying questions outside step 3

### DIFF
--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -209,7 +209,7 @@
                                 <a ng-hide="survey.attributes.length" ng-click="openQuestionModal(null)" translate="survey.targeted_survey.add_a_question">Add a question...</a>
                             </div>
                             <div ng-hide="isActiveStep(3)">
-                                    <p ng-repeat="question in survey.attributes">{{question.label}}</p>
+                                    <p ng-repeat="question in survey.attributes | orderBy: 'priority'">{{question.label}}</p>
                             </div>
 
 


### PR DESCRIPTION
This pull request makes the following changes:
- adds filter orderBy when displaying questions outside step 3

Testing checklist:
- Create a new survey
- Add a number of questions, move order by dragging and dropping them
- Make a note of the order the questions appear on the screen
- Click continue
- [ ] the displayed order of the questions should be the same order as you had after dragging and dropping
- click back to numbers
- [ ] the displayed order of the questions should be the same order as you had after dragging and dropping
- Publish the survey
- Check the db
- [ ] The priority column should reflect the same order as you had after dragging and dropping

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
