### PR TITLE
Rtl display

### DIFF
--- a/app/common/directives/category-selector.html
+++ b/app/common/directives/category-selector.html
@@ -28,7 +28,7 @@
                     value="category.id"
                     checklist-model="selectedParents"
             >
-            {{ ::category.tag }}
+            <bdi>{{ ::category.tag }}</bdi>
         </label>
         <div class="form-field checkbox" ng-if="category.children" ng-repeat="child in category.children">
             <label>
@@ -40,7 +40,7 @@
                     ng-selected="selected.indexOf(category.id) >-1"
                     checklist-change="changeCategories()"
                 >
-                {{ ::child.tag }}
+                <bdi>{{ ::child.tag }}</bdi>
         </label>
         </div>
     </div>

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -11,7 +11,9 @@
         <post-lock ng-if="post.lock" post="post"></post-lock>
 
         <div class="postcard-body">
-              <h1 class="form-sheet-title survey-title" linkify>{{post.title}}</h1>
+            <h1 class="form-sheet-title survey-title" linkify>
+                      <bdi>{{post.title}}</bdi>
+            </h1>
 
             <div class="postcard-header">
                 <post-metadata post="post" hide-date-this-week="true"></post-metadata>
@@ -56,7 +58,7 @@
               ng-repeat="task in tasks"
               ng-class="{'active': visibleTask == task.id}"  >
               <a ng-click="activateTaskTab(task.id)">
-                {{task.label}}
+                <bdi>{{task.label}}</bdi>
               </a>
               <span class="status" ng-class="{'completed': taskIsComplete(visibleTask)}">
               </span>

--- a/app/main/posts/detail/post-value.html
+++ b/app/main/posts/detail/post-value.html
@@ -2,7 +2,7 @@
 
     <div ng-if="attribute.input !== 'video'">
       <h2 class="form-label">
-          {{attribute.label}}
+          <bdi>{{attribute.label}}</bdi>
       </h2>
 
       <div ng-if="attribute.input === 'tags'">
@@ -10,15 +10,15 @@
         <svg class="iconic" style="margin-right:4px;">
             <use xlink:href="/img/iconic-sprite.svg#tag"></use>
         </svg>
-          {{value}}
+          <bdi>{{value}}</bdi>
         </p>
       </div>
 
       <div ng-repeat="entry in value track by $index" ng-if="attribute.type === 'relation'">
-          <a ui-sref="posts.detail.data({postId: entry.id})">{{entry.title}}</a>
+          <a ui-sref="posts.detail.data({postId: entry.id})"><bdi>{{entry.title}}<bdi></a>
       </div>
      <div ng-repeat="entry in value track by $index" ng-if="attribute.type !== 'relation' && attribute.input !== 'tags'">
-          <p ng-if="attribute.type !== 'markdown'" linkify>{{entry}}</p>
+          <p ng-if="attribute.type !== 'markdown'" linkify><bdi>{{entry}}<bdi></p>
           <p ng-if="attribute.type === 'markdown'" markdown-to-html="entry"></p>
       </div>
     </div>

--- a/app/main/posts/detail/post-video-value.html
+++ b/app/main/posts/detail/post-video-value.html
@@ -1,6 +1,6 @@
 <div class="postcard-field">
   <h2 class="form-label">
-    {{label}}
+    <bdi>{{label}}</bdi>
   </h2>
   <div class="video_embed-fluid">
     <iframe src="{{videoUrl}}" frameborder="0" allowfullscreen></iframe>

--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -3,10 +3,10 @@
     <layout-class layout="a"></layout-class>
     <header class="mode-context-header">
         <ol class="breadcrumbs">
-            <li><a href="/" ng-controller="navigation as nav">{{nav.site.name}}</a></li>
+            <li><a href="/" ng-controller="navigation as nav"><bdi>{{nav.site.name}}</bdi></a></li>
         </ol>
 
-        <h1 class="mode-context-title">{{post.form.name}}</h1>
+        <h1 class="mode-context-title"><bdi>{{post.form.name}}</bdi></h1>
     </header>
 
     <span class="mode-context-trigger" dropdown-toggle>

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -12,10 +12,10 @@
             }"
         >
              <label>
-                {{attribute.label}}
+                <bdi>{{attribute.label}}</bdi>
             </label>
             <p>
-                {{attribute.instructions}}
+                <bdi>{{attribute.instructions}}</bdi>
             </p>
             <input id="title"
                 name="title" type="text" ng-model="post.title" ng-required="true" ng-minlength=2 ng-maxlength=150 adaptive-input>
@@ -43,10 +43,10 @@
             adaptive-form
         >
             <label>
-                {{attribute.label}}
+                <bdi>{{attribute.label}}</bdi>
             </label>
             <p>
-                {{attribute.instructions}}
+                <bdi>{{attribute.instructions}}</bdi>
             </p>
             <textarea id="content" name="content" data-min-rows="1" rows="1"
                 ng-model="post.content" ng-required="true" adaptive-input msd-elastic>
@@ -78,7 +78,7 @@
                 <svg ng-show="attribute.response_private" class="iconic">
                     <use xlink:href="/img/iconic-sprite.svg#lock-locked"></use>
                 </svg>
-                {{attribute.label}}
+                <bdi>{{attribute.label}}</bdi>
             </label>
             <!-- Attribute Instructions -->
             <p>{{attribute.instructions}}</p>
@@ -121,7 +121,7 @@
                         ng-model="post.values[attribute.key][key]"
                         ng-required="attribute.required"
                         >
-                        <option ng-repeat="opt in attribute.options" value="{{opt}}">{{opt}}</option>
+                        <option ng-repeat="opt in attribute.options" value="{{opt}}"><bdi>{{opt}}</bdi></option>
                     </select>
                     <!-- type: number -->
                     <input
@@ -223,9 +223,9 @@
                 'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
                 'success': ! form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
                 'required': attribute.required
-            }">{{attribute.label}}</label>
+            }"><bdi>{{attribute.label}}<bdi></label>
             <!-- Attribute Instructions -->
-            <p>{{attribute.instructions}}</p>
+            <p><bdi>{{attribute.instructions}}</bdi></p>
 
             <!-- attributes which use the form-field structure -->
             <div ng-switch="attribute.input">
@@ -241,7 +241,7 @@
                                 ng-required="attribute.required"
                                 value="{{option}}"
                             >
-                            {{option}}
+                            <bdi>{{option}}</bdi>
                         </label>
                     </div>
                     </div>
@@ -258,7 +258,7 @@
                             checklist-value="option"
                             value="option"
                         >
-                            {{option}}
+                            <bdi>{{option}}</bdi>
                     </label>
                     </div>
                 </div>

--- a/app/main/posts/views/add-post-survey-list.html
+++ b/app/main/posts/views/add-post-survey-list.html
@@ -2,7 +2,7 @@
     <li ng-repeat="form in forms" ng-show="!form.targeted_survey">
         <a ng-click="handleClick(form)">
             <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
-            {{form.name}}
+            <bdi>{{form.name}}</bdi>
         </a>
     </li>
 </ul>

--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -13,7 +13,7 @@
         <div class="postcard-overflow">
             <div class="postcard-title">
                 <div class="postcard-field">
-                {{ post.title || post.content | stripHtml | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}
+                <bdi>{{ post.title || post.content | stripHtml | limitTo:150 }}{{ !post.title && post.content.length > 150 ? ' ...' : ''}}</bdi>
                 </div>
             </div>
 
@@ -22,10 +22,10 @@
             <!-- <img src="http://lorempixel.com/400/300/" class="postcard-image"> -->
 
             <div ng-if="!shortContent" class="postcard-field">
-                {{ post.content | stripHtml }}
+                <bdi>{{ post.content | stripHtml }}</bdi>
             </div>
             <div ng-if="shortContent" class="postcard-field">
-                {{ post.content | stripHtml | limitTo:150 }}{{ post.content.length > 150 ? ' ...' : ''}}
+                <bdi>{{ post.content | stripHtml | limitTo:150 }}{{ post.content.length > 150 ? ' ...' : ''}}</bdi>
             </div>
         </div>
     </div> <!-- /postcard-body -->

--- a/app/main/posts/views/filters/active-search-filters.html
+++ b/app/main/posts/views/filters/active-search-filters.html
@@ -3,7 +3,7 @@
         <svg class="iconic" ng-click="removeCollection(collection, $event)">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
         </svg>
-        <span><em><translate translate="app.collection"></translate>: </em>{{collection.name}}</span>
+        <span><em><translate translate="app.collection"></translate>: </em><bdi>{{collection.name}}<bdi></span>
     </span>
 </div>
 <div class="form-field saved-search" ng-show="savedSearch">
@@ -11,7 +11,7 @@
         <svg class="iconic" ng-click="removeSavedSearch(savedSearch, $event)">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
         </svg>
-        <span><em><translate translate="app.saved_search"></translate>: </em>{{savedSearch.name}}</span>
+        <span><em><translate translate="app.saved_search"></translate>: </em><bdi>{{savedSearch.name}}</bdi></span>
     </span>
     <div ng-repeat="(key, values) in savedSearch.filter">
         <span ng-if="isArray(values)">
@@ -19,7 +19,7 @@
                 <svg class="iconic" ng-click="removeFilter(key, value, savedSearch, $event)">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                 </svg>
-                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> {{ transformFilterValue(value, key) }}</span>
+                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> <bdi>{{ transformFilterValue(value, key) }}</bdi></span>
             </span>
         </span>
         <span ng-if="!isArray(values)">
@@ -27,7 +27,7 @@
                 <svg class="iconic" ng-click="removeFilter(key, values, savedSearch, $event)">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                 </svg>
-                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> {{ transformFilterValue(values, key) }}</span>
+                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> <bdi>{{ transformFilterValue(values, key) }}</bdi></span>
             </span>
         </span>
     </div>
@@ -39,7 +39,7 @@
                 <svg class="iconic" ng-click="removeFilter(key, value, false, $event)">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                 </svg>
-                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> {{ transformFilterValue(value, key) }}</span>
+                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> <bdi>{{ transformFilterValue(value, key) }}</bdi></span>
             </span>
         </span>
         <span ng-if="!isArray(values)">
@@ -47,7 +47,7 @@
                 <svg class="iconic" ng-click="removeFilter(key, values, false, $event)">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                 </svg>
-                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> {{ transformFilterValue(values, key) }}</span>
+                <span><em><translate translate="global_filter.filter_tabs.{{key}}"></translate>:</em> <bdi>{{ transformFilterValue(values, key) }}</bdi></span>
             </span>
         </span>
     </div>

--- a/app/main/posts/views/filters/filter-category.html
+++ b/app/main/posts/views/filters/filter-category.html
@@ -8,10 +8,10 @@
                 checklist-value="category.id"
                 value="category.id"
                 checklist-model="selectedCategories"
-            > 
-            {{ ::category.tag }}
+            >
+            <bdi>{{ ::category.tag }}</bdi>
         </label>
-        <div 
+        <div
           class="form-field checkbox"
           ng-repeat="child in category.children"
         >
@@ -23,9 +23,9 @@
             value="child.id"
             ng-selected="selectedCategories.indexOf(category.id) >-1"
           >
-            {{ ::child.tag }}
+            <bdi>{{ ::child.tag }}</bdi>
         </label>
-    </div> 
+    </div>
     </div>
       <span class="form-field-toggle">
         <svg class="iconic">

--- a/app/main/posts/views/filters/filter-form.html
+++ b/app/main/posts/views/filters/filter-form.html
@@ -3,7 +3,7 @@
 
     <div class="form-field checkbox" ng-repeat="(index, form) in forms" ng-class="{ overflow : ($index > 1) }">
         <label>
-            <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms" > {{ ::form.name }}
+            <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms"> <bdi>{{ ::form.name }}</bdi>
         </label>
     </div>
     <div class="form-field checkbox" ng-class="{ overflow : (forms.length > 1) }">

--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -6,7 +6,7 @@
                 <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
                 <label class="checked">
                     <input type="checkbox" checklist-value="form.id" checklist-model="filters.form">
-                    {{ ::form.name }}
+                    <bdi>{{ ::form.name }}</bdi>
                 </label>
             </div>
              <span class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>

--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -93,7 +93,7 @@
                             ng-value="parent.id"
                             ng-model="category.parent_id"
                           />
-                          {{parent.tag}}
+                          <bdi>{{parent.tag}}</bdi>
                       </label>
                   </div>
                 </div>

--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -74,7 +74,7 @@
                     <p translate>data_export.select_fields_desc</p>
                 </div>
                 <div class="form-field" ng-repeat="form in forms">
-                    <label>{{form.name}}</label>
+                    <label><bdi>{{form.name}}</bdi></label>
                     <div class="form-field checkbox" ng-show="form.attributes">
                         <label>
                             <input
@@ -93,7 +93,7 @@
                             checklist-value="attribute.id"
                             value="attribute.id"
                         >
-                        {{attribute.label}}
+                        <bdi>{{attribute.label}}</bdi>
                     </label>
                     </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "socket.io-client": "2.0.3",
     "sortablejs": "^1.7.0",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "v3.7.2-rc.38"
+    "ushahidi-platform-pattern-library": "3.11.0-rc.1"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the element `<bdi></bdi>` to texts we display that the users can change, for example post-field-labels, survey-field-labels, survey-names, category-names and so on
- This makes the browser figure out itself what direction the text has and display it accordingly.

Testing checklist:
- Add a new survey with different fields in english and make sure the names ends with ? or .
- Switch to an rtl-language
- [ ] Check the edit-survey page, the english labels should be displayed correctly, the ? or . should not appear in front of the first word,
- Add a post to the new survey, 
- [ ] Check that the english labels are displayed correctly, with the ? or . in the end of each label, not in the beginning.
- make sure to add ? to the title and description fields
- [ ] Check that the english labels are displayed correctly, with the ? or . in the end of each label, not in the beginning in the postlist in data-view, post-detail and in the map-labels
- Click on the filter-dropdown
 - [ ] Check that the english labels for the surveys are displayed correctly, with the ? or . in the end of each label, not in the beginning.
- Select the new survey as a filter
- [ ] Check that the english is displayed correctly in the filter-bug-icon
- Go to data-export in settings, click on "Select fields to export"
 - [ ] Check that the english labels for the surveys are displayed correctly, with the ? or . in the end of each label, not in the beginning.
- Click around the app and make sure there are no other inconsistencies when displaying english text in rtl-format

KNOWN problem. When typing in textboxes, such as when adding a post, strong characters like ? and . ends up in the beginning of the sentence. I have not found a fix for this and am not even sure there is one. Have looked at other arabic sites and they have the same issue :/


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform