### PR TITLE
Fixing share-url in survey-settings

### DIFF
--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -198,7 +198,7 @@
         </div>
         <!-- Share Tab Options -->
         <div id="survey-share-post" class="survey-details tabs-target" ng-show="survey.id">
-          <share-menu survey-id="survey.id"></share-menu>
+          <share-menu survey-id="surveyId"></share-menu>
         </div>
       </section>
       <!-- Task sections -->


### PR DESCRIPTION
This pull request makes the following changes:
- sends correct survey-id to share-modal-directive

Testing checklist:
- Go to settings-survey and select a survey (not a targeted survey)
- Click on "share"-tab
- [ ] The address in the box "Your survey's web address" should be in the format /posts/create/{{survey-id}}

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2431 .

Ping @ushahidi/platform