### PR TITLE
assigning priority only on new questions, not when editing #2754

### DIFF
--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -243,13 +243,14 @@ function (
         }
 
         $scope.editQuestion.input = 'textarea';
-        $scope.editQuestion.priority = getPriority($scope.survey.attributes);
         $scope.editQuestion.type = 'text';
+
         // This is to avoid the 2-way binding and the label to update while writing in the modal
         $scope.editQuestion.label = angular.copy($scope.editQuestion.question);
 
         // This is to avoid adding same question twice and we don't have any unique id-s for the questions yet
         if ($scope.editQuestion.newQuestion) {
+            $scope.editQuestion.priority = getPriority($scope.survey.attributes);
             delete $scope.editQuestion.newQuestion;
             $scope.survey.attributes.push($scope.editQuestion);
         }


### PR DESCRIPTION
This pull request makes the following changes:
- Only change the priority of a question when either changing order by dragging/dropping or when adding a new question, not when editing an existing question.

Testing checklist:
1. Go to settings->survey->new survey->new targeted survey
2. Add a number of questions, remember the order
3. Reorder the questions, remember the order
4. Edit a question
Note, step 3 and 4 could be done in any order and how many time you would like, the outcome should still be: 
-  [ ] Click on continue, the list of questions should still be same as after the last reordering
- Publish survey
- [ ] Check the db, the priority should match the order of the questions


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
