### PR TITLE
2795 converting nums to E164

### DIFF
--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -1,4 +1,4 @@
-import { isValidNumber } from 'libphonenumber-js';
+import { isValidNumber, formatNumber, parse } from 'libphonenumber-js';
 // re-route if feature flag is not enabled
 module.exports = [
     '$scope',
@@ -167,6 +167,10 @@ function (
                 $scope.finalNumbers.badNumbersString = $scope.finalNumbers.badNumbersString + number + ',';
                 $scope.finalNumbers.badNumberCount = $scope.finalNumbers.badNumberCount + 1;
             } else if (isValidNumber(number, $scope.selectedCountry.country_code) && number.length) {
+                // parse() isn't as complete as isValidNumber(), but formatNumber() needs parsed data
+                //  so with this lib, we have to do _all_ of these things to get to E164
+                let parsedResult = parse(number, $scope.selectedCountry.country_code);
+                number = formatNumber(parsedResult, 'E.164');
                 if ($scope.finalNumbers.storageObj[number]) {
                     $scope.finalNumbers.repeatCount = $scope.finalNumbers.repeatCount + 1;
                 } else {

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -186,7 +186,7 @@ describe('setting create targeted survey controller', function () {
                     }
                 };
                 $scope.selectedCountry = { 'country_name': 'United States', 'dial_code': '+1', 'country_code': 'US' };
-                $scope.textBoxNumbers = '3172351967, 3176742327';
+                $scope.textBoxNumbers = '3175551967, 3175552327';
                 $scope.completeStepTwo();
                 expect($scope.activeStep).toEqual(3);
                 expect($scope.stepTwoWarning).toEqual(false);
@@ -199,7 +199,7 @@ describe('setting create targeted survey controller', function () {
                     }
                 };
                 $scope.selectedCountry = { 'country_name': 'United States', 'dial_code': '+1', 'country_code': 'US' };
-                $scope.textBoxNumbers = '3172351967, 3176742327, 123';
+                $scope.textBoxNumbers = '3175551967, 3175552327, 123';
                 $scope.completeStepTwo();
                 expect($scope.activeStep).toEqual(2);
                 expect($scope.stepTwoWarning).toEqual(false);
@@ -212,20 +212,20 @@ describe('setting create targeted survey controller', function () {
                     }
                 };
                 $scope.selectedCountry = { 'country_name': 'United States', 'dial_code': '+1', 'country_code': 'US' };
-                $scope.textBoxNumbers = '3172351967, 3176742327, 123';
+                $scope.textBoxNumbers = '3175551967, 3175552327, 123';
                 $scope.completeStepTwo();
                 expect($scope.activeStep).toEqual(2);
                 expect($scope.stepTwoWarning).toEqual(true);
             });
             it('should reset the phone number object, which enables user to add to/edit numbers', function () {
                 $scope.finalNumbers = {
-                    goodNumbers: ['3172351967', '3176742327'],
-                    goodNumbersString: '3172351967, 3176742327,',
+                    goodNumbers: ['3175551967', '3175552327'],
+                    goodNumbersString: '3175551967, 3175552327,',
                     badNumbersString: '12345',
                     repeatCount: 1,
                     storageObj: {
-                        '3172351967': '3172351967',
-                        '3176742327': '3176742327'
+                        '3175551967': '3175551967',
+                        '3175552327': '3175552327'
                     },
                     badNumberCount: 0
                 };
@@ -253,71 +253,71 @@ describe('setting create targeted survey controller', function () {
                 };
             });
             it('should validate phone numbers as GOOD numbers', function () {
-                $scope.runValidations('3172351967, 3176742327');
+                $scope.runValidations('3175551967, 3175552327');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['+13172351967', '+13176742327'],
-                    goodNumbersString: '+13172351967,+13176742327,',
+                    goodNumbers: ['+13175551967', '+13175552327'],
+                    goodNumbersString: '+13175551967,+13175552327,',
                     badNumbersString: '',
                     repeatCount: 0,
                     storageObj: {
-                        '+13172351967': '+13172351967',
-                        '+13176742327': '+13176742327'
+                        '+13175551967': '+13175551967',
+                        '+13175552327': '+13175552327'
                     },
                     badNumberCount: 0
                 });
             });
             it('should validate phone numbers with special characters as GOOD numbers', function () {
-                $scope.runValidations('317-235-1967, 317.674.2327');
+                $scope.runValidations('317-555-1967, 317.555.2327');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['+13172351967', '+13176742327'],
-                    goodNumbersString: '+13172351967,+13176742327,',
+                    goodNumbers: ['+13175551967', '+13175552327'],
+                    goodNumbersString: '+13175551967,+13175552327,',
                     badNumbersString: '',
                     repeatCount: 0,
                     storageObj: {
-                        '+13172351967': '+13172351967',
-                        '+13176742327': '+13176742327'
+                        '+13175551967': '+13175551967',
+                        '+13175552327': '+13175552327'
                     },
                     badNumberCount: 0
                 });
             });
             it('should remove duplicate numbers', function () {
-                $scope.runValidations('3172351967, 3176742327, 3172351967');
+                $scope.runValidations('3175551967, 3175552327, 3175551967');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['+13172351967', '+13176742327'],
-                    goodNumbersString: '+13172351967,+13176742327,',
+                    goodNumbers: ['+13175551967', '+13175552327'],
+                    goodNumbersString: '+13175551967,+13175552327,',
                     badNumbersString: '',
                     repeatCount: 1,
                     storageObj: {
-                        '+13172351967': '+13172351967',
-                        '+13176742327': '+13176742327'
+                        '+13175551967': '+13175551967',
+                        '+13175552327': '+13175552327'
                     },
                     badNumberCount: 0
                 });
             });
             it('should separate good and bad numbers', function () {
-                $scope.runValidations('3172351967, 3176742327, 3172351967, 12345');
+                $scope.runValidations('3175551967, 3175552327, 3175551967, 12345');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['+13172351967', '+13176742327'],
-                    goodNumbersString: '+13172351967,+13176742327,',
+                    goodNumbers: ['+13175551967', '+13175552327'],
+                    goodNumbersString: '+13175551967,+13175552327,',
                     badNumbersString: '12345,',
                     repeatCount: 1,
                     storageObj: {
-                        '+13172351967': '+13172351967',
-                        '+13176742327': '+13176742327'
+                        '+13175551967': '+13175551967',
+                        '+13175552327': '+13175552327'
                     },
                     badNumberCount: 1
                 });
             });
             it('should disregard empty elements', function () {
-                $scope.runValidations('3172351967, 3176742327, 3172351967, 12345,, ');
+                $scope.runValidations('3175551967, 3175552327, 3175551967, 12345,, ');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['+13172351967', '+13176742327'],
-                    goodNumbersString: '+13172351967,+13176742327,',
+                    goodNumbers: ['+13175551967', '+13175552327'],
+                    goodNumbersString: '+13175551967,+13175552327,',
                     badNumbersString: '12345,',
                     repeatCount: 1,
                     storageObj: {
-                        '+13172351967': '+13172351967',
-                        '+13176742327': '+13176742327'
+                        '+13175551967': '+13175551967',
+                        '+13175552327': '+13175552327'
                     },
                     badNumberCount: 1
                 });

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -280,6 +280,22 @@ describe('setting create targeted survey controller', function () {
                     badNumberCount: 0
                 });
             });
+            it('should not add country code if already included', function () {
+                $scope.runValidations('1 317 555 1961, 13175552327, 1-317-555-1967,  +1-317-555-1968');
+                expect($scope.finalNumbers).toEqual({
+                    goodNumbers: ['+13175551961', '+13175552327', '+13175551967', '+13175551968'],
+                    goodNumbersString: '+13175551961,+13175552327,+13175551967,+13175551968,',
+                    badNumbersString: '',
+                    repeatCount: 0,
+                    storageObj: {
+                        '+13175551961': '+13175551961',
+                        '+13175552327': '+13175552327',
+                        '+13175551967': '+13175551967',
+                        '+13175551968': '+13175551968'
+                    },
+                    badNumberCount: 0
+                });
+            });
             it('should remove duplicate numbers', function () {
                 $scope.runValidations('3175551967, 3175552327, 3175551967');
                 expect($scope.finalNumbers).toEqual({

--- a/test/unit/settings/surveys/targeted-edit.controller.spec.js
+++ b/test/unit/settings/surveys/targeted-edit.controller.spec.js
@@ -255,13 +255,13 @@ describe('setting create targeted survey controller', function () {
             it('should validate phone numbers as GOOD numbers', function () {
                 $scope.runValidations('3172351967, 3176742327');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['3172351967', '3176742327'],
-                    goodNumbersString: '3172351967,3176742327,',
+                    goodNumbers: ['+13172351967', '+13176742327'],
+                    goodNumbersString: '+13172351967,+13176742327,',
                     badNumbersString: '',
                     repeatCount: 0,
                     storageObj: {
-                        '3172351967': '3172351967',
-                        '3176742327': '3176742327'
+                        '+13172351967': '+13172351967',
+                        '+13176742327': '+13176742327'
                     },
                     badNumberCount: 0
                 });
@@ -269,13 +269,13 @@ describe('setting create targeted survey controller', function () {
             it('should validate phone numbers with special characters as GOOD numbers', function () {
                 $scope.runValidations('317-235-1967, 317.674.2327');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['317-235-1967', '317.674.2327'],
-                    goodNumbersString: '317-235-1967,317.674.2327,',
+                    goodNumbers: ['+13172351967', '+13176742327'],
+                    goodNumbersString: '+13172351967,+13176742327,',
                     badNumbersString: '',
                     repeatCount: 0,
                     storageObj: {
-                        '317-235-1967': '317-235-1967',
-                        '317.674.2327': '317.674.2327'
+                        '+13172351967': '+13172351967',
+                        '+13176742327': '+13176742327'
                     },
                     badNumberCount: 0
                 });
@@ -283,13 +283,13 @@ describe('setting create targeted survey controller', function () {
             it('should remove duplicate numbers', function () {
                 $scope.runValidations('3172351967, 3176742327, 3172351967');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['3172351967', '3176742327'],
-                    goodNumbersString: '3172351967,3176742327,',
+                    goodNumbers: ['+13172351967', '+13176742327'],
+                    goodNumbersString: '+13172351967,+13176742327,',
                     badNumbersString: '',
                     repeatCount: 1,
                     storageObj: {
-                        '3172351967': '3172351967',
-                        '3176742327': '3176742327'
+                        '+13172351967': '+13172351967',
+                        '+13176742327': '+13176742327'
                     },
                     badNumberCount: 0
                 });
@@ -297,13 +297,13 @@ describe('setting create targeted survey controller', function () {
             it('should separate good and bad numbers', function () {
                 $scope.runValidations('3172351967, 3176742327, 3172351967, 12345');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['3172351967', '3176742327'],
-                    goodNumbersString: '3172351967,3176742327,',
+                    goodNumbers: ['+13172351967', '+13176742327'],
+                    goodNumbersString: '+13172351967,+13176742327,',
                     badNumbersString: '12345,',
                     repeatCount: 1,
                     storageObj: {
-                        '3172351967': '3172351967',
-                        '3176742327': '3176742327'
+                        '+13172351967': '+13172351967',
+                        '+13176742327': '+13176742327'
                     },
                     badNumberCount: 1
                 });
@@ -311,13 +311,13 @@ describe('setting create targeted survey controller', function () {
             it('should disregard empty elements', function () {
                 $scope.runValidations('3172351967, 3176742327, 3172351967, 12345,, ');
                 expect($scope.finalNumbers).toEqual({
-                    goodNumbers: ['3172351967', '3176742327'],
-                    goodNumbersString: '3172351967,3176742327,',
+                    goodNumbers: ['+13172351967', '+13176742327'],
+                    goodNumbersString: '+13172351967,+13176742327,',
                     badNumbersString: '12345,',
                     repeatCount: 1,
                     storageObj: {
-                        '3172351967': '3172351967',
-                        '3176742327': '3176742327'
+                        '+13172351967': '+13172351967',
+                        '+13176742327': '+13176742327'
                     },
                     badNumberCount: 1
                 });


### PR DESCRIPTION
According to our friends at TenFour, all of our SMS providers will accept a number in the E164 format standard, so as a rule, they use that exclusively throughout TenFour. Based on that recommendation, I'm doing that conversion in the client along with the other validations that happen prior to storing numbers in storageObject. 

This pull request makes the following changes:
- Adds code to convert all phone numbers to E164 format before storing and sending to API
- Updates tests to expect E164 format
- Adds test to ensure that country code is properly ignored if included (this was apparently a problem with some ports of libphonenumber)

Testing checklist:
- [ ] Configure twilio as dataprovider
- [x] Create a targeted survey with various phone numbers of a selected country
- [x] Review requests to API to ensure that numbers are correctly formatted
- [ ] send a message with a targeted survey to phone numbers in various formats, ensure that they are all correctly sent

- [x] I certify that I ran my checklist

Ping @ushahidi/platform