### PR TITLE
Bugfix/2838

### DIFF
--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -101,8 +101,8 @@ function (
             $scope.selectedFields[form.id] = [];
         } else {
             _.each(form.attributes, function (attribute) {
-                if (!_.contains($scope.selectedFields[form.id], attribute.id)) {
-                    $scope.selectedFields[form.id].push(attribute.id);
+                if (!_.contains($scope.selectedFields[form.id], attribute.key)) {
+                    $scope.selectedFields[form.id].push(attribute.key);
                 }
             });
         }

--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -90,8 +90,8 @@
                         <input
                             type="checkbox"
                             checklist-model="selectedFields[form.id]"
-                            checklist-value="attribute.id"
-                            value="attribute.id"
+                            checklist-value="attribute.key"
+                            value="attribute.key"
                         >
                         <bdi>{{attribute.label}}</bdi>
                     </label>

--- a/test/unit/settings/data-export/data-export.controller.spec.js
+++ b/test/unit/settings/data-export/data-export.controller.spec.js
@@ -109,19 +109,19 @@ describe('data-export-controller', function () {
             expect($scope.selectedFields[5]).toBeDefined();
         });
         it('should remove attributes from selectedFields if they are already there', function () {
-            $scope.selectedFields[5] = [1,3,5];
-            $scope.selectAll({id: 5, attributes: [{id: 1}, {id: 3}, {id: 5}]});
+            $scope.selectedFields[5] = ['key1', 'key3', 'key5'];
+            $scope.selectAll({id: 5, attributes: [{id: 1, key: 'key1'}, {id: 3, key: 'key3'}, {id: 5, key: 'key5'}]});
             expect($scope.selectedFields[5]).toEqual([]);
         });
         it('should add all attributes to selectedFields if only some are selected', function () {
-            $scope.selectedFields[5] = [1,3];
-            $scope.selectAll({id: 5, attributes: [{id: 1}, {id: 3}, {id: 5}]});
-            expect($scope.selectedFields[5]).toEqual([1, 3, 5]);
+            $scope.selectedFields[5] = ['key1', 'key3'];
+            $scope.selectAll({id: 5, attributes: [{id: 1, key: 'key1'}, {id: 3, key: 'key3'}, {id: 5, key: 'key5'}]});
+            expect($scope.selectedFields[5]).toEqual(['key1', 'key3', 'key5']);
         });
         it('should add all attributes to selectedFields if none is selected', function () {
             $scope.selectedFields[4] = [];
-            $scope.selectAll({id: 4, attributes: [{id: 1}, {id: 3}, {id: 5}]});
-            expect($scope.selectedFields[4]).toEqual([1, 3, 5]);
+            $scope.selectAll({id: 4, attributes: [{id: 1, key: 'key1'}, {id: 3, key: 'key3'}, {id: 5, key: 'key5'}]});
+            expect($scope.selectedFields[4]).toEqual(['key1', 'key3', 'key5']);
         });
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Change attribute.id to attribute.key since the backend for postvalue uses key, not ids

Testing checklist:

### Demo script

- [x] In the export screen, click **Select fields**. 
- [x] A **Select fields for export...** screen appears, along with a list of all human-readable field names for each available survey type
- [x] Select individual checkboxes. 
- [x] Uncheck one of the checks you selected before and check it again. 
- [x] Open chrome dev tools. Click the export data button.
    - [x] When the job is requested, the `fields` param is sent with the keys of the attributes you selected

------------------

- [x] Select **Select all...** checkbox for a survey
    - [x] all checkboxes are selected for that survey
- [x] If all survey fields are checked:
    - [x] the **Select all...** checkbox remains checked


Fixes ushahidi/platform# .

Ping @ushahidi/platform
