### PR TITLE
fix: Url encode emails before passing them to cloud UI

### DIFF
--- a/app/settings/plans/plans.controller.js
+++ b/app/settings/plans/plans.controller.js
@@ -25,7 +25,7 @@ function (
             $scope.specialPlan = site.tier;
         }
     });
-    $scope.username = ($rootScope.currentUser || {}).email;
+    $scope.username = encodeURIComponent(($rootScope.currentUser || {}).email);
     /* globals apiDomain, deploymentsDomain */
     $scope.cloudDomain = typeof deploymentsDomain !== 'undefined' ? deploymentsDomain : 'ushahidi.io' ;
     $scope.subdomain = typeof apiDomain !== 'undefined' ?


### PR DESCRIPTION
This pull request makes the following changes:
- Url encode emails before passing them to cloud UI

Testing checklist:
- [ ] Create a user and deployment in ushahidi.io. The email should be in a format like "yourusername+1234@ushahidi.com"
- [ ] Log in to new deployment
- [ ] Go to settings/plans
- [ ] Try to upgrade to a responder plan
- [ ] You are able to pass the password confirmation and enter credit card details

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2806

Ping @ushahidi/platform
