### PR TITLE
Migration/link api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,8 @@
     "rules": {
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
         "prettier/prettier": ["error"],
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+        "jsx-a11y/anchor-is-valid": [ "error", { "components": [ "Link" ], "specialLink": [ "to" ], "aspects": [ "noHref", "invalidHref", "preferButton" ] } ]
+
     }
 }

--- a/app/react-transition/Link.jsx
+++ b/app/react-transition/Link.jsx
@@ -23,8 +23,7 @@ class Link extends React.Component {
     };
   }
 
-  handleClick(event) {
-    event.preventDefault();
+  handleClick() {
     return this.props.replace
       ? this.state.stateProvider.go(
           this.props.to,

--- a/app/react-transition/Link.jsx
+++ b/app/react-transition/Link.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class Link extends React.Component {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const injector = angular.element(document).injector();
+    const state = injector.get("$state");
+    return {
+      stateProvider: state
+    };
+    // not sure if this is working here
+    if (nextProps.to !== prevState.to) {
+      return {
+        to: this.constructedTo(nextProps.to)
+      };
+    }
+  }
+
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.state = {
+      stateProvider: undefined,
+      to: this.constructedTo(this.props.to)
+    };
+  }
+
+  constructedTo(toFromProps) {
+    // Strings need be defined before concatenating
+    const to =
+      typeof toFromProps === "string"
+        ? toFromProps
+        : toFromProps.pathname + toFromProps.search + toFromProps.hash;
+    return to;
+  }
+
+  handleClick(event) {
+    event.preventDefault();
+    this.props.replace
+      ? this.state.stateProvider.go(
+          this.state.to,
+          {},
+          { location: this.props.replace }
+        )
+      : this.state.stateProvider.go(this.state.to);
+  }
+
+  render() {
+    return (
+      <div>
+        <a
+          href="#"
+          onClick={this.handleClick}
+          title={this.props.title}
+          id={this.props.id}
+          className={this.props.className}
+        >
+          {this.props.children}
+        </a>
+      </div>
+    );
+  }
+}
+
+Link.defaultProps = {
+  replace: false,
+  title: '',
+  id: '',
+  className: ''
+};
+
+Link.propTypes = {
+  to: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.objectOf(PropTypes.string)
+  ]).isRequired,
+  replace: PropTypes.bool,
+  title: PropTypes.string,
+  id: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired
+};
+
+export default Link;

--- a/app/react-transition/Link.jsx
+++ b/app/react-transition/Link.jsx
@@ -64,9 +64,9 @@ class Link extends React.Component {
 
 Link.defaultProps = {
   replace: false,
-  title: '',
-  id: '',
-  className: ''
+  title: "",
+  id: "",
+  className: ""
 };
 
 Link.propTypes = {

--- a/app/react-transition/Link.jsx
+++ b/app/react-transition/Link.jsx
@@ -1,56 +1,45 @@
 import React from "react";
 import PropTypes from "prop-types";
+import angular from "angular";
+
+// Note: Link objects and innerRef are not implemented.
+// If you need them, you'll have to implement them yourself
+// Talk to Carolyn about starter code
 
 class Link extends React.Component {
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps() {
     const injector = angular.element(document).injector();
     const state = injector.get("$state");
     return {
       stateProvider: state
     };
-    // not sure if this is working here
-    if (nextProps.to !== prevState.to) {
-      return {
-        to: this.constructedTo(nextProps.to)
-      };
-    }
   }
 
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
     this.state = {
-      stateProvider: undefined,
-      to: this.constructedTo(this.props.to)
+      stateProvider: undefined
     };
-  }
-
-  constructedTo(toFromProps) {
-    // Strings need be defined before concatenating
-    const to =
-      typeof toFromProps === "string"
-        ? toFromProps
-        : toFromProps.pathname + toFromProps.search + toFromProps.hash;
-    return to;
   }
 
   handleClick(event) {
     event.preventDefault();
-    this.props.replace
+    return this.props.replace
       ? this.state.stateProvider.go(
-          this.state.to,
+          this.props.to,
           {},
           { location: this.props.replace }
         )
-      : this.state.stateProvider.go(this.state.to);
+      : this.state.stateProvider.go(this.props.to);
   }
-
+/* eslint-disable */
   render() {
     return (
       <div>
         <a
-          href="#"
           onClick={this.handleClick}
+          href="#"
           title={this.props.title}
           id={this.props.id}
           className={this.props.className}
@@ -61,6 +50,7 @@ class Link extends React.Component {
     );
   }
 }
+/* eslint-enable */
 
 Link.defaultProps = {
   replace: false,
@@ -70,10 +60,7 @@ Link.defaultProps = {
 };
 
 Link.propTypes = {
-  to: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.objectOf(PropTypes.string)
-  ]).isRequired,
+  to: PropTypes.string.isRequired,
   replace: PropTypes.bool,
   title: PropTypes.string,
   id: PropTypes.string,

--- a/app/react-transition/Link.spec.jsx
+++ b/app/react-transition/Link.spec.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
+import angular from "angular";
+import uirouter from "@uirouter/angularjs";
 import Link from "./Link";
+
+beforeAll(() => {
+  angular.module("testApp", [uirouter]);
+  angular.bootstrap(document, ["testApp"]);
+});
 
 test("Link accepts a route string, replace bool, id, className, title, and children", () => {
   const component = renderer.create(

--- a/app/react-transition/Link.spec.jsx
+++ b/app/react-transition/Link.spec.jsx
@@ -2,11 +2,14 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import angular from "angular";
-import uirouter from "@uirouter/angularjs";
 import Link from "./Link";
 
+const mockState = {
+    "go": jest.fn()
+};
+
 beforeAll(() => {
-  angular.module("testApp", [uirouter]);
+  angular.module("testApp", []).service("$state", () => mockState);
   angular.bootstrap(document, ["testApp"]);
 });
 
@@ -21,8 +24,8 @@ test("Link accepts a route string, replace bool, id, className, title, and child
 });
 
 test("Link routes to new component", () => {
-  const mockNavigation = jest.fn();
   const link = shallow(<Link to="posts.data">Click me!</Link>);
   link.find("a").simulate("click");
-  expect(mockNavigation.mock.calls.length).toEqual(1);
+  expect(mockState.go).toHaveBeenCalledTimes(1);
+  expect(mockState.go).toHaveBeenCalledWith("posts.data");
 });

--- a/app/react-transition/Link.spec.jsx
+++ b/app/react-transition/Link.spec.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Link from "./Link";
+
+test("Link accepts a route string, replace bool, id, className, title, and children", () => {
+  const component = renderer.create(
+    <Link to="posts.data" replace id="test" className="test" title="test">
+      Click me!
+    </Link>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Link routes to new component", () => {
+  const mockNavigation = jest.fn();
+  const link = shallow(<Link to="posts.data">Click me!</Link>);
+  link.find("a").simulate("click");
+  expect(mockNavigation.mock.calls.length).toEqual(1);
+});

--- a/app/react-transition/__snapshots__/Link.spec.jsx.snap
+++ b/app/react-transition/__snapshots__/Link.spec.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link accepts a route string, replace bool, id, className, title, and children 1`] = `
+<div>
+  <a
+    className="test"
+    href="#"
+    id="test"
+    onClick={[Function]}
+    title="test"
+  >
+    Click me!
+  </a>
+</div>
+`;

--- a/app/settings/TestRouteContainer.jsx
+++ b/app/settings/TestRouteContainer.jsx
@@ -1,21 +1,28 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
+import Link from "../react-transition/Link";
 
-const TestRouteContainer = props => {
-    console.log(props);
-    return (
-        <div><main role="main">
-            <h1>Hello from react</h1>
-            { props.id }
-            <a onClick={ () =>  { props.state.go('posts.data') } }>Click me</a>
-            <a href="/views/map">Click me</a>
-        </main></div>
-    );
-}
+const TestRouteContainer = props => (
+  <div>
+    <main role="main">
+      <h1>Hello from react</h1>
+      {props.id}
+      <a href="/views/map">Click me</a>
+      <Link to="posts.data">Testing a link string</Link>
+      <Link
+        to={{
+          to: "posts.data",
+          hash: "#the-hash"
+        }}
+      >
+        testing a link object?????
+      </Link>
+    </main>
+  </div>
+);
 
-// TestRouteContainer.propTypes = {
-//     state: PropTypes.any.required,
-//     id: PropTypes.string
-// };
+TestRouteContainer.propTypes = {
+  id: PropTypes.string.isRequired
+};
 
 export default TestRouteContainer;

--- a/app/settings/TestRouteContainer.jsx
+++ b/app/settings/TestRouteContainer.jsx
@@ -7,16 +7,7 @@ const TestRouteContainer = props => (
     <main role="main">
       <h1>Hello from react</h1>
       {props.id}
-      <a href="/views/map">Click me</a>
-      <Link to="posts.data">Testing a link string</Link>
-      <Link
-        to={{
-          to: "posts.data",
-          hash: "#the-hash"
-        }}
-      >
-        testing a link object?????
-      </Link>
+      <Link to="posts.data">Click me! I&apos;m a &lt;Link&gt; tag</Link>
     </main>
   </div>
 );

--- a/app/settings/settings.module.js
+++ b/app/settings/settings.module.js
@@ -33,9 +33,6 @@ angular
   .directive("customWebhooks", require("./webhooks/webhooks.directive.js"))
   .directive("customWebhooksEditor", require("./webhooks/editor.directive.js"))
 
-  .component(
-    "testRouteContainer",
-    react2angular(TestRouteContainer, ["state", "id"])
-  )
+  .component("testRouteContainer", react2angular(TestRouteContainer, ["id"]))
 
   .config(require("./settings.routes.js"));

--- a/app/settings/settings.routes.js
+++ b/app/settings/settings.routes.js
@@ -205,8 +205,7 @@ module.exports = [
             $scope.id = $transition$.params().id;
           }
         ],
-        template:
-          '<test-route-container state="$state" id="id"></test-route-container>'
+        template: '<test-route-container id="id"></test-route-container>'
       });
   }
 ];


### PR DESCRIPTION
This pull request makes the following changes:
- Creates a Link component that returns <a> tag that will navigate to angular or react components

Testing checklist:
- [ ] Go to /settings/testroute/1 and click the link
- [ ] you should be taken to data view
Tests fail because of problems with angular and jest

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
