### PR TITLE
Feature/export hdx data to api

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1113,7 +1113,14 @@
         "hxl_instructions_9": "HXL 'cheat sheet'",
         "HXL_tags": "HXL tags",
         "HXL_attributes": "HXL attributes",
-        "tag_preview": "Tag preview"
+        "tag_preview": "Tag preview",
+        "upload_title": "Are you ready to upload to an Humanitarian Data Exchange (HDX) account?",
+        "hdx_csv_title": "Are you ready to export to CSV?",
+        "upload_desc": "You selected {{fields}} fields to upload to a Humanitarian Data Exchange (HDX) account. <br /> <br /> You assigned tags and attributes - to check, you can go back. If you are done, you can add details and upload. <br /> <br /> The Humanitarian Data Exchange (HDX) requires a few more details in order to upload to their system. You'll add these next",
+        "hdx_csv_desc": "You selected {{fields}} fields to export to CSV.<br /> <br /> You assigned tags and attributes - to check these are correct, you can go back and check. If you're done, you can export.",
+        "upload_button": "Add dataset details and upload to hdx",
+        "export_button": "Export to csv",
+        "go_back": "Go back and check"
     },
     "user": {
         "role_display" : "Role: {{role}}",

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -156,7 +156,12 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
             }
             let buttonText = button ? button : 'message.button.default';
             let cancelButtonText = cancel ? cancel : 'message.button.cancel';
-            let template = '<div class="form-field">' + descriptionTemplate + '<p><i translate>notify.default.proceed_warning</i></p>' + `<button class="button" ng-click="$parent.cancel()" translate>${cancelButtonText}</button>` + `<button class="button-alpha button-flat" ng-click="$parent.confirm()" translate>${buttonText}</button>` + '</div>';
+            let template = `<div class="form-field">
+                                ${descriptionTemplate}
+                                <p><i translate>notify.default.proceed_warning</i></p>
+                                <button class="button" ng-click="$parent.cancel()" translate>${cancelButtonText}</button>
+                                <button class="button-alpha button-flat" ng-click="$parent.confirm()" translate>${buttonText}</button>
+                            </div>`;
 
             ModalService.openTemplate(
                 template, confirmText, false, scope, false, false);

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -133,7 +133,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
         return deferred.promise;
     }
 
-    function confirmModal(confirmText, translateValues, description, descriptionValues, button) {
+    function confirmModal(confirmText, translateValues, description, descriptionValues, button, cancel) {
         var deferred = $q.defer();
 
         var scope = getScope();
@@ -155,7 +155,8 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService) {
                 descriptionTemplate = `<p translate=${description} translate-values="${descriptionValues}"></p>`;
             }
             let buttonText = button ? button : 'message.button.default';
-            let template = '<div class="form-field">' + descriptionTemplate + '<p><i translate>notify.default.proceed_warning</i></p>' + '<button class="button-flat" ng-click="$parent.cancel()" translate="message.button.cancel">Cancel</button>' + `<button class="button-beta button-flat" ng-click="$parent.confirm()" translate>${buttonText}</button>` + '</div>';
+            let cancelButtonText = cancel ? cancel : 'message.button.cancel';
+            let template = '<div class="form-field">' + descriptionTemplate + '<p><i translate>notify.default.proceed_warning</i></p>' + `<button class="button" ng-click="$parent.cancel()" translate>${cancelButtonText}</button>` + `<button class="button-alpha button-flat" ng-click="$parent.confirm()" translate>${buttonText}</button>` + '</div>';
 
             ModalService.openTemplate(
                 template, confirmText, false, scope, false, false);

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -5,6 +5,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
     var exportJobs = [];
     function startExport(query) {
         query.entity_type = 'post';
+
         // saving the new job to the db
         ExportJobEndpoint.save(query).$promise.then(function (job) {
             updateExportJobsList(job);

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -4,18 +4,22 @@ module.exports = [
     'Features',
     '$location',
     'HxlExport',
+    'DataExport',
     '_',
     'LoadingProgress',
+    'Notify',
 function (
     $scope,
     $rootScope,
     Features,
     $location,
     HxlExport,
+    DataExport,
     _,
-    LoadingProgress
+    LoadingProgress,
+    Notify
 ) {
-    $scope.selectAttribute = selectHxlAttribute;
+    $scope.selectHxlAttribute = selectHxlAttribute;
     $scope.addAnother = addAnother;
     $scope.range = range;
     $scope.selectTag = selectTag;
@@ -116,37 +120,63 @@ function (
     }
 
     function formatIds() {
-        let data = [];
+        let hxlData = [];
         _.each($scope.forms, (form) => {
             _.each(form.attributes, (formAttribute) => {
                 if (formAttribute.selected && formAttribute.selected.length > 0) {
-                    let ids = {
-                            form_attribute_id : formAttribute.id,
-                            hxl_tag: null
-                        };
-
-                    if (formAttribute.selectedTag) {
-                        ids.hxl_tag = {
-                            hxl_tag_id: formAttribute.selectedTag.id
-                        };
-
-                        if (formAttribute.selectedHxlAttributes) {
-                            ids.hxl_tag.hxl_attribute_ids = [];
-                            _.each(formAttribute.selectedHxlAttributes, (hxlAttribute) => {
-                                ids.hxl_tag.hxl_attribute_ids.push(hxlAttribute.id);
-                            });
-                        }
+                    let obj = formAttribute.selectedTag ? {form_attribute_id: formAttribute.id, hxl_tag_id: formAttribute.selectedTag.id} : {form_attribute_id: formAttribute.id};
+                    if (formAttribute.selectedHxlAttributes && !_.isEmpty(formAttribute.selectedHxlAttributes)) {
+                        _.each(formAttribute.selectedHxlAttributes, (hxlAttribute) => {
+                            let objWithAttr = angular.copy(obj);
+                            objWithAttr.hxl_attribute_id = hxlAttribute.id;
+                            hxlData.push(objWithAttr);
+                        });
+                    } else {
+                        hxlData.push(obj);
                     }
-                    data.push(ids);
                 }
             });
         });
-        return data;
+        return hxlData;
     }
 
-    function exportData() {
-        let data = formatIds();
-        //Connect to endpoint
-        console.log(data);
+    function exportData(sendToHDX) {
+        if (formatIds().length === 0) {
+            // displaying notification if no fields are selected
+            var message =  '<p translate="data_export.no_fields"></p>';
+            Notify.notifyAction(message, null, false, 'warning', 'error');
+        } else {
+            let title, description, button, cancel;
+            let data = {
+                'fields': 'test',
+                'filters':
+                {
+                    'status' : ['published','draft'],
+                    'has_location' : 'all',
+                    'orderby' : 'created',
+                    'order' : 'desc',
+                    'order_unlocked_on_top' : 'true',
+                    'source' : ['sms','twitter','web','email']
+                },
+                'send_to_hdx': sendToHDX,
+                'include_hxl': sendToHDX,
+                'send_to_browser': !sendToHDX,
+                'hxl_heading_row': formatIds()
+            };
+            if (sendToHDX) {
+                title = 'data_export.upload_title';
+                description = 'data_export.upload_desc';
+                button = 'data_export.upload_button';
+            } else {
+                title = 'data_export.hdx_csv_title';
+                description = 'data_export.hdx_csv_desc';
+                button = 'data_export.export_button';
+            }
+            cancel = 'data_export.go_back';
+
+            Notify.confirmModal(title, null, description, `{fields: ${getSelectedFields()}}`, button, cancel).then(() => {
+                DataExport.startExport(data);
+            });
+        }
     }
 }];

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -89,11 +89,11 @@ function (
     }
 
     function getSelectedFields() {
-        let selectedFields = 0;
+        let selectedFields = [];
         _.each($scope.forms, (form) => {
             _.each(form.attributes, (attribute) => {
                 if (attribute.selected && attribute.selected.length > 0) {
-                    selectedFields++;
+                    selectedFields.push(attribute.id);
                 }
             });
         });
@@ -149,7 +149,7 @@ function (
         } else {
             let title, description, button, cancel;
             let data = {
-                'fields': 'test',
+                'fields': $scope.getSelectedFields(),
                 'filters':
                 {
                     'status' : ['published','draft'],
@@ -164,6 +164,7 @@ function (
                 'send_to_browser': !sendToHDX,
                 'hxl_heading_row': formatIds()
             };
+
             if (sendToHDX) {
                 title = 'data_export.upload_title';
                 description = 'data_export.upload_desc';
@@ -173,9 +174,10 @@ function (
                 description = 'data_export.hdx_csv_desc';
                 button = 'data_export.export_button';
             }
+
             cancel = 'data_export.go_back';
 
-            Notify.confirmModal(title, null, description, `{fields: ${getSelectedFields()}}`, button, cancel).then(() => {
+            Notify.confirmModal(title, null, description, `{fields: ${getSelectedFields().length}}`, button, cancel).then(() => {
                 DataExport.startExport(data);
             });
         }

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -124,11 +124,12 @@ function (
         _.each($scope.forms, (form) => {
             _.each(form.attributes, (formAttribute) => {
                 if (formAttribute.selected && formAttribute.selected.length > 0) {
+                    // checking if there is a tag selected. If not, there will be no hxl-attributes selected either
                     let obj = formAttribute.selectedTag ? {form_attribute_id: formAttribute.id, hxl_tag_id: formAttribute.selectedTag.id} : {form_attribute_id: formAttribute.id};
                     if (formAttribute.selectedHxlAttributes && !_.isEmpty(formAttribute.selectedHxlAttributes)) {
                         _.each(formAttribute.selectedHxlAttributes, (hxlAttribute) => {
                             let objWithAttr = angular.copy(obj);
-                            objWithAttr.hxl_attribute_id = hxlAttribute.id;
+                            objWithAttr.hxl_attribute_id = parseInt(hxlAttribute.id);
                             hxlData.push(objWithAttr);
                         });
                     } else {

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -93,7 +93,7 @@ function (
         _.each($scope.forms, (form) => {
             _.each(form.attributes, (attribute) => {
                 if (attribute.selected && attribute.selected.length > 0) {
-                    selectedFields.push(attribute.id);
+                    selectedFields.push(attribute.key);
                 }
             });
         });

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -143,9 +143,9 @@
                     </table>
                 </fieldset>
                 <div class="form-field"  ng-hide="isLoading()">
-                    <p>{{getSelectedFields()}} fields selected</p>
+                    <p>{{getSelectedFields().length}} fields selected</p>
                 </div>
-                <div class="form-field button-group" ng-hide="isLoading()">
+                <div class="form-field button-group">
                     <button class="button-alpha" ng-click="exportData(false)">Export to CSV</button>
                     <a ng-click="exportData(true)" class="button button-alpha">Upload to a hdx account</a>
                     <a ui-sref="settings.dataExport" class="button">Cancel</a>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -136,7 +136,7 @@
                                     <a ng-click="addAnother(formAttribute)" class="link-blue">Add another hxl attribute?</a>
                                 </td>
                                 <td>
-                                    {{attribute.pretty}}
+                                    {{formAttribute.pretty}}
                                 </td>
                             </tr>
                         </tbody>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -146,8 +146,8 @@
                     <p>{{getSelectedFields()}} fields selected</p>
                 </div>
                 <div class="form-field button-group" ng-hide="isLoading()">
-                    <button class="button-alpha" ng-click="exportData()">Export to CSV</button>
-                    <a ng-click="exportData()" class="button button-alpha">Upload to a hdx account</a>
+                    <button class="button-alpha" ng-click="exportData(false)">Export to CSV</button>
+                    <a ng-click="exportData(true)" class="button button-alpha">Upload to a hdx account</a>
                     <a ui-sref="settings.dataExport" class="button">Cancel</a>
             </div>
             </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Sends data with hdx-tags/attributes to the export-job-endpoint

Testing checklist:
- Go to data-export->assign tags and attributes
- Assign a couple of fields without tags/attributes
- Assign a couple of fields with only tags
- Assign a couple of fields with tags and attributes
- Click on Export to CSV
- [ ] This modal should appear: 
![screen shot 2018-05-16 at 18 11 54](https://user-images.githubusercontent.com/8624777/40129468-a9d537e0-5934-11e8-91a7-3802257619d5.png)

- Click "go back and change"
- [ ] You should go back to previous screen, all fields and tags as they where before
- Click on Export to CSV again + click "Export"
-  [ ] Export-job should start (designs after this step will be covered by next pr)

Repeat above but click 'upload to Hdx'
- [ ] This modal should appear: 
![screen shot 2018-05-16 at 18 14 06](https://user-images.githubusercontent.com/8624777/40129608-feca8534-5934-11e8-9509-e6bce946da79.png)
- Click "go back and change"
- [ ] You should go back to previous screen, all fields and tags as they where before
- Click on "add dataset details..."-button
- [ ] An export-job is started and you see a notification-bar (this shouldnt happen in this step but will be covered by next pr)


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
