### PR TITLE
fix: configure api key should go to usersettings screen, not hdx

### DIFF
--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -79,10 +79,7 @@
                         <div class="alert" >
                             <p>{{'data_export.hxl_apikey_alert_1' | translate}}</p>
                             <p>{{'data_export.hxl_apikey_alert_2' | translate}}
-                            <a href="https://data.humdata.org/" class="link-blue" target="_blank">
-                                <svg class="iconic">
-                                    <use xlink:href="/img/iconic-sprite.svg#external-link"></use>
-                                </svg>
+                            <a ui-sref="settings.userSettings" class="link-blue">
                                 {{'data_export.hxl_configure' | translate}}
                             </a>
                                 {{'data_export.hxl_apikey_alert_3' | translate}}


### PR DESCRIPTION
This pull request makes the following changes:
- changes external HDX link to internal link to user settings. 

Testing checklist:
- [ ] when you go to the export screen and get the warning to configure your user api key, the link should take you to the user settings screen (NOT HDX)

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
