### PR TITLE
3038 targeted survey edit

### DIFF
--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -87,6 +87,31 @@ function (
     $scope.totalRecipients = 0;
     $scope.totalSent = 0;
     $scope.totalPending = 0;
+    $scope.default_attributes = [
+        {
+            cardinality: 0,
+            input: 'text',
+            label: 'Title',
+            priority: 1,
+            required: true,
+            type: 'title',
+            options: [],
+            config: {},
+            form_stage_id: null
+        },
+        {
+            cardinality: 0,
+            input: 'text',
+            label: 'Description',
+            priority: 2,
+            required: true,
+            type: 'description',
+            options: [],
+            config: {},
+            form_stage_id: null
+        }
+    ];
+
     Features.loadFeatures()
            .then(() => {
             $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
@@ -301,8 +326,10 @@ function (
 
 
     function saveFormStageAttributes(id) {
+
+        var attributes = $scope.default_attributes.concat($scope.survey.attributes);
         let task = {
-            attributes: $scope.survey.attributes,
+            attributes: attributes,
             formId: id,
             is_public: true,
             label: 'Post',
@@ -321,7 +348,7 @@ function (
             .then(function (savedTask) {
                 $scope.survey.stageId = savedTask.id;
                 let questions = [];
-                _.each($scope.survey.attributes, function (question) {
+                _.each(attributes, function (question) {
                         question.form_stage_id = savedTask.id;
                         question.formId = id;
                         questions.push(FormAttributeEndpoint

--- a/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
+++ b/app/settings/surveys/targeted-surveys/targeted-edit.controller.js
@@ -308,7 +308,8 @@ function (
 
     function saveContacts(id) {
         FormContactEndpoint.save({formId: id, contacts: $scope.textBoxNumbers, country_code: $scope.selectedCountry.country_code}).$promise.then(function (response) {
-            let messages = $scope.finalNumbers.goodNumbers.length * $scope.survey.attributes.length;
+            // Ensure that title and description are not taken into consideration when counting number of messages to send
+            let messages = $scope.finalNumbers.goodNumbers.length * ($scope.survey.attributes.length - 2);
             let notifyMessage = messages === 1 ? 'survey.targeted_survey.publish_notification_one' : 'survey.targeted_survey.publish_notification_many';
             Notify.notifyAction(notifyMessage, {messages}, false, 'thumb-up', 'circle-icon confirmation', {callback: goToDataView, text: 'survey.targeted_survey.notification_button', callbackArg: id, actionClass: 'button button-alpha'});
             $state.go('settings.surveys', {}, { reload: true });

--- a/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
+++ b/app/settings/surveys/targeted-surveys/targeted-survey-edit.html
@@ -195,7 +195,7 @@
 
                             <div class="form-field" ng-show="isActiveStep(3)">
                                 <ul id="listWithHandle" class="sortble-list">
-                                    <li class="sortable-list-item" ng-repeat="question in survey.attributes" data={{question.label}}>
+                                    <li class="sortable-list-item" ng-repeat="question in survey.attributes" data={{question.label}} ng-hide="question.type === 'title' || question.type === 'description'">
                                         <span class="list-handle">
                                             <svg class="iconic">
                                                  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#grid-four-up"></use>
@@ -209,7 +209,7 @@
                                 <a ng-hide="survey.attributes.length" ng-click="openQuestionModal(null)" translate="survey.targeted_survey.add_a_question">Add a question...</a>
                             </div>
                             <div ng-hide="isActiveStep(3)">
-                                    <p ng-repeat="question in survey.attributes | orderBy: 'priority'">{{question.label}}</p>
+                                    <p ng-repeat="question in survey.attributes | orderBy: 'priority'" ng-hide="question.type === 'title' || question.type === 'description'">{{question.label}}</p>
                             </div>
 
 


### PR DESCRIPTION
This pull request makes the following changes:
- This fixes the issue where targeted surveys do not correctly create Title and Description attributes when they are saved

Testing checklist:
- [x] With Targeted-Surveys enabled
- [x] Go to Settings/Surveys -> new survey -> Send a targeted survey via SMS >
- [x] Create and save a targeted survey
- [x] Go to data view
  - [x] You should see a new Post created for each of the recipients of your targeted survey
  - [x] Select a post, click edit, change a field and save
  - [x] The Post should save successfully.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3038

Ping @ushahidi/platform
