### PR TITLE
3039 messages missing from post edit

### DIFF
--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -59,6 +59,7 @@
           ng-if="form"
         >
         </post-tabs>
+        <post-messages post="post" ng-if="post.contact.id"></post-messages>
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
 

--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -88,6 +88,8 @@
              medias="medias"
              visible-stage="visibleStage">
           </post-tabs>
+
+          <post-messages post="post" ng-if="post.contact.id"></post-messages>
           <!-- <div class="form-sheet">
             <div class="form-sheet-actions">
                   <div class="form-field" ng-show="!post.id">


### PR DESCRIPTION
This pull request makes the following changes:
- Adding conversation with author section to post edit views

Testing checklist:
- [ ] Follow test checklist for [3038](https://github.com/ushahidi/platform-client/pull/1164)
- [ ] On the Post edit view for one of the Posts generated for the recipients of the targeted survey you should see the conversation with author section below the Post fields section

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3039

Ping @ushahidi/platform
