### PR TITLE
fix(i18n): lower language completion threshold to get more languages in

### DIFF
--- a/gulp/transifex-download.js
+++ b/gulp/transifex-download.js
@@ -6,8 +6,8 @@ let dotenv       = require('dotenv'),
 let project_slug = 'ushahidi-v3',
     mode = 'default',
     resource = 'client-en',
-    // Get languages that are at least 90% translated
-    completion_threshold = 70;
+    // Get languages that are at least 60% translated
+    completion_threshold = 60;
 
 function getCompletedLanguages(transifex) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This pull request makes the following changes:
- lowers the completion threshold that determines whether a language is pulled from transifex or not

we have included many new strings recently, which has brought many languages below the threshold

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
