### PR TITLE
test(ush-logo-react): Fix props for UshLogoReact component in tests

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -216,7 +216,7 @@ angular
         }
     ])
 
-    .component("myComponent", react2angular(MyComponent));
+    .component("myComponent", react2angular(MyComponent, ['foo', 'baz']));
 
 // Load submodules
 require("./directives/adaptive-input.js");

--- a/app/common/directives/ush-logo-react/ugh-logo.spec.jsx
+++ b/app/common/directives/ush-logo-react/ugh-logo.spec.jsx
@@ -5,18 +5,25 @@ import { PlainUshLogo as MyComponent } from "./ush-logo";
 
 test("foo and bar match the props", () => {
   const forms = [{ id: "junk" }];
+  const actions = {
+  	receiveForms: jest.fn()
+  };
   // Note that the way you pass down props in react vs. angular is different
   // Therefore you need pass down props differently
   const component = renderer.create(
-    <MyComponent forms={forms} foo={1} baz={2} />
+    <MyComponent forms={forms} foo={1} baz={2} UshLogoActions={actions} />
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("MyComponent to correctly render foo and baz in p tags", () => {
+  const forms = [{ id: "junk" }];
+  const actions = {
+  	receiveForms: jest.fn()
+  };
   // Render a checkbox with label in the document
-  const fooBaz = shallow(<MyComponent foo={4} baz={1} />);
+  const fooBaz = shallow(<MyComponent forms={forms} foo={4} baz={1} UshLogoActions={actions} />);
 
   expect(fooBaz.find("p").length).toBe(2);
   expect(fooBaz.find("p.foo").text()).toBe("Foo: 4");

--- a/app/react/react-transition/connectWithStore.jsx
+++ b/app/react/react-transition/connectWithStore.jsx
@@ -12,7 +12,6 @@ const connectWithStore = (WrappedComponent, ...args) => {
         const store = injector.get("$ngRedux");
         return <ConnectedWrappedComponent store={store} {...props} />;
     };
-    ConnectedComponentWithStore.propTypes = WrappedComponent.propTypes;
 
     return ConnectedComponentWithStore;
 };


### PR DESCRIPTION
This pull request makes the following changes:
- Add missing props to UshLogoReact tests
- Fix proptypes handling in connectWithStore
    - Remove propTypes copying from connectWithStore
    - Manually specify props on react2angular component

Testing checklist:
- [x] npm run test

Fixes ushahidi/platform#3021

Ping @ushahidi/platform
