### PR TITLE
Bugfix/3086 unable to name saved search

### DIFF
--- a/app/main/posts/savedsearches/editor-directive.js
+++ b/app/main/posts/savedsearches/editor-directive.js
@@ -1,5 +1,6 @@
 module.exports = [
     '$q',
+    '$filter',
     '$location',
     '$rootScope',
     '$translate',
@@ -11,6 +12,7 @@ module.exports = [
     'PostFilters',
 function (
     $q,
+    $filter,
     $location,
     $rootScope,
     $translate,
@@ -44,7 +46,9 @@ function (
             $scope.views = ViewHelper.views();
 
             $scope.cpySavedSearch = _.clone($scope.savedSearch);
-
+            // translate the description and name if they have a translation available (ie the "My posts" search)
+            $scope.cpySavedSearch.description = $filter('translate')($scope.cpySavedSearch.description);
+            $scope.cpySavedSearch.name = $filter('translate')($scope.cpySavedSearch.name);
             $scope.save = function (savedSearch) {
                 $scope.isSaving = true;
                 var persist = savedSearch.id ? SavedSearchEndpoint.update : SavedSearchEndpoint.save;

--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -2,12 +2,12 @@
 
     <div class="form-field title">
         <label translate>set.name_savedsearch</label>
-        <input type="text" placeholder="Name your Saved Search..." ng-model="cpySavedSearch.name | translate" translate/>
+        <input type="text" placeholder="Name your Saved Search..." ng-model="cpySavedSearch.name" translate/>
     </div>
 
     <div class="form-field">
         <label class="input-label" translate>set.description</label>
-        <textarea ng-model="cpySavedSearch.description | translate" />
+        <textarea ng-model="cpySavedSearch.description" />
     </div>
 
     <div class="form-field switch" ng-if="featuredEnabled()">


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#3086 

Testing checklist:
Test 1 - create a saved search: 
- [x] Go to the sort and filter menu 
- [x] Add any filter (for example, a category filter)
- [x] Click the save search button in the filters menu 
- [x] Create your saved search. Add a name and description

- [x] You should be able to edit it successfully. 
Test 2 - select and edit a saved search: 
- [x] Go to the sort and filter menu 
- [x] Select a saved search
- [x] Click the edit button
- [x] change the name of the saved search in the edit modal
- [x] change the description of the saved search in the edit modal
- [x] You should be able to save it successfully. 



- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
