### PR TITLE
25 acc Map layers not clearing correctly

### DIFF
--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -16,6 +16,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
 
     function PostViewMapLink($scope, element, attrs, controller) {
         var map, markers;
+        var geoJsonLayers = [];
         var limit = 200;
         var requestBlockSize = 5;
         var numberOfChunks = 0;
@@ -75,9 +76,13 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
         }
 
         function clearData() {
-            if (markers) {
-                map.removeLayer(markers);
+            if (geoJsonLayers.length > 0) {
+                angular.forEach(geoJsonLayers, function (layer) {
+                    //map.removeLayer(layer)
+                    layer.clearLayers();
+                });
                 markers = undefined;
+                geoJsonLayers = [];
             }
         }
 
@@ -100,6 +105,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                 markers = geojson;
             }
             markers.addTo(map);
+            geoJsonLayers.push(markers);
 
             if (posts.features.length > 0) {
                 map.fitBounds(geojson.getBounds());


### PR DESCRIPTION
This pull request makes the following changes:
- Adds storage of geojson layers constructed by chunk loading of map points when clustering is disabled

Testing checklist:
- [x] Ensure that the database contains more than 500 posts with location data and that these points are split into at least 2 surveys
- [x] Ensure that clustering is turned off in Setting->General
  - [x] Test that all points are loaded
  - [x] Using the filters deselect one of the surveys, only the points for the other survey should be shown
- [x] Re-enable clustering
  - [x] Ensure all points load
  - [x] Using filters deselect one of the surveys, ensure the number of posts in clusters decreases by the correct amount

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
