### PR TITLE
 feat: Sanitize data sentry to sentry

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -42,6 +42,9 @@
         "afterEach",
         "-event",
         "makeTestApp",
-        "BACKEND_URL"
+        "BACKEND_URL",
+        "RAVEN_URL",
+        "ENVIRONMENT",
+        "GIT_COMMIT"
     ]
 }

--- a/app/app.js
+++ b/app/app.js
@@ -22,14 +22,12 @@ require('angular-linkify');
 require('./common/common-module.js');
 require('./main/main-module.js');
 require('./settings/settings.module.js');
+import ravenModule from './common/raven/raven';
 
 // Load platform-pattern-library CSS
 require('ushahidi-platform-pattern-library/assets/fonts/Lato/css/fonts.css');
 require('ushahidi-platform-pattern-library/assets/css/style.min.css');
 require('../sass/vendor.scss');
-
-// Stub ngRaven module incase its not configured
-angular.module('ngRaven', []);
 
 // Make sure we have a window.ushahidi object
 window.ushahidi = window.ushahidi || {};
@@ -80,7 +78,7 @@ angular.module('app',
         'nvd3',
         'angular-cache',
         'linkify',
-        'ngRaven',
+        ravenModule,
         'ushahidi.common',
         'ushahidi.main',
         'ushahidi.settings',

--- a/app/common/raven/raven.js
+++ b/app/common/raven/raven.js
@@ -12,6 +12,23 @@ if (RAVEN_URL) {
             environment: ENVIRONMENT,
             tags: {
                 git_commit: GIT_COMMIT
+            },
+            sanitizeKeys: [/Authorization/i, /password/i, /accessToken/i, /api_key/i, /client_secret/i],
+            dataCallback: (data) => {
+                // Replace stringified sensitive info
+                if (data.message) {
+                    data.message = data.message.replace(/"Authorization":"(.*?)"/, '"Authorization":"****"');
+                    data.message = data.message.replace(/"client_secret":"(.*?)"/, '"client_secret":"****"');
+                    data.message = data.message.replace(/"password":"(.*?)"/, '"password":"****"');
+                    data.message = data.message.replace(/"accessToken":"(.*?)"/, '"accessToken":"****"');
+                }
+
+                if (data.fingerprint && data.fingerprint[0]) {
+                    data.fingerprint[0] = data.fingerprint[0].replace(/"Authorization":"(.*?)"/, '"Authorization":"****"');
+                    data.fingerprint[0] = data.fingerprint[0].replace(/"client_secret":"(.*?)"/, '"client_secret":"****"');
+                    data.fingerprint[0] = data.fingerprint[0].replace(/"password":"(.*?)"/, '"password":"****"');
+                    data.fingerprint[0] = data.fingerprint[0].replace(/"accessToken":"(.*?)"/, '"accessToken":"****"');
+                }
             }
         })
         .addPlugin(require('raven-js/plugins/angular'), angular)

--- a/app/common/raven/raven.js
+++ b/app/common/raven/raven.js
@@ -1,0 +1,44 @@
+import angular from 'angular';
+import ravenService from './raven.service';
+
+let ravenModule;
+// Load raven if configured
+if (RAVEN_URL) {
+    let Raven = require('raven-js');
+
+    Raven
+        .config(RAVEN_URL, {
+            release: GIT_COMMIT,
+            environment: ENVIRONMENT,
+            tags: {
+                git_commit: GIT_COMMIT
+            }
+        })
+        .addPlugin(require('raven-js/plugins/angular'), angular)
+        .install();
+
+    ravenModule = angular.module('app.raven', [
+        'ngRaven'
+    ])
+
+    .factory('Raven', () => {
+        return Raven;
+    })
+
+    .service({
+        ravenService
+    })
+
+    .run(['ravenService', (ravenService) => {
+        if (RAVEN_URL) {
+            ravenService.init();
+        }
+    }])
+
+    .name;
+
+} else {
+    ravenModule = angular.module('app.raven', []).name;
+}
+
+export default ravenModule;

--- a/app/common/raven/raven.js
+++ b/app/common/raven/raven.js
@@ -1,15 +1,16 @@
 import angular from 'angular';
 import ravenService from './raven.service';
 
+const ravenUrl = window.ushahidi.ravenUrl || false;
 let ravenModule;
 // Load raven if configured
-if (RAVEN_URL) {
+if (ravenUrl) {
     let Raven = require('raven-js');
 
     Raven
-        .config(RAVEN_URL, {
+        .config(ravenUrl, {
             release: GIT_COMMIT,
-            environment: ENVIRONMENT,
+            environment: window.ushahidi.environment || ENVIRONMENT,
             tags: {
                 git_commit: GIT_COMMIT
             },
@@ -47,7 +48,7 @@ if (RAVEN_URL) {
     })
 
     .run(['ravenService', (ravenService) => {
-        if (RAVEN_URL) {
+        if (ravenUrl) {
             ravenService.init();
         }
     }])

--- a/app/common/raven/raven.service.js
+++ b/app/common/raven/raven.service.js
@@ -1,0 +1,34 @@
+class RavenService {
+    constructor($rootScope, Session, Raven) {
+        'ngInject';
+        this.$rootScope = $rootScope;
+        this.Session = Session;
+        this.Raven = Raven;
+    }
+
+    init() {
+        this.$rootScope.$on('event:authentication:login:succeeded', this.handleLogin.bind(this));
+        this.$rootScope.$on('event:authentication:logout:succeeded', this.handleLogout.bind(this));
+
+        if (this.Session.getSessionDataEntry('userId')) {
+            this.handleLogin();
+        }
+    }
+
+    handleLogin() {
+        if (this.Session.getSessionDataEntry('userId')) {
+            this.Raven.setUserContext({
+                id: this.Session.getSessionDataEntry('userId')
+            });
+        } else {
+            this.Raven.setUserContext({});
+        }
+    }
+
+    handleLogout() {
+        this.Raven.setUserContext({});
+    }
+
+}
+
+export default RavenService;

--- a/app/index.html
+++ b/app/index.html
@@ -123,15 +123,6 @@
             }
         </script>
         <script>
-            if (window.ushahidi && window.ushahidi.ravenUrl) {
-                (function(d, t, c, s) {
-                    var g = d.createElement(t);g.id = 'ravenScript';g.type = 'text/javascript';g.async = true; g.src = 'https://cdn.ravenjs.com/3.8.0/angular/raven.min.js';g.onload=c;g.onreadystatechange=c; s = d.getElementsByTagName(t)[0];s.parentNode.insertBefore(g, s);
-                }(document, 'script', function () {
-                    Raven.config(window.ushahidi.ravenUrl).install();
-                }));
-            }
-        </script>
-        <script>
             if (window.ushahidi && window.ushahidi.googleMapsApiKey) {
                 (function(d, t, c, s) {
                     var g = d.createElement(t);g.id = 'mapsApi';g.type = 'text/javascript';g.async = true; g.src = 'https://maps.googleapis.com/maps/api/js?key=' + window.ushahidi.googleMapsApiKey + '&libraries=places';g.onload=c;g.onreadystatechange=c; s = d.getElementsByTagName(t)[0];s.parentNode.insertBefore(g, s);

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "ng-showdown": "^1.1.0",
     "ngGeolocation": "rjmackay/ngGeolocation",
     "nvd3": "^1.8.4",
+    "raven-js": "^3.26.3",
     "socket.io-client": "2.0.3",
     "sortablejs": "^1.7.0",
     "underscore": "^1.7.0",

--- a/test/unit/common/raven.spec.js
+++ b/test/unit/common/raven.spec.js
@@ -1,0 +1,77 @@
+import RavenService from 'app/common/raven/raven.service';
+
+describe('Raven service', () => {
+    let raven, $rootScope, Raven, Session;
+
+    beforeEach(() => {
+        $rootScope = {
+            $emit: (ev) => {},
+            $on: (ev) => {}
+        };
+
+        let mockedSessionData = {
+            email: 'robbie@ushahidi.com',
+            name: 'Robbie',
+            userId: 10
+        };
+        Session =  {
+            getSessionDataEntry: function (key) {
+                return mockedSessionData[key];
+            },
+            setSessionDataEntry: function (key, value) {
+                mockedSessionData[key] = value;
+            }
+        };
+
+        Raven = {
+            setUserContext: jasmine.createSpy('setUserContext')
+        };
+
+        global.RAVEN_DSN = 'http://abc123';
+
+        spyOn($rootScope, '$emit');
+        spyOn($rootScope, '$on');
+
+        raven = new RavenService($rootScope, Session, Raven);
+    });
+
+    it('should listen to log in/out events', () => {
+        raven.init();
+
+        expect($rootScope.$on).toHaveBeenCalledWith('event:authentication:login:succeeded', jasmine.any(Function));
+        expect($rootScope.$on).toHaveBeenCalledWith('event:authentication:logout:succeeded', jasmine.any(Function));
+
+        expect(Raven.setUserContext).toHaveBeenCalled();
+    });
+
+    it('should set user at creation if logged in', () => {
+        Session.setSessionDataEntry('userId', 10);
+        raven.init();
+
+        expect(Raven.setUserContext).toHaveBeenCalled();
+    });
+
+    it('should not set user at creation if logged out', () => {
+        Session.setSessionDataEntry('userId', false);
+        raven.init();
+
+
+        expect(Raven.setUserContext).not.toHaveBeenCalled();
+    });
+
+    it('should set user on login', () => {
+        raven.init();
+        raven.handleLogin();
+
+        expect(Raven.setUserContext).toHaveBeenCalledWith({
+            id: 10
+        });
+    });
+
+    it('should clear user on logout', () => {
+        raven.init();
+        raven.handleLogout();
+
+        expect(Raven.setUserContext).toHaveBeenCalledWith({});
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,6 @@ module.exports = {
 
     new webpack.DefinePlugin({
         BACKEND_URL: JSON.stringify(process.env.BACKEND_URL || 'http://backend.url.undefined'),
-        RAVEN_URL: JSON.stringify(process.env.RAVEN_URL || false),
         ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
         GIT_COMMIT: JSON.stringify(GIT_COMMIT || false)
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,14 @@ var imgPath = path.resolve('node_modules/ushahidi-platform-pattern-library/asset
 
 var extractCss = new ExtractTextPlugin('[name].[chunkhash].css');
 
+var GIT_COMMIT;
+// Try to get the current GIT COMMIT
+try {
+  GIT_COMMIT = require('child_process').execSync('git rev-parse HEAD').toString().trim();
+} catch (e) {
+  GIT_COMMIT = process.env.CI_COMMIT_ID || null;
+}
+
 module.exports = {
   devtool: 'source-map',
   entry: {'app': [
@@ -89,7 +97,10 @@ module.exports = {
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
 
     new webpack.DefinePlugin({
-        BACKEND_URL: JSON.stringify(process.env.BACKEND_URL || 'http://backend.url.undefined')
+        BACKEND_URL: JSON.stringify(process.env.BACKEND_URL || 'http://backend.url.undefined'),
+        RAVEN_URL: JSON.stringify(process.env.RAVEN_URL || false),
+        ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
+        GIT_COMMIT: JSON.stringify(GIT_COMMIT || false)
     }),
 
     // Injects bundles in your index.html instead of wiring all manually.


### PR DESCRIPTION
This pull request makes the following changes:
- refactor: Import raven within our app instead of custom script tag 
- Send user id to sentry
- feat: Sanitize data sentry to sentry

Testing checklist:
- [x] Configure your client deployment to with `RAVEN_URL=https://407e538550a64857ac099f98ac8cceef@sentry.io/88046` in .env
- [x] Open the client
- [x] Move around the UI and generate errors (data view has a few noisey errors)
- [x] Log in as a normal user (not admin)
- [x] Move around the UI and generate errors (data view has a few noisey errors)
- [x] Check Sentry errors in dashboard now show your user id
- [x] Log out
- [x] Trigger errors on the client and watch for sentry HTTP requests
- [x] Check Sentry errors in dashboard no longer show your user id
- [ ] Check data sent to sentry.io in network tab does not contain sensitive info
    - The simplest issue to look for is the 'unhandled rejection' for 403's when trying to load users/contacts/etc without admin privileges
- [x] Check Sentry dashboard and confirm logged errors do not contain sensitive info
    - The simplest issue to look for is the 'unhandled rejection' for 403's when trying to load users/contacts/etc without admin privileges

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#1596

Ping @ushahidi/platform
