### PR TITLE
fix: Sanitize raven breadcrumbs too

### DIFF
--- a/app/common/raven/raven.js
+++ b/app/common/raven/raven.js
@@ -18,17 +18,21 @@ if (ravenUrl) {
             dataCallback: (data) => {
                 // Replace stringified sensitive info
                 if (data.message) {
-                    data.message = data.message.replace(/"Authorization":"(.*?)"/, '"Authorization":"****"');
-                    data.message = data.message.replace(/"client_secret":"(.*?)"/, '"client_secret":"****"');
-                    data.message = data.message.replace(/"password":"(.*?)"/, '"password":"****"');
-                    data.message = data.message.replace(/"accessToken":"(.*?)"/, '"accessToken":"****"');
+                    data.message = data.message.replace(/"(Authorization|client_secret|password|accessToken)":"(.*?)"/, '"$1":"****"');
                 }
 
-                if (data.fingerprint && data.fingerprint[0]) {
-                    data.fingerprint[0] = data.fingerprint[0].replace(/"Authorization":"(.*?)"/, '"Authorization":"****"');
-                    data.fingerprint[0] = data.fingerprint[0].replace(/"client_secret":"(.*?)"/, '"client_secret":"****"');
-                    data.fingerprint[0] = data.fingerprint[0].replace(/"password":"(.*?)"/, '"password":"****"');
-                    data.fingerprint[0] = data.fingerprint[0].replace(/"accessToken":"(.*?)"/, '"accessToken":"****"');
+                if (data.fingerprint) {
+                    data.fingerprint.forEach((value, index) => {
+                        data.fingerprint[index] = value.replace(/"(Authorization|client_secret|password|accessToken)":"(.*?)"/, '"$1":"****"');
+                    });
+                }
+
+                if (data.breadcrumbs && data.breadcrumbs.values) {
+                    data.breadcrumbs.values.forEach((value, index) => {
+                        if (value.message) {
+                            data.breadcrumbs.values[index].message = value.message.replace(/"(Authorization|client_secret|password|accessToken)":"(.*?)"/, '"$1":"****"');
+                        }
+                    });
                 }
             }
         })


### PR DESCRIPTION
This pull request makes the following changes:
- Sanitize breadcrumbs too
- Clean up regex to sanitize all options at once

Testing checklist:
- [x] Configure your client deployment in config.js with `ravenUrl: 'https://407e538550a64857ac099f98ac8cceef@sentry.io/88046'`
- [x] Open the client
- [x] Move around the UI and generate errors (data view has a few noisey errors)
- [x] Log in as a normal user (not admin)
- [x] Move around the UI and generate errors (data view has a few noisey errors)
- [x] Check Sentry errors in dashboard now show your user id
- [x] Log out
- [x] Trigger errors on the client and watch for sentry HTTP requests
- [x] Check Sentry errors in dashboard no longer show your user id
- [ ] Check data sent to sentry.io in network tab does not contain sensitive info
    - The simplest issue to look for is the 'unhandled rejection' for 403's when trying to load users/contacts/etc without admin privileges
- [x] Check Sentry dashboard and confirm logged errors do not contain sensitive info
    - The simplest issue to look for is the 'unhandled rejection' for 403's when trying to load users/contacts/etc without admin privileges

- [x] I certify that I ran my checklist

Refs ushahidi/platform#1596

Ping @ushahidi/platform
