### PR TITLE
3134 cancel action

### DIFF
--- a/app/settings/user-settings/user-settings.controller.js
+++ b/app/settings/user-settings/user-settings.controller.js
@@ -114,7 +114,7 @@ function (
         }
 
         if ($scope.api.hdx_maintainer_id.$dirty) {
-            tmpSetting = $scope.hdxSettings.hdx_api_key;
+            tmpSetting = $scope.hdxSettings.hdx_maintainer_id;
             tmpSetting.config_value = $scope.tempMaintainerId;
             calls.push(
                 UserSettingsEndpoint.saveCache(tmpSetting).$promise

--- a/app/settings/user-settings/user-settings.controller.js
+++ b/app/settings/user-settings/user-settings.controller.js
@@ -22,9 +22,17 @@ function (
     $scope.saveKey = saveKey;
     $scope.changeKey = changeKey;
     $scope.changeId = changeId;
-    $scope.hxlApiKeySet = false;
+
+    $scope.showCancel = false;
     $scope.hxlMaintainerSet = false;
+    $scope.hxlApiKeySet = false;
+    $scope.cancelMaintainerSet = cancelMaintainerSet;
+    $scope.cancelApiKeySet = cancelApiKeySet;
     $scope.isLoading = LoadingProgress.getLoadingState;
+
+    $scope.tempApiKey = '';
+    $scope.tempMaintainerId = '';
+
     $scope.hdxSettings = {
         'hdx_api_key': {
             id: null,
@@ -62,20 +70,32 @@ function (
             setting.config_value = '*** *** *** *** *** *** *** ' + setting.config_value.slice(setting.config_value.length - 4);
             $scope.hdxSettings.hdx_api_key = setting;
             $scope.hxlApiKeySet = true;
+            $scope.showCancel = true;
         }
         if (setting.config_key === 'hdx_maintainer_id') {
             $scope.hxlMaintainerSet = true;
+            $scope.tempMaintainerId = setting.config_value;
             $scope.hdxSettings.hdx_maintainer_id = setting;
+            $scope.showCancel = true;
         }
     }
 
     function changeKey() {
-        $scope.hdxSettings.hdx_api_key.config_value = '';
         $scope.hxlApiKeySet = false;
     }
 
     function changeId() {
         $scope.hxlMaintainerSet = false;
+    }
+
+    function cancelMaintainerSet() {
+        $scope.tempMaintainerId = $scope.hdxSettings.hdx_maintainer_id.config_value;
+        $scope.hxlMaintainerSet = true;
+    }
+
+    function cancelApiKeySet() {
+        $scope.tempApiKey = '';
+        $scope.hxlApiKeySet = true;
     }
 
     function goToHdxView() {
@@ -84,16 +104,20 @@ function (
 
     function saveKey() {
         var calls = [];
-
-        if ($scope.api['api-key'].$dirty) {
+        var tmpSetting;
+        if ($scope.api.api_key.$dirty) {
+            tmpSetting = $scope.hdxSettings.hdx_api_key;
+            tmpSetting.config_value = $scope.tempApiKey;
             calls.push(
-                UserSettingsEndpoint.saveCache($scope.hdxSettings.hdx_api_key).$promise
+                UserSettingsEndpoint.saveCache(tmpSetting).$promise
             );
         }
 
         if ($scope.api.hdx_maintainer_id.$dirty) {
+            tmpSetting = $scope.hdxSettings.hdx_api_key;
+            tmpSetting.config_value = $scope.tempMaintainerId;
             calls.push(
-                UserSettingsEndpoint.saveCache($scope.hdxSettings.hdx_maintainer_id).$promise
+                UserSettingsEndpoint.saveCache(tmpSetting).$promise
             );
         }
 

--- a/app/settings/user-settings/user-settings.html
+++ b/app/settings/user-settings/user-settings.html
@@ -43,18 +43,17 @@
             <form name="api">
                 <div
                     class="form-field init required"
-                    ng-class="{'error': api.$invalid && api.$dirty,'success': !api.$invalid && api.$dirty}"
+                    ng-class="{'error': api.hdx_maintainer_id.$invalid && api.hdx_maintainer_id.$dirty,'success': !api.hdx_maintainer_id.$invalid && api.hdx_maintainer_id.$dirty}"
                     ng-show="!hxlMaintainerSet"
                 >
-                
                     <label class="required " for="hdx_maintainer_id" translate="settings.user_settings.hdx_maintainer_id">
                         HDX User Id
                     </label>
                     <p translate="settings.user_settings.profile_page"> Found on your Humanitarian Data Exchange (HDX) profile page</p>
-                    <input id="hdx_maintainer_id" name="hdx_maintainer_id" ng-required="true" type="text" ng-model="hdxSettings['hdx_maintainer_id'].config_value" required="required"/>
+                    <input id="hdx_maintainer_id" name="hdx_maintainer_id" ng-required="true" type="text" ng-model="tempMaintainerId" required="required"/>
                 </div>
 
-                <div class="form-field alert error" ng-show="api.$invalid && api.$dirty">
+                <div class="form-field alert error" ng-show="!hxlMaintainerSet && api.hdx_maintainer_id.$invalid && api.hdx_maintainer_id.$dirty">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
                     </svg>
@@ -62,50 +61,53 @@
                 </div>
 
                 <div class="form-field" ng-show="!hxlMaintainerSet">
+                    <button ng-show="showCancel" type="button" class="button-link" ng-click="cancelMaintainerSet()" translate="app.cancel">Cancel</button>
                     <button class="button button-alpha" translate="app.save" ng-click="saveKey()">Save</button>
+                </div>
+
+
+                <div class="form-field init required key" ng-show="hxlMaintainerSet">
+                    <label class="required " for="hdx_maintainer_id_text" translate="settings.user_settings.hdx_maintainer_id">
+                        HDX Maintainer Id
+                    </label>
+                    <span id="hdx_maintainer_id_text">{{hdxSettings['hdx_maintainer_id'].config_value}}
+                        <a class="link-blue" ng-click="changeId()" >Change your User ID</a>
+                    </span>
                 </div>
 
                 <div
                     class="form-field init required"
-                    ng-class="{'error': api.$invalid && api.$dirty,'success': !api.$invalid && api.$dirty}"
+                    ng-class="{'error': api.api_key.$invalid && api.api_key.$dirty,'success': !api.api_key.$invalid && api.api_key.$dirty}"
                     ng-show="!hxlApiKeySet"
                 >
-                    <label class="required " for="api-key" translate="settings.user_settings.api_key">
+                    <label class="required " for="api_key" translate="settings.user_settings.api_key">
                         Api key
                     </label>
                     <p translate="settings.user_settings.profile_page"> Found on your Humanitarian Data Exchange (HDX) profile page</p>
-                    <input id="api-key" name="api-key" ng-required="true" type="text" ng-model="hdxSettings['hdx_api_key'].config_value" required="required"/>
+                    <input id="api_key" name="api_key" ng-required="true" type="text" ng-model="tempApiKey" required="required"/>
                 </div>
 
-                <div class="form-field alert error" ng-show="api.$invalid && api.$dirty && !hxlApiKeySet">
+                <div class="form-field alert error" ng-show="!hxlApiKeySet && api.api_key.$invalid && api.api_key.$dirty && !hxlApiKeySet">
                     <svg class="iconic">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
                     </svg>
                     <p translate="settings.user_settings.valid_key">A valid key is required</p>
                 </div>
+
+                <div class="form-field" ng-show="!hxlApiKeySet">
+                    <button ng-show="showCancel" type="button" class="button-link" ng-click="cancelApiKeySet()" translate="app.cancel">Cancel</button>
+                    <button class="button button-alpha" translate="app.save" ng-click="saveKey()">Save</button>
+                </div>
+
+                <div class="form-field init required key" ng-show="hxlApiKeySet">
+                    <label class="required" for="api_key_text" translate="settings.user_settings.api_key">
+                        Api key
+                    </label>
+                    <span id="api_key_text">{{hdxSettings['hdx_api_key'].config_value}}
+                        <a class="link-blue" ng-click="changeKey()" >Change your API key</a>
+                    </span>
+                </div>
             </form>
-
-            <div class="form-field" ng-show="!hxlApiKeySet">
-                <button class="button button-alpha" translate="app.save" ng-click="saveKey()">Save</button>
-            </div>
-
-            <div class="form-field init required key" ng-show="hxlMaintainerSet">
-                <label class="required " for="hdx_maintainer_id" translate="settings.user_settings.hdx_maintainer_id">
-                    HDX Maintainer Id
-                </label>
-                <span id="hdx_maintainer_id">{{hdxSettings['hdx_maintainer_id'].config_value}}
-                    <a class="link-blue" ng-click="changeId()" >Change your User ID</a>
-                </span>
-            </div>
-
-            <div class="form-field init required key" ng-show="hxlApiKeySet">
-                <label class="required" for="api-key" translate="settings.user_settings.api_key">
-                    Api key
-                </label>
-                <span id="api-key">{{hdxSettings['hdx_api_key'].config_value}}
-                    <a class="link-blue" ng-click="changeKey()" >Change your API key</a>
-                </span>
-            </div>
         </div>
     </div>
 </main>


### PR DESCRIPTION
This pull request makes the following changes:
- [x] Add cancel button next to save button for HDX Config edit view
- [x] Should only appear on change view

### Acceptance Criteria
- [x] When no API Key or Maintainer is saved no  'cancel' button appears next to the Save button
- [x] When editing an existing Maintainer setting a text button appears next to the save button called 'cancel'
- [x] When 'cancel' is clicked the change mode is exited and the user is returned to the view mode 
- [x] When editing an existing API Key setting a text button appears next to the save button called 'cancel'
- [x] When 'cancel' is clicked the change mode is exited and the user is returned to the view mode 
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3134

Ping @ushahidi/platform
