### PR TITLE
Export tags - when a user selects #geo+lat or #geo+lon, they should automatically get the opposite attribute (lat/lon) added

### DIFF
--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -151,7 +151,7 @@ function (
         let needsMatchLatLon = ignoreMatch;
         if (!!ignoreMatch == false && attribute.selectedTag.tag_name === 'geo' && attribute.selectedHxlAttributes.length < 2) {
             needsMatchLatLon = _.filter(attribute.selectedHxlAttributes, (selected) => {
-                return selected.hxl_tag_id == geoTag.id && (selected.attribute === 'lon' || selected.attribute === 'lat');
+                return selected.attribute === 'lon' || selected.attribute === 'lat';
             }).length;
             needsMatchLatLon = needsMatchLatLon === 1;
         }
@@ -176,11 +176,7 @@ function (
         }
         return attribute;
     }
-
-    function createPrettyAttribute() {
-
-    }
-
+    
     function formatIds() {
         let hxlData = [];
         _.each($scope.forms, (form) => {

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -68,7 +68,7 @@ function (
     function hxlAttributeSelected(hxlAttribute, formAttribute, index) {
         let disabled = false;
         // hack to not disable the value in the current dropdown
-        let selectedHxlAttributes = angular.copy(formAttribute.selectedHxlAttributes);
+        let selectedHxlAttributes = _.toArray(angular.copy(formAttribute.selectedHxlAttributes));
         delete selectedHxlAttributes[index];
         if (_.findWhere(selectedHxlAttributes, {id: hxlAttribute.id})) {
             disabled = true;
@@ -112,59 +112,73 @@ function (
             attribute.pretty = ['#' + attribute.selectedTag.tag_name];
         } else {
             attribute.pretty = [];
+            addAnother(attribute);
         }
-        attribute.nbAttributes = 1;
-        attribute.selectedHxlAttributes = {};
+
+        attribute.selectedHxlAttributes = [];
     }
 
     function selectHxlAttribute(attribute, ignoreMatch) {
-        let needsMatchLatLon = false;
-        let geoTag = _.find(attribute.tags, (tag) => {
-            return tag.tag_name === 'geo';
-        });
         attribute.pretty = [];
-        var prettyIndex = 0;
+        let prettyIndex = 0;
         if (attribute.pretty.length === 0) {
             attribute.pretty.push('#' + attribute.selectedTag.tag_name);
         } else {
             prettyIndex = attribute.pretty.indexOf('#' + attribute.selectedTag.tag_name);
         }
-        if (!!ignoreMatch == false && attribute.selectedTag.tag_name === 'geo' && _.keys(attribute.selectedHxlAttributes).length < 2) {
-            needsMatchLatLon = _.filter(attribute.selectedHxlAttributes, (selected) => {
-                return selected.hxl_tag_id == geoTag.id && (selected.attribute === 'lon' || selected.attribute === 'lat');
-            }).length;
-            needsMatchLatLon = needsMatchLatLon === 1;
-            console.log("NEEDS MATCH", needsMatchLatLon, attribute.selectedHxlAttributes);
-        }
+        let geoTag = _.find(attribute.tags, (tag) => {
+            return tag.tag_name === 'geo';
+        });
+        let needsMatchLatLon = locationNeedsMatchedAttribute(attribute, ignoreMatch, geoTag);
         _.each(attribute.selectedHxlAttributes, (hxl_attribute) => {
             if (hxl_attribute !== '') {
                 attribute.pretty[prettyIndex] = attribute.pretty[prettyIndex] + '+' + hxl_attribute.attribute;
                 if (needsMatchLatLon) {
-                    let opposite = null;
-                    if (hxl_attribute.attribute === 'lon') {
-                        opposite = _.find(geoTag.hxl_attributes, (hxl) => {
-                            return hxl.attribute === 'lat';
-                        });
-                    } else if (hxl_attribute.attribute === 'lat') {
-                        opposite = _.find(geoTag.hxl_attributes, (hxl) => {
-                            return hxl.attribute === 'lon';
-                        });
-                    }
-                    attribute.selectedHxlAttributes[_.keys(attribute.selectedHxlAttributes).length] = opposite;
-                    attribute.pretty.push('#' + attribute.selectedTag.tag_name +  '+' + opposite.attribute);
-                    attribute.nbAttributes++;
-                    $scope.forms = _.map($scope.forms, (form) => {
-                        form.attributes = _.map(form.attributes, (_attribute) => {
-                            if (_attribute.id === attribute.id) {
-                                _attribute = attribute;
-                            }
-                            return _attribute;
-                        });
-                        return form;
-                    });
+                    attribute = selectAttributeProgrammatically(attribute, hxl_attribute, geoTag);
                 }
             }
         });
+    }
+
+    /**
+     * Checks if there is a geo tag name and if there is, it checks if we need a matched lat/lon attribute
+     * @param attribute
+     * @param ignoreMatch
+     * @param needsMatchLatLon
+     * @returns {*}
+     */
+    function locationNeedsMatchedAttribute(attribute, ignoreMatch, geoTag) {
+        let needsMatchLatLon = ignoreMatch;
+        if (!!ignoreMatch == false && attribute.selectedTag.tag_name === 'geo' && attribute.selectedHxlAttributes.length < 2) {
+            needsMatchLatLon = _.filter(attribute.selectedHxlAttributes, (selected) => {
+                return selected.hxl_tag_id == geoTag.id && (selected.attribute === 'lon' || selected.attribute === 'lat');
+            }).length;
+            needsMatchLatLon = needsMatchLatLon === 1;
+        }
+        return needsMatchLatLon;
+    }
+
+    function selectAttributeProgrammatically(attribute, hxl_attribute, geoTag) {
+        let opposite = null;
+        addAnother(attribute);
+        if (hxl_attribute.attribute === 'lon') {
+            opposite = _.find(geoTag.hxl_attributes, (hxl) => {
+                return hxl.attribute === 'lat';
+            });
+        } else if (hxl_attribute.attribute === 'lat') {
+            opposite = _.find(geoTag.hxl_attributes, (hxl) => {
+                return hxl.attribute === 'lon';
+            });
+        }
+        attribute.selectedHxlAttributes.push(opposite);
+        if (opposite) {
+            attribute.pretty.push('#' + attribute.selectedTag.tag_name +  '+' + opposite.attribute);
+        }
+        return attribute;
+    }
+
+    function createPrettyAttribute() {
+
     }
 
     function formatIds() {

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -108,7 +108,7 @@ function (
     }
 
     function selectTag(attribute) {
-        attribute.selected = true;
+        attribute.selected = [attribute.id];
         if (attribute.selectedTag && attribute.selectedTag.tag_name) {
             attribute.hxl_label = ['#' + attribute.selectedTag.tag_name];
         } else {

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -121,11 +121,12 @@ function (
         if (!needsMatchedAttribute(attribute)) {
             attribute.hxl_label = createHxlLabel(attribute);
         } else {
-            attribute = addGeoMatchedAttribute(attribute.selectedHxlAttributes[attribute.selectedHxlAttributes.length - 1], attribute);
+            attribute = addGeoMatchedAttribute(attribute);
         }
         return attribute;
     }
-    function addGeoMatchedAttribute(hxl_attribute, attribute) {
+    function addGeoMatchedAttribute(attribute) {
+        const hxl_attribute = attribute.selectedHxlAttributes[attribute.selectedHxlAttributes.length - 1];
         // check if we have lat or lon and assign the correct opposite attribute for it
         const opposite_attribute_str = hxl_attribute.attribute === 'lat' ? 'lon' : 'lat';
         // If the label is not just #geo, it means the action is removing a tag instead of adding one,

--- a/app/settings/data-export/hdx-export.controller.js
+++ b/app/settings/data-export/hdx-export.controller.js
@@ -118,11 +118,14 @@ function (
     }
 
     function selectHxlAttribute(attribute) {
-        const hxl_attribute = attribute.selectedHxlAttributes[attribute.selectedHxlAttributes.length - 1];
         if (!needsMatchedAttribute(attribute)) {
             attribute.hxl_label = createHxlLabel(attribute);
-            return attribute;
+        } else {
+            attribute = addGeoMatchedAttribute(attribute.selectedHxlAttributes[attribute.selectedHxlAttributes.length - 1], attribute);
         }
+        return attribute;
+    }
+    function addGeoMatchedAttribute(hxl_attribute, attribute) {
         // check if we have lat or lon and assign the correct opposite attribute for it
         const opposite_attribute_str = hxl_attribute.attribute === 'lat' ? 'lon' : 'lat';
         // If the label is not just #geo, it means the action is removing a tag instead of adding one,

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -107,7 +107,7 @@
                             <tr ng-repeat="formAttribute in form.attributes">
                                 <td class="form-field">
                                     <input
-                                        type="checkbox"
+                                        type="checkbox"F
                                         checklist-model="formAttribute.selected"
                                         checklist-value="formAttribute.id"
                                         ng-selected="formAttribute.selected"
@@ -131,17 +131,17 @@
                                 <td class="form-field">
                                     <div class="custom-select" ng-repeat="a in range(formAttribute)">
                                         <select
-                                            ng-disabled="!formAttribute.selectedTag"
-                                            ng-model="formAttribute.selectedHxlAttributes[a]"
-                                            ng-change="selectHxlAttribute(formAttribute)"
+                                                ng-disabled="!formAttribute.selectedTag"
+                                                ng-model="formAttribute.selectedHxlAttributes[a]"
+                                                ng-change="selectHxlAttribute(formAttribute)"
                                         >
                                             <option value=''>Leave empty</option>
                                             <option
-                                                ng-value="hxlAttribute"
-                                                ng-repeat="hxlAttribute in formAttribute.selectedTag.hxl_attributes"
-                                                ng-disabled="hxlAttributeSelected(hxlAttribute, formAttribute, a)"
+                                                    ng-value="hxlAttribute"
+                                                    ng-repeat="hxlAttribute in formAttribute.selectedTag.hxl_attributes"
+                                                    ng-disabled="hxlAttributeSelected(hxlAttribute, formAttribute, a)"
                                             >
-                                                 {{hxlAttribute.attribute}}
+                                                {{hxlAttribute.attribute}}
                                             </option>
 
                                         </select>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -110,7 +110,7 @@
                                         type="checkbox"
                                         checklist-model="formAttribute.selected"
                                         checklist-value="formAttribute.id"
-                                        ng-checked="formAttribute.selected"
+                                        ng-checked="_.isEmpty(attribute.selected)"
                                     >
                                 </td>
                                 <td>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -98,7 +98,7 @@
                                     <input type="checkbox" ng-model="form.selected" ng-value="1" ng-change="selectAll(form)">
                                 </td>
                                 <td>
-                                    <em translate="nav.select_all">Select all<em>
+                                    <em translate="nav.select_all">Select all</em>
                                 </td>
                                 <td></td>
                                 <td></td>
@@ -149,7 +149,7 @@
                                     <a ng-click="addAnother(formAttribute)" class="link-blue">Add another hxl attribute?</a>
                                 </td>
                                 <td>
-                                    {{formAttribute.pretty}}
+                                    <span ng-repeat="pretty in formAttribute.pretty"><em>{{pretty}} </em></span>
                                 </td>
                             </tr>
                         </tbody>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -132,18 +132,17 @@
                                     <div class="custom-select" ng-repeat="a in range(formAttribute)">
                                         <select
                                                 ng-disabled="!formAttribute.selectedTag"
-                                                ng-model="formAttribute.selectedHxlAttributes[a]"
+                                                ng-model="formAttribute.selectedHxlAttributes[a].attribute"
                                                 ng-change="selectHxlAttribute(formAttribute)"
                                         >
                                             <option value=''>Leave empty</option>
                                             <option
-                                                    ng-value="hxlAttribute"
+                                                    ng-value="hxlAttribute.attribute"
                                                     ng-repeat="hxlAttribute in formAttribute.selectedTag.hxl_attributes"
                                                     ng-disabled="hxlAttributeSelected(hxlAttribute, formAttribute, a)"
                                             >
                                                 {{hxlAttribute.attribute}}
                                             </option>
-
                                         </select>
                                     </div>
                                     <a ng-click="addAnother(formAttribute)" class="link-blue">Add another hxl attribute?</a>

--- a/app/settings/data-export/hdx-export.html
+++ b/app/settings/data-export/hdx-export.html
@@ -148,7 +148,7 @@
                                     <a ng-click="addAnother(formAttribute)" class="link-blue">Add another hxl attribute?</a>
                                 </td>
                                 <td>
-                                    <span ng-repeat="pretty in formAttribute.pretty"><em>{{pretty}} </em></span>
+                                    <span ng-repeat="hxl_label in formAttribute.hxl_label"><em>{{hxl_label}} </em></span>
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
This pull request makes the following changes:
-

Test with https://github.com/ushahidi/platform/pull/3136
Testing checklist:
## Expected behavior (UI)

- [ ] User checks 'Location field'
- [ ] Chooses #geo as the HXL tag
- [ ] Attribute drop-down becomes 'active' (not greyed out)
- [ ] User chooses +lon as the 1st attribute.
- [ ] A second attribute drop-down populated with +lat is automatically added. The tag preview is populated with the 'two' tag&attribute previews shown in the above screenshot. (#geo+lat and #geo+lon)
- [ ] User adds in a third attribute drop down (#geo can also be used with +elevation). The tag preview will populate with #geo+lat+elevation and #geo+lon+elevation (this is the way the csv will display it)



- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform


