### PR TITLE
fix(PasswordReset) password reset confirm tokens should be decoded

### DIFF
--- a/app/common/auth/password-reset-confirm.controller.js
+++ b/app/common/auth/password-reset-confirm.controller.js
@@ -3,8 +3,7 @@ module.exports = PasswordResetConfirmController;
 PasswordResetConfirmController.$inject = ['$rootScope', 'PasswordReset', '$location', '$transition$'];
 function PasswordResetConfirmController($rootScope, PasswordReset, $location, $transition$) {
     var $scope = $rootScope.$new();
-    $scope.token = $transition$.params().token;
-
+    $scope.token = decodeURIComponent($transition$.params().token);
     PasswordReset.openResetConfirm($scope);
     $location.url('/');
 }


### PR DESCRIPTION

This pull request makes the following changes:
- password reset confirm tokens should be decoded before we send to the server if coming from :token route (instead of directly pasting the confirm token in the confirm form) 

Testing checklist:
- [ ] Test with https://github.com/ushahidi/platform/pull/3151 


## Test case 1: 
- [ ]  Go to a ushahidi.io deployment 
- [ ]  Click on the Login button
- [ ]  In the login modal, click on "forgot your password? "
- [ ]  In the "Forgot your password" modal, set your email and hit the "RESET MY PASSWORD" button.
- [ ]  Wait for the password reset email. When you get the email, click on the "Reset your password" button. 
- [ ] In the Reset password modal, try to setup your new password. 
- [ ]  You should be able to reset your password and login with it

## Test case 2

- [ ] Go to a ushahidi.io deployment 
- [ ] Click on the Login button
- [ ] In the login modal, click on "forgot your password? "
- [ ] In the "Forgot your password" modal, set your email and hit the "RESET MY PASSWORD" button. Stay in the confirm modal.
- [ ] Wait for the password reset email. When you get the email, copy the token manually into the confirmation modal's "Password reset token" field and setup your new password. 
- [ ] You should be able to reset your password and login with it**




- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
