### PR TITLE
3105: replace "reports" with "posts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ server/www/img/icons/
 server/www/
 app/locales/
 package-lock.json
+app/stats.html

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -608,7 +608,7 @@
         "posts" : "Posts",
         "there_are_no_posts" : "There are no posts",
         "in_this_deployment" : " in this deployment, yet.",
-        "reports_total": " {{posts}} of {{total_nb}} reports",
+        "posts_total": " {{posts}} of {{total_nb}} posts",
         "by" : "by",
         "task_completed" : "Task completed",
         "everyone" : "Everyone",
@@ -703,7 +703,7 @@
             "unlocked" : "Post successfully unlocked",
             "unlock" : "Unlock",
             "lock_broken_by_other" : "Your Post has been unlocked. Your current unsaved changes will be lost.",
-            "locked_message" : "The report is locked because <strong>{{ user }}</strong> is working on it right now. Try editing a different post."
+            "locked_message" : "The post is locked because <strong>{{ user }}</strong> is working on it right now. Try editing a different post."
         },
         "modify" : {
             "intro" : "Select survey:",
@@ -1021,7 +1021,7 @@
             "saving_changes": "Saving",
             "unavailable": "The datasource {{value}} is unavailable. <a href=\"/settings/plan\">Upgrade your plan</a> to get it!",
             "email": {
-                "email_desc": "In order to receive reports by email, please input your email account settings below",
+                "email_desc": "In order to receive posts by email, please input your email account settings below",
                 "incoming_server_type": "Incoming Server Type",
                 "incoming_server_type_pop": "POP",
                 "incoming_server_type_imap": "IMAP",
@@ -1434,7 +1434,7 @@
             "stage_save_success" : "Updated {{stage}}",
             "export" : "This will export filtered posts. Are you sure you want to continue?",
             "update_status_success_bulk" : "Status updated for {{count}} posts",
-            "leave_without_save" : "Do you want to leave this report without saving?",
+            "leave_without_save" : "Do you want to leave this post without saving?",
             "leave_confirm_message" : "If you continue, all of your changes will be lost",
             "leave_confirm" : "Continue without saving"
         },

--- a/app/main/posts/common/post-lock.html
+++ b/app/main/posts/common/post-lock.html
@@ -6,7 +6,7 @@
     </div>
 
     <div class="message-body">
-        <p translate-values="{ user: user.realname }" translate="post.locking.locked_message">The report is locked because <strong>Seth Hall</strong> is working on it right now. Try editing a different post.</p>
+        <p translate-values="{ user: user.realname }" translate="post.locking.locked_message">The post is locked because <strong>Seth Hall</strong> is working on it right now. Try editing a different post.</p>
 
         <div class="button-group" ng-if="isAdmin()">
              <button class="button button-alpha" translate="post.locking.unlock" ng-click="unlock()">Unlock</button>

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -66,7 +66,7 @@
         <div class="listing timeline init">
 
         <div class="bulk-action" ng-if="posts.length > 0 || !isLoading()">
-            <div class="bulk-action-primary" translate="post.reports_total" translate-values="{'posts': posts.length, 'total_nb': totalItems }"></div>
+            <div class="bulk-action-primary" translate="post.posts_total" translate-values="{'posts': posts.length, 'total_nb': totalItems }"></div>
             <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin" translate="post.modify.bulk_actions">Bulk Actions</button>
         </div>
             <post-card

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -47,7 +47,7 @@
             <input type="text" placeholder="{{ 'survey.survey_name' | translate }}" ng-model="survey.name">
 
             <label class="hidden" translate>app.description</label>
-            <textarea placeholder="{{ 'survey.describe_your_survey' | translate }}" ng-model="survey.description">Reports about streets that need resurfacing, repairs, or the removal of a hazard.</textarea>
+            <textarea placeholder="{{ 'survey.describe_your_survey' | translate }}" ng-model="survey.description">Posts about streets that need resurfacing, repairs, or the removal of a hazard.</textarea>
         </div>
 
         <nav class="tabs-menu init" data-tabs="survey-details">


### PR DESCRIPTION
This pull request makes the following changes:
- fix: replaces reports with posts

Testing checklist:
- Navigate to data view
- [ ] confirm that total at top refers to "posts" not "reports"
- edit a post
- try to edit that same post in another window as another user
- [ ] error message should refer to "post" not "report"

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
