### PR TITLE
fix(HXLMetadata): add organisation_name to metadata to be able to generate hxl slugs correctly

### DIFF
--- a/app/settings/data-export/hdx-details.directive.js
+++ b/app/settings/data-export/hdx-details.directive.js
@@ -75,6 +75,11 @@ function HdxDetailsController($scope, $rootScope, $stateParams, LoadingProgress,
         if ($scope.metadata.$valid) {
             $scope.details.export_job_id = parseInt($state.params.jobId);
             $scope.details.user_id = $rootScope.currentUser.userId;
+            const organisation_id = $scope.details.organisation.id;
+            const organisation_name = $scope.details.organisation.name;
+            $scope.details.organisation = organisation_id;
+            $scope.details.organisation_name = organisation_name;
+
             HxlMetadataEndpoint.save($scope.details).$promise.then((response) => {
                 if (response.id) {
                     $scope.exportJob.hxl_meta_data_id = response.id;

--- a/app/settings/data-export/hdx-details.directive.js
+++ b/app/settings/data-export/hdx-details.directive.js
@@ -77,7 +77,7 @@ function HdxDetailsController($scope, $rootScope, $stateParams, LoadingProgress,
             $scope.details.user_id = $rootScope.currentUser.userId;
             const organisation_id = $scope.details.organisation.id;
             const organisation_name = $scope.details.organisation.name;
-            $scope.details.organisation = organisation_id;
+            $scope.details.organisation_id = organisation_id;
             $scope.details.organisation_name = organisation_name;
 
             HxlMetadataEndpoint.save($scope.details).$promise.then((response) => {

--- a/app/settings/data-export/hdx-details.directive.js
+++ b/app/settings/data-export/hdx-details.directive.js
@@ -75,10 +75,8 @@ function HdxDetailsController($scope, $rootScope, $stateParams, LoadingProgress,
         if ($scope.metadata.$valid) {
             $scope.details.export_job_id = parseInt($state.params.jobId);
             $scope.details.user_id = $rootScope.currentUser.userId;
-            const organisation_id = $scope.details.organisation.id;
-            const organisation_name = $scope.details.organisation.name;
-            $scope.details.organisation_id = organisation_id;
-            $scope.details.organisation_name = organisation_name;
+            $scope.details.organisation_id = $scope.details.organisation.id;
+            $scope.details.organisation_name = $scope.details.organisation.name;
 
             HxlMetadataEndpoint.save($scope.details).$promise.then((response) => {
                 if (response.id) {

--- a/app/settings/data-export/hdx-details.html
+++ b/app/settings/data-export/hdx-details.html
@@ -107,7 +107,7 @@
                     <div class="custom-select" >
                         <select name="organisation" ng-required="true" id="organisation" ng-model="details.organisation">
                             <option value="" translate="data_export.select_organisation">Select an organisation</option>
-                            <option ng-repeat="organisation in organisations" ng-value="organisation.id">{{organisation.name}}</option>
+                            <option ng-repeat="organisation in organisations" ng-value="organisation">{{organisation.name}}</option>
                         </select>
                     </div>
                     <div


### PR DESCRIPTION
This pull request makes the following changes:
- adds both organisation name to the HXL Metadata creation request. 
- Needs this PR https://github.com/ushahidi/platform/pull/3167 to test it

Testing checklist:
- [ ] Setup an hxl export with some hxl tags. Continue to the HXL Metadata setup page (after clicking "Upload to HDX")
- [ ] In the HXL metadata page you should see your list of organisations
- [ ] Select an organisation. 
- [ ] Fill in all the details in the page, and submit
- [ ] A new export job should be created. 

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
