### PR TITLE
Bugfix: replaces save with send when sending sms reply to post

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -760,6 +760,7 @@
             "reply" : "Reply to Message thread",
             "send" : "Send New Message",
             "save" : "Save",
+            "simple_send" : "Send",
             "title" : "Conversation with author",
             "associated_messages": "View messages associated with this post",
             "show_only_incoming": "Show only {{provider}} not assigned to a survey yet ",

--- a/app/main/posts/detail/post-messages-reply.html
+++ b/app/main/posts/detail/post-messages-reply.html
@@ -8,7 +8,7 @@
       <button type="submit" class="button-alpha modal-trigger"
 	      ng-submit="sendMessage()"
 	      ng-disabled="form.reply.$invalid"
-	      translate>post.messages.save</button>
+	      translate>post.messages.simple_send</button>
     </div>
   </form>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
-

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
