### PR TITLE
Export history into develop

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -12,7 +12,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
 
     // todo: move to service
     $rootScope.hasManageSettingsPermission = function () {
-        return $rootScope.isAdmin() ? true : (_.intersection(($rootScope.currentUser || {}).permissions, ['Manage Users', 'Manage Settings', 'Bulk Data Import']).length > 0);
+        return $rootScope.isAdmin() ? true : (_.intersection(($rootScope.currentUser || {}).permissions, ['Manage Users', 'Manage Settings', 'Bulk Data Import and Export']).length > 0);
     };
 
     // todo: move to service
@@ -79,7 +79,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     }
 
     function loadExportJob() {
-        if ($rootScope.hasPermission('Bulk Data Import')) {
+        if ($rootScope.hasPermission('Bulk Data Import and Export')) {
             DataExport.loadExportJob();
         }
     }

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1108,7 +1108,7 @@
             "manage_users": "Manage Users",
             "manage_posts": "Manage Posts",
             "manage_settings": "Mangage Settings",
-            "bulk_data_import": "Bulk Data Import",
+            "bulk_data_import": "Bulk Data Import and Export",
             "edit_own_posts": "Edit their own posts",
             "registred_member": "Registered member",
             "administrator": "Administrator"

--- a/app/main/posts/views/share/share-menu.directive.js
+++ b/app/main/posts/views/share/share-menu.directive.js
@@ -31,7 +31,7 @@ function ShareMenuController(
     $scope.loading = false;
     $scope.shareUrl = Util.currentUrl();
     $scope.isExportable = isExportable;
-    $scope.hasPermission = $rootScope.hasPermission('Bulk data import');
+    $scope.hasPermission = $rootScope.hasPermission('Bulk Data Import and Export');
 
     activate();
 

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -48,7 +48,7 @@ function (
     });
 
     // Redirect to home if not authorized
-    if ($rootScope.hasPermission('Bulk Data Import') === false) {
+    if ($rootScope.hasPermission('Bulk Data Import and Export') === false) {
         return $location.path('/');
     }
 

--- a/app/settings/data-import/data-import.html
+++ b/app/settings/data-import/data-import.html
@@ -20,7 +20,7 @@
     <main role="main">
 
         <div class="main-col" importer-csv>
-          <div class="alert" translate="feature_limits.view_unavailable" translate-values="{value: 'Bulk data import'}" ng-show="!csvEnabled">
+          <div class="alert" translate="feature_limits.view_unavailable" translate-values="{value: 'Bulk Data Import and Export'}" ng-show="!csvEnabled">
           </div>
           <form name="upload" ng-show="csvEnabled">
             <div class="form-sheet">

--- a/app/settings/settings-list.html
+++ b/app/settings/settings-list.html
@@ -43,7 +43,7 @@
                    </div>
                </div>
 
-               <div class="listing-item" ng-show="hasPermission('Bulk Data Import')">
+               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export')">
                    <div class="listing-item-primary">
                        <h2 class="listing-item-title"><a ui-sref="settings.dataImport" translate>settings.settings_list.import</a></h2>
                        <p class="listing-item-secondary" translate>settings.settings_list.import_desc</p>
@@ -57,7 +57,7 @@
                    </div>
                </div>
 
-               <div class="listing-item" ng-show="hasPermission('Bulk Data Import')">
+               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export')">
                    <div class="listing-item-primary">
                        <h2 class="listing-item-title">
                            <a ui-sref="settings.dataExport" translate>{{dataExportTitle}}</a></h2>


### PR DESCRIPTION
This pull request makes the following changes:
- replaces bulk imports to include exports so that permissions match the API. Allows users with manage imports and exports permissions to see their own exports


Testing checklist:
- Test with platform develop
- make sure you have a user that has manage imports/exports permissions
- login as that user
- go to settings->Export data
- Request an export
- go to export history
- [ ] export should show up (not including any exports done by other users)
---------
- login as admin
- go to settings->Export data
- Request an export
- go to export history
- [ ] export by admin should show up (not including any exports done by other users)

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
