### PR TITLE
Fixing redirect from map to specific post when in collections/savedsearch

### DIFF
--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -97,11 +97,13 @@ function (
                     }
                 }]
             },
-            onEnter: ['$state', 'PostFilters', function ($state, PostFilters) {
-                if (PostFilters.getMode() === 'savedsearch') {
-                    $state.go('posts.data.savedsearch', {savedSearchId: PostFilters.getModeId()});
-                } else if (PostFilters.getMode() === 'collection') {
-                    $state.go('posts.data.collection', {collectionId: PostFilters.getModeId()});
+            onEnter: ['$state', 'PostFilters', 'post', function ($state, PostFilters, post) {
+                if (!post) {
+                    if (PostFilters.getMode() === 'savedsearch') {
+                        $state.go('posts.data.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                    } else if (PostFilters.getMode() === 'collection') {
+                        $state.go('posts.data.collection', {collectionId: PostFilters.getModeId()});
+                    }
                 }
             }]
         }


### PR DESCRIPTION
## Requirements
When I select a post to see details while in a collection, I should be routed to the data view with that post selected

## Acceptance criteria
- navigate to a collection
- select a post
- click the post again to go to detail view
- [ ] confirm you are routed to the data view with the post selected

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3033

Ping @ushahidi/platform
