### PR TITLE
Updating route to support Posts linked from collections

### DIFF
--- a/app/main/posts/posts-routes.js
+++ b/app/main/posts/posts-routes.js
@@ -68,11 +68,13 @@ function (
             resolve: {
                 collection: resolveCollection
             },
-            onEnter: ['$state', 'collection', function ($state, collection) {
-                if (collection.view === 'data' || collection.view === 'list') {
-                    $state.go('posts.data.collection', {collectionId: collection.id});
-                } else {
-                    $state.go('posts.map.collection', {collectionId: collection.id});
+             onEnter: ['$state', 'PostFilters', 'post', function ($state, PostFilters, post) {
+                if (!post) {
+                    if (PostFilters.getMode() === 'savedsearch') {
+                        $state.go('posts.data.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                    } else if (PostFilters.getMode() === 'collection') {
+                        $state.go('posts.data.collection', {collectionId: PostFilters.getModeId()});
+                    }
                 }
             }]
         }


### PR DESCRIPTION
## Requirements
When I select a post to see details while in a collection, I should be routed to the data view with that post selected

## Acceptance criteria
- navigate to a collection
- select a post
- click the post again to go to detail view
- [ ] confirm you are routed to the data view with the post selected

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3033

Ping @ushahidi/platform
