### PR TITLE
3078 Fix: Add documentation to roles settings

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1111,7 +1111,8 @@
             "bulk_data_import": "Bulk Data Import and Export",
             "edit_own_posts": "Edit their own posts",
             "registred_member": "Registered member",
-            "administrator": "Administrator"
+            "administrator": "Administrator",
+            "roles_description": "These options control what this type of role you can make changes to. <a href=\"https://www.ushahidi.com/support/custom-roles#add-a-role\" target=\"_blank\">Visit our support guides to find out more."
         },
         "deployment_delete_this" : "Delete this deployment",
         "deployment_delete" : "Delete deployment",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -1112,7 +1112,7 @@
             "edit_own_posts": "Edit their own posts",
             "registred_member": "Registered member",
             "administrator": "Administrator",
-            "roles_description": "These options control what this type of role you can make changes to. <a href=\"https://www.ushahidi.com/support/custom-roles#add-a-role\" target=\"_blank\">Visit our support guides to find out more."
+            "roles_description": "These options control what this type of role can make changes to. <a href=\"https://www.ushahidi.com/support/custom-roles#add-a-role\" target=\"_blank\">Visit our support guides to find out more."
         },
         "deployment_delete_this" : "Delete this deployment",
         "deployment_delete" : "Delete deployment",

--- a/app/settings/roles/roles-edit.html
+++ b/app/settings/roles/roles-edit.html
@@ -52,6 +52,7 @@
 
                    <fieldset>
                        <legend translate>role.permissions</legend>
+                       <p translate>settings.roles.roles_description</p>
 
                        <div class="alert" ng-hide="permissions.length">
                            <p ng-hide="permissions.length"><em translate>empty.permission</em></p>


### PR DESCRIPTION
This pull request makes the following changes:
- adds documentation text and link to settings/roles page

Testing checklist:
- [ ] go to settings -> roles -> add and edit
- [ ] confirm that "These options control what this type of role you can make changes to. Visit our support guides to find out more." appears under permissions and links out to documentation page.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3078

Ping @ushahidi/platform
