### PR TITLE
DATA_IMPORT_EXPORT - revert after releasing to production .

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -79,7 +79,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     }
 
     function loadExportJob() {
-        if ($rootScope.hasPermission('Bulk Data Import and Export')) {
+        if ($rootScope.hasPermission('Bulk Data Import and Export') || $rootScope.hasPermission('Bulk Data Import')) {
             DataExport.loadExportJob();
         }
     }

--- a/app/main/posts/views/share/share-menu.directive.js
+++ b/app/main/posts/views/share/share-menu.directive.js
@@ -31,7 +31,7 @@ function ShareMenuController(
     $scope.loading = false;
     $scope.shareUrl = Util.currentUrl();
     $scope.isExportable = isExportable;
-    $scope.hasPermission = $rootScope.hasPermission('Bulk Data Import and Export');
+    $scope.hasPermission = $rootScope.hasPermission('Bulk Data Import and Export') || $rootScope.hasPermission('Bulk Data Import');
 
     activate();
 

--- a/app/settings/data-export/data-export.controller.js
+++ b/app/settings/data-export/data-export.controller.js
@@ -39,7 +39,7 @@ function (
     });
 
     // Redirect to home if not authorized
-    if ($rootScope.hasPermission('Bulk Data Import and Export') === false) {
+    if ($rootScope.hasPermission('Bulk Data Import and Export') === false && $rootScope.hasPermission('Bulk Data Import') === false) {
         return $location.path('/');
     }
     // Change layout class

--- a/app/settings/settings-list.html
+++ b/app/settings/settings-list.html
@@ -43,13 +43,13 @@
                    </div>
                </div>
 
-               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export')">
+               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export') || hasPermission('Bulk Data Import')">
                    <div class="listing-item-primary">
                        <h2 class="listing-item-title"><a ui-sref="settings.dataImport" translate>settings.settings_list.import</a></h2>
                        <p class="listing-item-secondary" translate>settings.settings_list.import_desc</p>
                    </div>
                </div>
-               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export')">
+               <div class="listing-item" ng-show="hasPermission('Bulk Data Import and Export') || hasPermission('Bulk Data Import')">
                <div class="listing-item">
                    <div class="listing-item-primary">
                        <h2 class="listing-item-title"><a ui-sref="settings.dataExport" translate>settings.settings_list.export</a></h2>


### PR DESCRIPTION
 This is a change to support the legacy DATA IMPORT permissions while we run migrations

##dependency 
- Test this changes with https://github.com/ushahidi/platform/pull/3190
This pull request makes the following changes:
- adds LEGACY DATA IMPORT 
- Checks for legacy and normal data import export permissions in the backend

Testing checklist:
## Normal test
- [ ] Create a new role with the data import-export permission
- [ ] Create a user with that role
- [ ] Login with that user:
    - you should be able to create an import for a survey
    - you should be able to start an export 
## Legacy database test
- [ ] Create a new role with the data import-export permission
- [ ] Create a user with that role
- [ ] Rename the permission to "Bulk Data Import" in the database (permissions table)
- [ ] Login with that user:
    - you should be able to create an import for a survey. 
    - you should be able to start an export .
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
