### PR TITLE
Targeted & Crowdsourced Survey stats in activity view

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -144,7 +144,23 @@
         "recent_activity_timeline" : "Recent Activity timeline",
         "new_post" : "New Post",
         "by" : "By",
-        "context_body": "A summary of how people are interacting with {{site}}."
+        "context_body": "A summary of how people are interacting with {{site}}.",
+        "inbound": "Inbound Response Messages",
+        "outbound": "Outbound Surveying Messages",
+        "recipients": "Unique Recipients of Targeted Survey",
+        "responders": "Unique Responders to Targeted Survey",
+        "all_targeted": "All Targeted Surveys",
+        "no_targeted": "You don't have any Targeted Survey data to show.",
+        "all_sources": "All Data Souces",
+        "web_mobile": "Web and Mobile",
+        "email": "email",
+        "sms": "sms",
+        "twitter": "twitter",
+        "all_crowdsourced": "All Crowdsourced Surveys",
+        "no_crowdsourced": "You don't have any Crowdsourced Survey data to show.",
+        "targeted_activity": "Tageted Survey Activity",
+        "crowdsourced_activity": "Crowdsourced Survey Activity"
+
     },
     "form": {
         "add_field" : "Add field",

--- a/app/common/services/endpoints/form-stats-endpoint.js
+++ b/app/common/services/endpoints/form-stats-endpoint.js
@@ -6,12 +6,13 @@ function (
     Util
 ) {
 
-    var FormStatsEndpoint = $resource(Util.apiUrl('/forms/:formId/stats/'), {
+    var FormStatsEndpoint = $resource(Util.apiUrl('/forms/:formId/stats/:extra'), {
         formId: '@formId'
     }, {
         query: {
             method: 'GET',
             isArray: false,
+            paramSerializer: '$httpParamSerializerJQLike',
             transformResponse: function (data /*, header*/) {
                 return angular.fromJson(data);
             }

--- a/app/main/activity/activity-module.js
+++ b/app/main/activity/activity-module.js
@@ -5,4 +5,6 @@ angular.module('ushahidi.activity', [])
 .directive('activityTimeline', require('./activity-timeline.directive.js'))
 .directive('activityBarChart', require('./bar-chart.directive.js'))
 .directive('activityTimeChart', require('./time-chart.directive.js'))
+.directive('targetedSurveyTable', require('./targeted-survey-table.directive.js'))
+.directive('crowdsourcedSurveyTable', require('./crowdsourced-survey-table.directive.js'))
 ;

--- a/app/main/activity/activity.controller.js
+++ b/app/main/activity/activity.controller.js
@@ -1,8 +1,8 @@
 module.exports = ActivityController;
 
-ActivityController.$inject = ['$scope', '$translate', 'moment', 'Features'];
+ActivityController.$inject = ['$rootScope', '$scope', '$translate', 'moment', 'Features'];
 
-function ActivityController($scope, $translate, moment, Features) {
+function ActivityController($rootScope, $scope, $translate, moment, Features) {
     // Initial values
     $scope.isActivityAvailable = false;
     $scope.currentInterval = 'all';
@@ -16,6 +16,8 @@ function ActivityController($scope, $translate, moment, Features) {
 
     $scope.saveFilters = saveFilters;
     $scope.cancelChangeFilters = cancelChangeFilters;
+    $scope.targetedSurveysEnabled = false;
+    $scope.loggedIn = false;
 
     activate();
 
@@ -26,9 +28,14 @@ function ActivityController($scope, $translate, moment, Features) {
         $translate('nav.activity').then(function (title) {
             $scope.$emit('setPageTitle', title);
         });
+        if ($rootScope.loggedin) {
+            $scope.loggedIn = true;
+        }
 
         Features.loadFeatures().then(function () {
             $scope.isActivityAvailable = Features.isViewEnabled('activity');
+            $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
+
         });
 
         update();

--- a/app/main/activity/activity.html
+++ b/app/main/activity/activity.html
@@ -122,6 +122,8 @@
                         <activity-time-chart filters="filters"></activity-bar-chart>
                     </div>
                 </div>
+            </div>
+            <div class="listing card init">
                 <div class="listing-item active">
                    <div class="listing-item-secondary">
                         <button ng-show="todo" type="button" class="button-beta button-flat">
@@ -142,7 +144,30 @@
                     </div>
                 </div>
             </div>
+            <div ng-if="targetedSurveysEnabled && loggedIn" class="listing card init">
+                <div class="listing-item active">
+                    <div class="listing-item-primary">
+                        <h2 class="listing-item-title" translate="">Tageted Survey Activity</h2>
+                    </div>
+
+                    <div class="listing-item-body">
+                        <targeted-survey-table filters="filters"></targeted-survey-table>
+                    </div>
+                </div>
+            </div>
+            <div class="listing card init" ng-if="loggedIn">
+                <div class="listing-item active">
+                    <div class="listing-item-primary">
+                        <h2 class="listing-item-title" translate="">Crowdsourced Survey Activity</h2>
+                    </div>
+
+                    <div class="listing-item-body">
+                        <crowdsourced-survey-table filters="filters"></crowdsourced-survey-table>
+                    </div>
+                </div>
+            </div>
         </div> <!--end main column-->
+
 
         <aside class="secondary-col" role="complementary">
             <!-- <activity-timeline></activity-timeline> -->

--- a/app/main/activity/activity.html
+++ b/app/main/activity/activity.html
@@ -147,7 +147,7 @@
             <div ng-if="targetedSurveysEnabled && loggedIn" class="listing card init">
                 <div class="listing-item active">
                     <div class="listing-item-primary">
-                        <h2 class="listing-item-title" translate="">Tageted Survey Activity</h2>
+                        <h2 class="listing-item-title" translate="activity.targeted_activity">Tageted Survey Activity</h2>
                     </div>
 
                     <div class="listing-item-body">
@@ -158,7 +158,7 @@
             <div class="listing card init" ng-if="loggedIn">
                 <div class="listing-item active">
                     <div class="listing-item-primary">
-                        <h2 class="listing-item-title" translate="">Crowdsourced Survey Activity</h2>
+                        <h2 class="listing-item-title" translate="activity.crowdsourced_activity">Crowdsourced Survey Activity</h2>
                     </div>
 
                     <div class="listing-item-body">

--- a/app/main/activity/crowdsourced-survey-table.directive.js
+++ b/app/main/activity/crowdsourced-survey-table.directive.js
@@ -14,11 +14,11 @@ function CrowdsourcedSurveyTable() {
 CrowdsourcedSurveyTableController.$inject = ['$scope', '$translate', 'FormEndpoint', 'FormStatsEndpoint', 'FormContactEndpoint', 'PostEndpoint', '_', 'PostFilters', 'Session'];
 function CrowdsourcedSurveyTableController($scope, $translate, FormEndpoint, FormStatsEndpoint, FormContactEndpoint, PostEndpoint, _, PostFilters, Session) {
     $scope.crowdsourcedSurveyStatsByForm = [];
-    $scope.totalAllReduced = 0;
-    $scope.totalWebReduced = 0;
-    $scope.totalEmailReduced = 0;
-    $scope.totalSmsReduced = 0;
-    $scope.totalTwitterReduced = 0;
+    $scope.totalAll = 0;
+    $scope.totalWeb = 0;
+    $scope.totalEmail = 0;
+    $scope.totalSms = 0;
+    $scope.totalTwitter = 0;
     $scope.noSurveys = false;
     $scope.unstructuredStats = {};
 
@@ -33,39 +33,41 @@ function CrowdsourcedSurveyTableController($scope, $translate, FormEndpoint, For
 
     function clearStats() {
         $scope.crowdsourcedSurveyStatsByForm = [];
-        $scope.totalAllReduced = 0;
-        $scope.totalWebReduced = 0;
-        $scope.totalEmailReduced = 0;
-        $scope.totalSmsReduced = 0;
-        $scope.totalTwitterReduced = 0;
+        $scope.totalAll = 0;
+        $scope.totalWeb = 0;
+        $scope.totalEmail = 0;
+        $scope.totalSms = 0;
+        $scope.totalTwitter = 0;
         $scope.unstructuredStats = {};
     }
 
     function getFormStats() {
         FormEndpoint.query().$promise.then((forms) => {
-            if (crowdsourcedSurveysExist) {
+            if (!crowdsourcedSurveysExist(forms)) {
+                $scope.noSurveys = true;
+            } else {
                 $scope.noSurveys = false;
                 forms.forEach((form) => {
                     if (!form.targeted_survey) {
                         let query = PostFilters.getQueryParams($scope.filters) || {};
-                        var postQuery = _.extend({}, query, {
+                        let postQuery = _.extend({}, query, {
                             formId: form.id
                         });
 
                         FormStatsEndpoint.query(postQuery).$promise.then((stats) => {
                             stats.name = form.name;
                             $scope.crowdsourcedSurveyStatsByForm.push(stats);
-                            $scope.totalAllReduced += parseInt(stats.total_by_data_source.all);
-                            $scope.totalWebReduced += parseInt(stats.total_by_data_source.web);
-                            $scope.totalEmailReduced += parseInt(stats.total_by_data_source.email);
-                            $scope.totalSmsReduced += parseInt(stats.total_by_data_source.sms);
-                            $scope.totalTwitterReduced += parseInt(stats.total_by_data_source.twitter);
+                            $scope.totalAll += parseInt(stats.total_by_data_source.all);
+                            $scope.totalWeb += parseInt(stats.total_by_data_source.web);
+                            $scope.totalEmail += parseInt(stats.total_by_data_source.email);
+                            $scope.totalSms += parseInt(stats.total_by_data_source.sms);
+                            $scope.totalTwitter += parseInt(stats.total_by_data_source.twitter);
 
                         });
                     }
                 });
                 let query = PostFilters.getQueryParams($scope.filters) || {};
-                var postQuery = _.extend({}, query, {
+                let postQuery = _.extend({}, query, {
                     form: 'none'
                 });
                 PostEndpoint.query(postQuery).$promise.then((posts) => {
@@ -81,8 +83,6 @@ function CrowdsourcedSurveyTableController($scope, $translate, FormEndpoint, For
                         $scope.unstructuredStats[post.source]++;
                     });
                 });
-            } else {
-                $scope.noSurveys = true;
             }
         });
     }

--- a/app/main/activity/crowdsourced-survey-table.directive.js
+++ b/app/main/activity/crowdsourced-survey-table.directive.js
@@ -1,0 +1,97 @@
+module.exports = CrowdsourcedSurveyTable;
+
+function CrowdsourcedSurveyTable() {
+    return {
+        restrict: 'E',
+        scope: {
+            filters: '='
+        },
+        controller: CrowdsourcedSurveyTableController,
+        template: require('./crowdsourced-survey-table.html')
+    };
+}
+
+CrowdsourcedSurveyTableController.$inject = ['$scope', '$translate', 'FormEndpoint', 'FormStatsEndpoint', 'FormContactEndpoint', 'PostEndpoint', '_', 'PostFilters', 'Session'];
+function CrowdsourcedSurveyTableController($scope, $translate, FormEndpoint, FormStatsEndpoint, FormContactEndpoint, PostEndpoint, _, PostFilters, Session) {
+    $scope.crowdsourcedSurveyStatsByForm = [];
+    $scope.totalAllReduced = 0;
+    $scope.totalWebReduced = 0;
+    $scope.totalEmailReduced = 0;
+    $scope.totalSmsReduced = 0;
+    $scope.totalTwitterReduced = 0;
+    $scope.noSurveys = false;
+    $scope.unstructuredStats = {};
+
+    // whenever the filters changes, update the current list of posts
+    // this also initiates the first call to get form stats because
+    // it is called when the filters load the first time
+    $scope.$watch('filters', function () {
+        clearStats();
+        getFormStats();
+    }, true);
+    PostFilters.setMode('activity');
+
+    function clearStats() {
+        $scope.crowdsourcedSurveyStatsByForm = [];
+        $scope.totalAllReduced = 0;
+        $scope.totalWebReduced = 0;
+        $scope.totalEmailReduced = 0;
+        $scope.totalSmsReduced = 0;
+        $scope.totalTwitterReduced = 0;
+        $scope.unstructuredStats = {};
+    }
+
+    function getFormStats() {
+        FormEndpoint.query().$promise.then((forms) => {
+            if (crowdsourcedSurveysExist) {
+                $scope.noSurveys = false;
+                forms.forEach((form) => {
+                    if (!form.targeted_survey) {
+                        let query = PostFilters.getQueryParams($scope.filters) || {};
+                        var postQuery = _.extend({}, query, {
+                            formId: form.id
+                        });
+
+                        FormStatsEndpoint.query(postQuery).$promise.then((stats) => {
+                            stats.name = form.name;
+                            $scope.crowdsourcedSurveyStatsByForm.push(stats);
+                            $scope.totalAllReduced += parseInt(stats.total_by_data_source.all);
+                            $scope.totalWebReduced += parseInt(stats.total_by_data_source.web);
+                            $scope.totalEmailReduced += parseInt(stats.total_by_data_source.email);
+                            $scope.totalSmsReduced += parseInt(stats.total_by_data_source.sms);
+                            $scope.totalTwitterReduced += parseInt(stats.total_by_data_source.twitter);
+
+                        });
+                    }
+                });
+                let query = PostFilters.getQueryParams($scope.filters) || {};
+                var postQuery = _.extend({}, query, {
+                    form: 'none'
+                });
+                PostEndpoint.query(postQuery).$promise.then((posts) => {
+                    $scope.unstructuredStats = {
+                        name: 'Unstructured Posts',
+                        all: posts.results.length,
+                        web: 0,
+                        email: 0,
+                        sms: 0,
+                        twitter: 0
+                    };
+                    posts.results.forEach((post) => {
+                        $scope.unstructuredStats[post.source]++;
+                    });
+                });
+            } else {
+                $scope.noSurveys = true;
+            }
+        });
+    }
+
+    function crowdsourcedSurveysExist(forms) {
+        return forms.find((form) => {
+            if (!form.targeted_survey) {
+                return true;
+            }
+        });
+    }
+}

--- a/app/main/activity/crowdsourced-survey-table.html
+++ b/app/main/activity/crowdsourced-survey-table.html
@@ -5,11 +5,11 @@
             <thead>
                 <tr>
                     <th></th>
-                    <th translate>All Data Sources</th>
-                    <th translate>Web and Mobile</th>
-                    <th translate>Email</th>
-                    <th translate>SMS</th>
-                    <th translate>Twitter</th>
+                    <th translate="activity.all_sources">All Data Sources</th>
+                    <th translate="activity.web_mobile">Web and Mobile</th>
+                    <th translate="activity.email">Email</th>
+                    <th translate="activity.sms">SMS</th>
+                    <th translate="activity.twitter">Twitter</th>
                     
                 </tr>
             </thead>
@@ -32,7 +32,7 @@
                     <td>{{unstructuredStats.twitter}}</td>
                 </tr>
                 <tr>
-                    <td>All Crowdsourced Surveys</td>
+                    <td translate="activity.">All Crowdsourced Surveys</td>
                     <td>{{totalAll}}</td>
                     <td>{{totalWeb}}</td>
                     <td>{{totalEmail}}</td>
@@ -42,5 +42,5 @@
             </tbody>
         </table>
     </fieldset>
-    <p ng-if="noSurveys">You don't have any Crowdsourced Survey data to show.</p>
+    <p translate="activity.no_crowdsourced" ng-if="noSurveys">You don't have any Crowdsourced Survey data to show.</p>
 </div>

--- a/app/main/activity/crowdsourced-survey-table.html
+++ b/app/main/activity/crowdsourced-survey-table.html
@@ -33,11 +33,11 @@
                 </tr>
                 <tr>
                     <td>All Crowdsourced Surveys</td>
-                    <td>{{totalAllReduced}}</td>
-                    <td>{{totalWebReduced}}</td>
-                    <td>{{totalEmailReduced}}</td>
-                    <td>{{totalSmsReduced}}</td>
-                    <td>{{totalTwitterReduced}}</td>
+                    <td>{{totalAll}}</td>
+                    <td>{{totalWeb}}</td>
+                    <td>{{totalEmail}}</td>
+                    <td>{{totalSms}}</td>
+                    <td>{{totalTwitter}}</td>
                 </tr>
             </tbody>
         </table>

--- a/app/main/activity/crowdsourced-survey-table.html
+++ b/app/main/activity/crowdsourced-survey-table.html
@@ -1,0 +1,46 @@
+<div>
+    <loading-dots button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="crowdsourcedSurveyStatsByForm.length === 0"></loading-dots>
+    <fieldset ng-if="crowdsourcedSurveyStatsByForm.length >= 1">
+        <table>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th translate>All Data Sources</th>
+                    <th translate>Web and Mobile</th>
+                    <th translate>Email</th>
+                    <th translate>SMS</th>
+                    <th translate>Twitter</th>
+                    
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr ng-repeat="survey in crowdsourcedSurveyStatsByForm">
+                    <td>{{survey.name}}</td>
+                    <td>{{survey.total_by_data_source.all}}</td>
+                    <td>{{survey.total_by_data_source.web}}</td>
+                    <td>{{survey.total_by_data_source.email}}</td>
+                    <td>{{survey.total_by_data_source.sms}}</td>
+                    <td>{{survey.total_by_data_source.twitter}}</td>
+                </tr>
+                <tr>
+                    <td>{{unstructuredStats.name}}</td>
+                    <td>{{unstructuredStats.all}}</td>
+                    <td>{{unstructuredStats.web}}</td>
+                    <td>{{unstructuredStats.email}}</td>
+                    <td>{{unstructuredStats.sms}}</td>
+                    <td>{{unstructuredStats.twitter}}</td>
+                </tr>
+                <tr>
+                    <td>All Crowdsourced Surveys</td>
+                    <td>{{totalAllReduced}}</td>
+                    <td>{{totalWebReduced}}</td>
+                    <td>{{totalEmailReduced}}</td>
+                    <td>{{totalSmsReduced}}</td>
+                    <td>{{totalTwitterReduced}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </fieldset>
+    <p ng-if="noSurveys">You don't have any Crowdsourced Survey data to show.</p>
+</div>

--- a/app/main/activity/targeted-survey-table.directive.js
+++ b/app/main/activity/targeted-survey-table.directive.js
@@ -1,0 +1,75 @@
+module.exports = TargetedSurveyTable;
+
+function TargetedSurveyTable() {
+    return {
+        restrict: 'E',
+        scope: {
+            filters: '='
+        },
+        controller: TargetedSurveyTableController,
+        template: require('./targeted-survey-table.html')
+    };
+}
+
+TargetedSurveyTableController.$inject = ['$rootScope', '$scope', '$translate', 'FormEndpoint', 'FormStatsEndpoint', 'FormContactEndpoint', 'PostEndpoint', '_', 'PostFilters', 'Session'];
+function TargetedSurveyTableController($rootScope, $scope, $translate, FormEndpoint, FormStatsEndpoint, FormContactEndpoint, PostEndpoint, _, PostFilters, Session) {
+    $scope.targetedSurveyStatsByForm = [];
+    $scope.totalResponsesReduced = 0;
+    $scope.totalMessagesSentReduced = 0;
+    $scope.totalRecipientsReduced = 0;
+    $scope.totalResponseRecipientsReduced = 0;
+    $scope.noSurveys = false;
+
+    // whenever the filters changes, update the current list of posts
+    // this also initiates the first call to get form stats because
+    // it is called when the filters load the first time
+    $scope.$watch('filters', function () {
+        if ($rootScope.loggedin) {
+            clearStats();
+            getFormStats();
+        }
+    }, true);
+    PostFilters.setMode('activity');
+
+    function clearStats() {
+        $scope.targetedSurveyStatsByForm = [];
+        $scope.totalResponsesReduced = 0;
+        $scope.totalMessagesSentReduced = 0;
+        $scope.totalRecipientsReduced = 0;
+        $scope.totalResponseRecipientsReduced = 0;
+    }
+
+    function getFormStats() {
+        FormEndpoint.query().$promise.then((forms) => {
+            if (!targetedSurveysExist(forms)) {
+                $scope.noSurveys = true;
+            } else {
+                $scope.noSurveys = false;
+                forms.forEach((form) => {
+                    if (form.targeted_survey) {
+                        let query = PostFilters.getQueryParams($scope.filters) || {};
+                        var postQuery = _.extend({}, query, {
+                            formId: form.id
+                        });
+                        FormStatsEndpoint.query(postQuery).$promise.then((stats) => {
+                            stats.name = form.name;
+                            $scope.targetedSurveyStatsByForm.push(stats);
+                            $scope.totalResponsesReduced += stats.total_responses;
+                            $scope.totalMessagesSentReduced += stats.total_messages_sent;
+                            $scope.totalRecipientsReduced += stats.total_recipients;
+                            $scope.totalResponseRecipientsReduced += stats.total_response_recipients;
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    function targetedSurveysExist(forms) {
+        return forms.find((form) => {
+            if (form.targeted_survey) {
+                return true;
+            }
+        });
+    }
+}

--- a/app/main/activity/targeted-survey-table.directive.js
+++ b/app/main/activity/targeted-survey-table.directive.js
@@ -14,10 +14,10 @@ function TargetedSurveyTable() {
 TargetedSurveyTableController.$inject = ['$rootScope', '$scope', '$translate', 'FormEndpoint', 'FormStatsEndpoint', 'FormContactEndpoint', 'PostEndpoint', '_', 'PostFilters', 'Session'];
 function TargetedSurveyTableController($rootScope, $scope, $translate, FormEndpoint, FormStatsEndpoint, FormContactEndpoint, PostEndpoint, _, PostFilters, Session) {
     $scope.targetedSurveyStatsByForm = [];
-    $scope.totalResponsesReduced = 0;
-    $scope.totalMessagesSentReduced = 0;
-    $scope.totalRecipientsReduced = 0;
-    $scope.totalResponseRecipientsReduced = 0;
+    $scope.totalResponses = 0;
+    $scope.totalMessagesSent = 0;
+    $scope.totalRecipients = 0;
+    $scope.totalResponseRecipients = 0;
     $scope.noSurveys = false;
 
     // whenever the filters changes, update the current list of posts
@@ -33,10 +33,10 @@ function TargetedSurveyTableController($rootScope, $scope, $translate, FormEndpo
 
     function clearStats() {
         $scope.targetedSurveyStatsByForm = [];
-        $scope.totalResponsesReduced = 0;
-        $scope.totalMessagesSentReduced = 0;
-        $scope.totalRecipientsReduced = 0;
-        $scope.totalResponseRecipientsReduced = 0;
+        $scope.totalResponses = 0;
+        $scope.totalMessagesSent = 0;
+        $scope.totalRecipients = 0;
+        $scope.totalResponseRecipients = 0;
     }
 
     function getFormStats() {
@@ -48,16 +48,16 @@ function TargetedSurveyTableController($rootScope, $scope, $translate, FormEndpo
                 forms.forEach((form) => {
                     if (form.targeted_survey) {
                         let query = PostFilters.getQueryParams($scope.filters) || {};
-                        var postQuery = _.extend({}, query, {
+                        let postQuery = _.extend({}, query, {
                             formId: form.id
                         });
                         FormStatsEndpoint.query(postQuery).$promise.then((stats) => {
                             stats.name = form.name;
                             $scope.targetedSurveyStatsByForm.push(stats);
-                            $scope.totalResponsesReduced += stats.total_responses;
-                            $scope.totalMessagesSentReduced += stats.total_messages_sent;
-                            $scope.totalRecipientsReduced += stats.total_recipients;
-                            $scope.totalResponseRecipientsReduced += stats.total_response_recipients;
+                            $scope.totalResponses += stats.total_responses;
+                            $scope.totalMessagesSent += stats.total_messages_sent;
+                            $scope.totalRecipients += stats.total_recipients;
+                            $scope.totalResponseRecipients += stats.total_response_recipients;
                         });
                     }
                 });

--- a/app/main/activity/targeted-survey-table.html
+++ b/app/main/activity/targeted-survey-table.html
@@ -23,10 +23,10 @@
                 </tr>
                 <tr>
                     <td>All Targeted Surveys</td>
-                    <td>{{totalResponsesReduced}}</td>
-                    <td>{{totalMessagesSentReduced}}</td>
-                    <td>{{totalRecipientsReduced}}</td>
-                    <td>{{totalResponseRecipientsReduced}}</td>
+                    <td>{{totalResponses}}</td>
+                    <td>{{totalMessagesSent}}</td>
+                    <td>{{totalRecipients}}</td>
+                    <td>{{totalResponseRecipients}}</td>
                 </tr>
             </tbody>
         </table>

--- a/app/main/activity/targeted-survey-table.html
+++ b/app/main/activity/targeted-survey-table.html
@@ -1,0 +1,35 @@
+<div>
+    <loading-dots button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="targetedSurveyStatsByForm.length === 0"></loading-dots>
+    <fieldset ng-if="targetedSurveyStatsByForm.length >= 1">
+        <table>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th translate>Inbound Response Messages</th>
+                    <th translate>Outbound Surveying Messages</th>
+                    <th translate>Unique Recipients of Targeted Survey</th>
+                    <th translate>Unique Responders to Targeted Survey</th>
+                    
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr ng-repeat="survey in targetedSurveyStatsByForm">
+                    <td>{{survey.name}}</td>
+                    <td>{{survey.total_responses}}</td>
+                    <td>{{survey.total_messages_sent}}</td>
+                    <td>{{survey.total_recipients}}</td>
+                    <td>{{survey.total_response_recipients}}</td>
+                </tr>
+                <tr>
+                    <td>All Targeted Surveys</td>
+                    <td>{{totalResponsesReduced}}</td>
+                    <td>{{totalMessagesSentReduced}}</td>
+                    <td>{{totalRecipientsReduced}}</td>
+                    <td>{{totalResponseRecipientsReduced}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </fieldset>
+    <p ng-if="noSurveys">You don't have any Targeted Survey data to show.</p>
+</div>

--- a/app/main/activity/targeted-survey-table.html
+++ b/app/main/activity/targeted-survey-table.html
@@ -5,10 +5,10 @@
             <thead>
                 <tr>
                     <th></th>
-                    <th translate>Inbound Response Messages</th>
-                    <th translate>Outbound Surveying Messages</th>
-                    <th translate>Unique Recipients of Targeted Survey</th>
-                    <th translate>Unique Responders to Targeted Survey</th>
+                    <th translate="activity.inbound">Inbound Response Messages</th>
+                    <th translate="activity.outbound">Outbound Surveying Messages</th>
+                    <th translate="activity.recipients">Unique Recipients of Targeted Survey</th>
+                    <th translate="activity.responders">Unique Responders to Targeted Survey</th>
                     
                 </tr>
             </thead>
@@ -22,7 +22,7 @@
                     <td>{{survey.total_response_recipients}}</td>
                 </tr>
                 <tr>
-                    <td>All Targeted Surveys</td>
+                    <td translate="activity.all_targeted">All Targeted Surveys</td>
                     <td>{{totalResponses}}</td>
                     <td>{{totalMessagesSent}}</td>
                     <td>{{totalRecipients}}</td>
@@ -31,5 +31,5 @@
             </tbody>
         </table>
     </fieldset>
-    <p ng-if="noSurveys">You don't have any Targeted Survey data to show.</p>
+    <p translate="activity.no_targeted" ng-if="noSurveys">You don't have any Targeted Survey data to show.</p>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds view for target survey and crowdsourced survey stats tables in activity view

Testing checklist:
- [ ] go to activity without targeted surveys enabled, you shouldn't see the tables
- [ ] go to activity not logged in, you shouldn't see the tables
- [ ] go to activity with targeted surveys enabled and logged in, tables should appear!
------
while logged in with targeted surveys enabled:
- [ ] go to activity without any surveys or posts, you should see a nice message telling you that you have no posts
-------
now make some surveys and posts, both targeted surveys and regular ones with various data-source types
- [ ] go to activity and see that each table shows the correct data 
- [ ] the totals should add up correctly at the bottom of each table
-------
add some filters
- [ ] see that the loading dots appear while we get new data
- [ ] see that each table now shows the correct data with your date filters applied

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
