### PR TITLE
always allow admin to submit to surveys (cherry-picked commit to lumen/develop)

### DIFF
--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -284,7 +284,6 @@ function SurveyEditorController(
             var roles_allowed = results[3];
 
             $scope.roles_allowed = _.pluck(roles_allowed, 'role_id');
-
             // Remove source survey information
             if ($scope.actionType === 'duplicate') {
 
@@ -654,6 +653,11 @@ function SurveyEditorController(
     }
 
     function saveRoles() {
+        // adding admin to roles_allowed if not already there
+        let admin = _.findWhere($scope.roles, {name: 'admin'});
+        if (!$scope.survey.everyone_can_create && _.indexOf($scope.roles_allowed, admin.id) === -1) {
+            $scope.roles_allowed.push(admin.id);
+        }
         return FormRoleEndpoint
         .saveCache(_.extend({ roles: $scope.roles_allowed }, { formId: $scope.survey.id }))
         .$promise;

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -195,7 +195,13 @@
               <div class="form-fieldgroup init" data-fieldgroup-target="survey-add_roles" ng-class="{true:'', false:'active'}[survey.everyone_can_create]">
                 <div class="form-field checkbox" ng-repeat="role in roles">
                   <label>
-                    <input type="checkbox" checklist-model="roles_allowed" checklist-value="role.id">
+                    <input
+                        type="checkbox"
+                        checklist-model="roles_allowed"
+                        ng-disabled="role.name === 'admin'"
+                        ng-checked="role.name === 'admin'"
+                        checklist-value="role.id"
+                    >
                     {{role.display_name | translate}}
                   </label>
                 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Always selects and disables the Admin-options in settings->surveys->configure->who can contribute to this survey (if the specific-roles is selected)

Testing checklist:
- Log in as an admin
- [x] Create a new role and assign a new user with that role
- Go to settings-> surveys-> select a survey
- Click on configuration-tab
- Click on "Specific roles" in "Who can contribute to this survey
- [x] The admin-option should be greyed out and selected
- Select on the newly created role and save the survey
-  As an admin, try submitting a post to the survey
- [x] The post should save as normal
- Log out and login as the new member with the new role
- Submit a post to the survey
- [x] The post should save as normal
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3129 .

Ping @ushahidi/platform
