### PR TITLE
feat: Add PUBLIC_PATH env option to set public path for assets

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -215,6 +215,7 @@ gulp.task('serve:static', function() {
         ui: false,
         codeSync: false,
         open: false,
+        cors: true,
         middleware: [
           historyApiFallback()
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,13 @@ module.exports = {
       },
       {
         test: /\.svg/,
-        use: 'svg-url-loader?limit=1'
+        use: {
+          loader: 'svg-url-loader',
+          options : {
+            publicPath: '/',
+            limit: 1
+          }
+        }
       },
       {
         test: /\.woff/,

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -5,7 +5,7 @@ var config  = require('./webpack.config');
 config.output = {
   filename: '[name].[chunkhash].js',
   chunkFilename: '[name].[chunkhash].js',
-  publicPath: '',
+  publicPath: process.env.PUBLIC_PATH || '/',
   path: path.resolve(__dirname, 'server/www') // Overwritten by gulp
 };
 


### PR DESCRIPTION
This pull request makes the following changes:
- Add PUBLIC_PATH env option to set public path for assets

Testing checklist:
- [ ] Run `PUBLIC_PATH=http://assets.test.com gulp dist`
- [ ] Check generated index.html refs correct domain
- [ ] Load the app through some http server (`gulp serve:static`) and confirm all assets work
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#1610

Ping @ushahidi/platform
