### PR TITLE
fix: Allow + in phone numbers

### DIFF
--- a/app/common/user-profile/notifications.html
+++ b/app/common/user-profile/notifications.html
@@ -72,7 +72,7 @@
                    ng-class="{ 'error': editContactForm.contact.$invalid && editContactForm.contact.$dirty }"
                    ng-maxlength="25"
                    ng-model="contact.contact"
-                   ng-pattern="/^\d+$/"
+                   ng-pattern="/^\+?\d+$/"
                    required>
           </div>
         </form>


### PR DESCRIPTION
This pull request makes the following changes:
- Allow + in phone numbers, otherwise numbers are never valid for twilio

Testing checklist:
- [x] Edit user profile
- [x] Go to notifications view
- [x] Add a phone number and include a +
- [x] Phone number can be saved
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
