### PR TITLE
Add PUBLIC_PATH env option to set folder for assets 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm-install-silent.sh
 COPY . ./
 ARG TX_USERNAME
 ARG TX_PASSWORD
+ENV PUBLIC_PATH '/assets/'
 RUN TX_USERNAME="${TX_USERNAME}" TX_PASSWORD="${TX_PASSWORD}" gulp build
 
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -61,9 +61,22 @@ gulp.task('dist:config', () => {
 
 // Build webpack for production
 gulp.task('dist:webpack', (done) => {
+  // process request for static assets
+  if (process.env.PUBLIC_PATH) {
+    if (process.env.PUBLIC_PATH[0] !== '/') {
+      throw Error('PUBLIC_PATH must begin with /');
+    }
+    if (process.env.PUBLIC_PATH.slice(-1) !== '/') {
+      // ensure public path ends with '/'
+      process.env.PUBLIC_PATH = process.env.PUBLIC_PATH + '/';
+    }
+    // anchor the generation of index.html
+    process.env.INDEX_PATH = paths.dest;
+  }
+  //
   const config = require('./webpack.dist.config');
   config.entry.app = paths.entry;
-  config.output.path = paths.dest;
+  config.output.path = path.join(paths.dest, process.env.PUBLIC_PATH || '');
 
   webpack(config, (err, stats) => {
     if(err)  {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -215,6 +215,7 @@ gulp.task('serve:static', function() {
         ui: false,
         codeSync: false,
         open: false,
+        cors: true,
         middleware: [
           historyApiFallback()
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,13 @@ module.exports = {
       },
       {
         test: /\.svg/,
-        use: 'svg-url-loader?limit=1'
+        use: {
+          loader: 'svg-url-loader',
+          options : {
+            publicPath: '/',
+            limit: 1
+          }
+        }
       },
       {
         test: /\.woff/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,7 @@ module.exports = {
         use: {
           loader: 'svg-url-loader',
           options : {
-            publicPath: '/',
+            publicPath: process.env.PUBLIC_PATH || '/',
             limit: 1
           }
         }
@@ -113,6 +113,7 @@ module.exports = {
     // with cache purging during deployment.
     new HtmlWebpackPlugin({
       template: 'app/index.html',
+      filename: path.join(process.env.INDEX_PATH || '', 'index.html'),
       inject: 'body',
       hash: false
     }),

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -5,7 +5,7 @@ var config  = require('./webpack.config');
 config.output = {
   filename: '[name].[chunkhash].js',
   chunkFilename: '[name].[chunkhash].js',
-  publicPath: '',
+  publicPath: process.env.PUBLIC_PATH || '/',
   path: path.resolve(__dirname, 'server/www') // Overwritten by gulp
 };
 


### PR DESCRIPTION
Asserts that the PUBLIC_PATH variable is an absolute path (i.e. '/assets') and configures webpack to drop all the js, css, svgs, etc in a folder with that name. index.html, config.js and locales/ are still placed in the top level folder. 

Fixes ushahidi/platform#1610 .

Ping @ushahidi/platform
