### PR TITLE
fix (post-view-data.html): disabled 'bulk actions' if there are no posts available

### DIFF
--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -67,7 +67,7 @@
 
         <div class="bulk-action" ng-if="posts.length > 0 || !isLoading()">
             <div class="bulk-action-primary" translate="post.posts_total" translate-values="{'posts': posts.length, 'total_nb': totalItems }"></div>
-            <button id="bulk-action" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin" translate="post.modify.bulk_actions">Bulk Actions</button>
+            <button id="bulk-action" ng-disabled="{{!totalItems}}" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin" translate="post.modify.bulk_actions">Bulk Actions</button>
         </div>
             <post-card
                 ng-repeat="post in posts"


### PR DESCRIPTION
This pull request makes the following changes:
- Checks total items to disable bulk actions

Testing checklist:
- [ ] Go to /views/data with 0 posts
- [ ] The button "Bulk actions" should be disabled.

- [ ] Go to /views/data with 1 or more posts
- [ ] The button "Bulk actions" should be enabled.

- [x] I certify that I ran my checklist

Notes:
When using the bulk actions to delete all the remaining posts the button stays enabled.
This is because of a preexisting issue with total items not being correctly updated.
I will create another PR for that since it affects the X of N post count.

Fixes ushahidi/platform#3321 .

Ping @ushahidi/platform
