### PR TITLE
fix (post-view-data.directive.js): updated total posts count after bulk delete

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -57,7 +57,7 @@ function PostViewDataController(
     $scope.itemsPerPageOptions = [10, 20, 50];
     $scope.itemsPerPage = $scope.itemsPerPageOptions[1];
     // until we have the correct total_count value from backend request:
-    $scope.totalItems = $scope.itemsPerPage;
+    $scope.totalItems = 0;
     $scope.posts = [];
     $scope.groupedPosts = {};
     $scope.deletePosts = deletePosts;
@@ -380,6 +380,7 @@ function PostViewDataController(
                 Notify.notify('notify.post.destroy_success_bulk');
                 // Remove deleted posts from state
                 var deletedIds = _.pluck(deleted, 'id');
+                $scope.totalItems = $scope.totalItems - deletedIds.length;
                 angular.forEach($scope.groupedPosts, function (posts, group) {
                     $scope.groupedPosts[group] = _.reject(posts, function (post) {
                         return _.contains(deletedIds, post.id);
@@ -456,7 +457,7 @@ function PostViewDataController(
     function resetPosts() {
         $scope.posts = [];
         $scope.groupedPosts = {};
-        $scope.totalItems = $scope.itemsPerPage;
+        $scope.totalItems = 0;
         $scope.currentPage = 1;
         $scope.selectedPosts = [];
         recentPosts = [];


### PR DESCRIPTION
This pull request makes the following changes:
- Updates total posts count after bulk delete

Testing checklist:
- [ ] go to views/data
- [ ] use the bulk actions to delete all the available posts
- [ ] the posts count should display 0 of 0 posts
- [ ] the bulk actions button should be disabled

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3324.

Ping @ushahidi/platform
