### PR TITLE
fixing problem with fab-button covered by demo-bar

### DIFF
--- a/app/main/posts/views/add-post-button.directive.js
+++ b/app/main/posts/views/add-post-button.directive.js
@@ -16,18 +16,22 @@ AddPostButtonController.$inject = [
     'Notify',
     'MainsheetService',
     'PostSurveyService',
-    '$location'
+    '$location',
+    '$rootScope'
 ];
 function AddPostButtonController(
     $scope,
     Notify,
     MainsheetService,
     PostSurveyService,
-    $location
+    $location,
+    $rootScope
 ) {
     $scope.forms = [];
     $scope.disabled = true;
     $scope.handleClick = handleClick;
+    // this is to add a class for adjustment of the fab-button in data-view when demo-bar is visible.
+    $scope.upgradeButton = $rootScope.demoBarVisible && $rootScope.loggedin;
 
     activate();
 

--- a/app/main/posts/views/add-post-button.html
+++ b/app/main/posts/views/add-post-button.html
@@ -1,4 +1,4 @@
-<div class="fab" data-message="add-post">
+<div class="fab" ng-class="{'upgrade-button': upgradeButton}" data-message="add-post">
     <button type="button" class="button-alpha button-fab" ng-click="handleClick()" ng-disabled="disabled" ng-class="{'disabled': $parent.$parent.bulkActionsSelected}">
         <svg class="iconic">
             <use xlink:href="/img/iconic-sprite.svg#plus"></use>

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "socket.io-client": "2.0.3",
     "sortablejs": "^1.7.0",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "^3.12.2-0"
+    "ushahidi-platform-pattern-library": "^3.12.3"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a new version of pattern-library
- Adds a new class to fab-button depending on if demo-bar is visible && user is logged in or not (demo-bar looks different if user is logged in or not which affects the height of the bar)

Testing checklist:
Repeat both for logged in user and not logged in user
- [ ] Go to dataview with the demobar activated
- [ ] Fab-button should be visible above the demobar
- [ ] Make screen smaller, fab-button should still be visible, even if the demobar changes size/modebar is visible in the bottom of the screen

- [x ] I certify that I ran my checklist

Fixes ushahidi/platform#3323 .

Ping @ushahidi/platform
