### PR TITLE
firing toggle demo-bar function when demobar is opened only

### DIFF
--- a/app/common/notifications/demo-slider.service.js
+++ b/app/common/notifications/demo-slider.service.js
@@ -16,6 +16,7 @@ function DemoSliderService($rootScope, $q, $templateRequest) {
     function openTemplate(template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate, loading, type) {
         deferredOpen.promise.then(function () {
             $rootScope.$emit('demoslider:open', template, icon, iconClass, scope, closeOnTimeout, showCloseButton, closeOnNavigate, loading, type);
+            $rootScope.toggleModalVisible(true, true);
         });
     }
 
@@ -27,7 +28,6 @@ function DemoSliderService($rootScope, $q, $templateRequest) {
     }
 
     function onOpen(callback, scope) {
-        $rootScope.toggleModalVisible(true, true);
         var handler = $rootScope.$on('demoslider:open', callback);
         if (scope) {
             scope.$on('$destroy', handler);


### PR DESCRIPTION
This pull request makes the following changes:
- Moves the toggling-function for demoBar visible to make it fire only when demo-slider is actually open

Testing checklist:
- [ ] Go to a demo-deployment, the fab-button should be visible in dataview, above the demobar
- [ ] Go to a non-demo-deployment, the fab-button should not have a margin as if the demobar was there, but be placed near the bottom of the page.

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3355 .

Ping @ushahidi/platform
