### PR TITLE
Remove export expiration field from history view

### DIFF
--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -156,16 +156,6 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
 
     function processJobFields(job) {
         if (job.status) {
-            /**
-             * only chhange the job.url_expiration if its a number or empty,
-             * to avoid "invalid date" from multiple conversions
-             */
-
-            if (!job.url_expiration) {
-                job.url_expiration = '';
-            } else if (_.isNumber(job.url_expiration)) {
-                job.url_expiration = new Date(job.url_expiration * 1000).toLocaleString();
-            }
             // keep the original timestamp for sorting
             job.created_timestamp = job.created_timestamp ? job.created_timestamp : job.created;
             job.created = new Date(job.created).toLocaleString();

--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -99,7 +99,6 @@
                                 <h2 class="listing-item-title"><a href="{{job.url}}" target="_blank" translate="data_export.job" translate-values="{jobId: job.id}">Job {{job.id}}</a></h2>
                                 <p class="listing-item-secondary" translate="data_export.{{job.status}}">Status: {{job.status}}</p>
                                 <p class="listing-item-secondary" translate="data_export.created" translate-values="{created: job.created}">Created: {{job.created}}</p>
-                                <p class="listing-item-secondary" translate="data_export.expires" translate-values="{expires: job.url_expiration}">Expires: {{job.url_expiration}}</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Export history should not display expiration as the export no longer expires

Testing checklist:
- [ ] I don't see an expiration in the list of exports

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
