### PR TITLE
Fix first load of saved search resetting filters

### DIFF
--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -117,17 +117,13 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
             });
     }
 
-    function doLogout(redirect) {
+    function doLogout() {
         $rootScope.currentUser = null;
         $rootScope.loggedin = false;
         DemoDeploymentService.demoCheck();
-        // we don' wat to reload until after filters are correctly set with the backend default that the user
-        // would get when logged out
+        // we don't want to reload until after filters are correctly set with
+        // the backend default that the user would get when logged out
         PostFilters.resetDefaults().then(function () {
-            if (redirect) {
-                $location.url(redirect);
-            }
-
             $state.go($state.$current.name ? $state.$current : 'map', null, { reload: true });
         });
     }

--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -71,8 +71,6 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     function activate() {
         if (Authentication.getLoginStatus()) {
             doLogin(false, true);
-        } else {
-            doLogout(false);
         }
     }
 


### PR DESCRIPTION
This pull request makes the following changes:
- fix: don't trigger doLogout when activating authentication-events
  This was causing a race condition, where if the reset filters didn't run before the saved search loaded, then the saved search filters weren't applied. This wasn't actually needed, since the default state for the scope is logged out and it was only introduced when the rest of the log out logic was moved to Authentication.service startup.
- refactor: Remove unused redirect param from doLogout

Testing checklist:
- [x] Load a deployment
- [x] Navigate to a saved search
- [x] Clear local storage
- [x] Reload the page (with the saved search URL)
- [x] Confirm the saved search filters applied correctly
- [x] Log in
- [x] Log out
- [x] Confirm filters have now been cleared
- [ ] I certify that I ran my checklist

Run checklist from this issue again https://github.com/ushahidi/platform-client/pull/903

Fixes ushahidi/account-management#64 .

Ping @ushahidi/platform
