### PR TITLE
Fix: Move `Who can see this` to the top of the saved search dialogue

### DIFF
--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -10,6 +10,23 @@
         <textarea ng-model="cpySavedSearch.description" />
     </div>
 
+    <!-- Who can see? -->
+    <role-selector model="savedSearch" title="'app.who_can_see_this'"></role-selector>
+    <div class="modal-actions">
+        <div class="form-field">
+            <button type="button" class="button-link  modal-trigger" ng-click="cancel()" translate>app.cancel</button>
+            <button type="button" class="button-alpha modal-trigger" ng-show="!isSaving" ng-click="save(cpySavedSearch)" translate>app.save_and_close</button>
+            <button ng-click="saveSearch()" ng-show="isSaving" disabled class="button-beta" type="button">
+                <div class="loading">
+                    <div class="line"></div>
+                    <div class="line"></div>
+                    <div class="line"></div>
+                </div>
+                <span class="button-label" translate="app.saving">Saving</span>
+            </button>
+        </div>
+    </div>
+
     <div class="form-field switch" ng-if="featuredEnabled()">
         <label for="saved-search-featured">
             <translate translate="saved_search.featured">Featured</translate>
@@ -31,22 +48,6 @@
         <div class="custom-select">
             <select ng-options="view.name as view.display_name for view in views" ng-model="cpySavedSearch.view">
             </select>
-        </div>
-    </div>
-    <!-- Who can see? -->
-    <role-selector model="savedSearch" title="'app.who_can_see_this'"></role-selector>
-    <div class="modal-actions">
-        <div class="form-field">
-            <button type="button" class="button-link  modal-trigger" ng-click="cancel()" translate>app.cancel</button>
-            <button type="button" class="button-alpha modal-trigger" ng-show="!isSaving" ng-click="save(cpySavedSearch)" translate>app.save_and_close</button>
-            <button ng-click="saveSearch()" ng-show="isSaving" disabled class="button-beta" type="button">
-            <div class="loading">
-                <div class="line"></div>
-                <div class="line"></div>
-                <div class="line"></div>
-            </div>
-            <span class="button-label" translate="app.saving">Saving</span>
-    </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Move `Who can see this` to the top of the saved search dialogue

![image](https://user-images.githubusercontent.com/28915865/49448219-6a2eb580-f7fe-11e8-888c-912d2a41d866.png)

Testing checklist:
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2387 .

Ping @justinscherer 
