### PR TITLE
Fix: Make title field look like an input field

### DIFF
--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -41,12 +41,15 @@
       <section class="form-sheet">
         <!-- TODO: get form colour here -->
         <span class="post-band" ng-style="{backgroundColor: survey.color}"></span>
-        <div class="form-field title survey-title">
+        <div class="form-field survey">
           <!--  TODO: add placeholder text-->
-            <label class="hidden" translate>survey.survey_name</label>
+            <label translate>survey.survey_name</label>
             <input type="text" placeholder="{{ 'survey.survey_name' | translate }}" ng-model="survey.name">
 
-            <label class="hidden" translate>app.description</label>
+        </div>
+
+          <div class="form-field survey">
+            <label translate>app.description</label>
             <textarea placeholder="{{ 'survey.describe_your_survey' | translate }}" ng-model="survey.description">Posts about streets that need resurfacing, repairs, or the removal of a hazard.</textarea>
         </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Make the title field look like an input field so that the user doesn't mistake it to be static text.

Screenshot:
![screenshot from 2018-12-05 14-42-12](https://user-images.githubusercontent.com/28915865/49502849-02c74300-f89c-11e8-9520-d3db9799cb2b.png)


Testing checklist:
- [x] I certify that I ran my checklist

Fixes Ushahidi/platform#2339.

Ping @justinscherer 