### PR TITLE
Fixed: new post count and duplicates.

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -489,6 +489,16 @@ function PostViewDataController(
         });
     }
 
+    function getUnique(arr, comp) {
+        const unique = arr
+            .map(ele => ele[comp]) // store the keys of the unique objects
+            .map((ele, i, final) => final.indexOf(ele) === i && i) // eliminate the dead keys & store unique objects
+            .filter(ele => arr[ele])
+            .map(ele => arr[ele]);
+
+        return unique;
+    }
+
     function getNewPosts() {
         let existingFilters = PostFilters.getQueryParams($scope.filters);
         let filterDate = moment(existingFilters.date_before).utc();
@@ -518,9 +528,12 @@ function PostViewDataController(
                     created_after_by_id: $scope.posts[0].id
                 });
             }
+
             PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
                 Array.prototype.unshift.apply(recentPosts, postsResponse.results);
-                $scope.newPostsCount += postsResponse.count;
+                recentPosts = getUnique(recentPosts, 'id');
+                $scope.newPostsCount = postsResponse.count;
+
             });
         }
     }


### PR DESCRIPTION
This pull request makes the following changes:

The new count wasn't working because of the `+=` used to calculate the count, thus it was increasing at every refresh.
The posts were still being duplicated bacause of the Array.unshift function.
Essentially, the unshift appended new posts onto the array without checking for duplicates and thus the count would rise again.

Testing checklist:
- [x] jscs
- [x] observation

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3325 .

Ping @ushahidi/platform
