### PR TITLE
Fixed link to heroku 1 click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ___
 
 ## Try it out on Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/lexoyo/platform-client/tree/master)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/ushahidi/platform-client/tree/master)
 
 You need to deploy the [Platform API](http://github.com/ushahidi/platform) first
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ___
 
 ## Try it out on Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/lexoyo/platform-client/tree/master)
 
 You need to deploy the [Platform API](http://github.com/ushahidi/platform) first
 


### PR DESCRIPTION
The link to heroku now takes the file app.json into account so that the developer can see a nice UI to provide values to required env vars

This pull request makes the following changes:
- In the readme, the link leads to 1 click deploy

Testing checklist:
- [x] link to 1 click deploy

- [x] I certify that I ran my checklist

Fixes ushahidi/platform-client#1295 .

Ping @ushahidi/platform
