### PR TITLE
fix(sorting-attributes): fix attribute display order according to backend priority

### DIFF
--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -46,8 +46,12 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
             // Create the map
             .then(addGeoJSONToMap)
             .then((data) => {
-                // Save points to scope
-                $scope.features = data.geojson.features.filter(f => f.geometry.type === 'Point');
+                if (data.geojson) {
+                    // Save points to scope
+                    $scope.features = data.geojson.features.filter(f => f.geometry.type === 'Point');
+                } else {
+                    $scope.features = [];
+                }
             })
             ;
 

--- a/app/main/posts/detail/map.directive.js
+++ b/app/main/posts/detail/map.directive.js
@@ -46,12 +46,8 @@ function PostDetailMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $c
             // Create the map
             .then(addGeoJSONToMap)
             .then((data) => {
-                if (data.geojson) {
-                    // Save points to scope
-                    $scope.features = data.geojson.features.filter(f => f.geometry.type === 'Point');
-                } else {
-                    $scope.features = [];
-                }
+                // Save points to scope
+                $scope.features = data.geojson.features.filter(f => f.geometry.type === 'Point');
             })
             ;
 

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -192,8 +192,9 @@ function PostDetailDataController(
     };
 
     $scope.isPostValue = function (key) {
-        return $scope.form_attributes[key] && $scope.post_task &&
+        let ret =  $scope.form_attributes[key] && $scope.post_task &&
             $scope.form_attributes[key].form_stage_id === $scope.post_task.id;
+        return ret;
     };
 
     $scope.showType = function (type) {

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -72,6 +72,7 @@ function PostDetailDataController(
     $scope.canCreatePostInSurvey = PostSurveyService.canCreatePostInSurvey;
     $scope.mapDataLoaded = false;
     $scope.form_attributes = [];
+    $scope.postValues = [];
     $scope.selectedPost = {post: $scope.post};
 
     activate();
@@ -100,6 +101,7 @@ function PostDetailDataController(
                 $scope.form_description = results[0].description;
                 $scope.form_color = results[0].color;
                 $scope.tags = results[3];
+                $scope.postValues = [];
                 // Set page title to '{form.name} Details' if a post title isn't provided.
                 if (!$scope.post.title) {
                     $translate('post.type_details', {type: results[0].name}).then(function (title) {
@@ -111,10 +113,17 @@ function PostDetailDataController(
                     .sortBy('priority')
                     .value();
 
-                angular.forEach(attributes, function (attr) {
-                    this[attr.key] = attr;
+                attributes.forEach(attr => {
+                    $scope.form_attributes[attr.key] = attr;
 
-                }, $scope.form_attributes);
+                    if ($scope.post.values && attr.type !== 'title' &&
+                        attr.type !== 'description' &&
+                        typeof $scope.post.values[attr.key] !== undefined
+                    ) {
+                        $scope.postValues.push({'key': attr.key, 'value': $scope.post.values[attr.key]});
+                    }
+                });
+
                 // Make the first task visible
                 if (!_.isEmpty(tasks) && tasks.length > 1) {
                     $scope.visibleTask = tasks[1].id;
@@ -142,12 +151,15 @@ function PostDetailDataController(
                 $scope.tasks = tasks;
                 // Figure out which tasks have values
                 $scope.tasks_with_attributes = [];
+
                 _.each($scope.post.values, function (value, key) {
 
                     if ($scope.form_attributes[key]) {
                         $scope.tasks_with_attributes.push($scope.form_attributes[key].form_stage_id);
                     }
+
                 });
+
                 $scope.tasks_with_attributes = _.uniq($scope.tasks_with_attributes);
             });
         } else {

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -18,7 +18,7 @@
       </div>
       <twitter-widget ng-if="post.source==='twitter'" twitter-widget-id="post.data_source_message_id">
       </twitter-widget>
-      <div
+      <!-- <div
         ng-repeat="postValue in postValues"
         ng-if="isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
         class="postcard-field"
@@ -28,21 +28,29 @@
           media-has-caption="form_attributes[postValue.key].config.hasCaption"
           label="{{form_attributes[postValue.key].label}}"
           media-id="postValue.value"></post-media-value>
-      </div>
+      </div> -->
       <div
         ng-if="post.content"
         class="postcard-field">
         <p markdown-to-html="post.content"></p>
       </div>
-      <post-value
+      <span 
         ng-repeat="postValue in postValues"
-        ng-if="form_attributes[postValue.key].type !== 'media' && isPostValue(postValue.key) && showType(form_attributes[postValue.key].type)"
-        key="postValue.key"
-        value="postValue.value"
-        attribute="form_attributes[postValue.key]"
-        tags="tags"
-        type="'post'">
-      </post-value>
+        ng-if="isPostValue(postValue.key) && showType(form_attributes[postValue.key].type)"
+      >
+        <post-media-value
+          ng-if="form_attributes[postValue.key].type === 'media'"
+          media-has-caption="form_attributes[postValue.key].config.hasCaption"
+          label="{{form_attributes[postValue.key].label}}"
+          media-id="postValue.value"></post-media-value>
+        <post-value
+          ng-if="form_attributes[postValue.key].type !== 'media'"
+          key="postValue.key"
+          value="postValue.value"
+          attribute="form_attributes[postValue.key]"
+          tags="tags"
+          type="'post'"></post-value>
+      </span>
       <post-detail-map post-id="post.id"></post-detail-map>
     </div>
   </article>
@@ -70,25 +78,21 @@
       </div>
       <div
         ng-repeat="postValue in postValues"
-        ng-if="form_attributes[postValue.key].type === 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+        ng-if="!isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
         ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
-        class="listing-item-primary"
+        ng-class="{'listing-item-primary': form_attributes[postValue.key].type === 'media'}"
       >
-      <post-media-value
-        label="{{form_attributes[postValue.key].label}}"
-        media-id="postValue.value"></post-media-value>
-      </div>
-      <div
-        ng-repeat="postValue in postValues"
-        ng-if="form_attributes[postValue.key].type !== 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
-        ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
-      >
+        <post-media-value
+          ng-if="form_attributes[postValue.key].type === 'media'"
+          label="{{form_attributes[postValue.key].label}}"
+          media-id="postValue.value"></post-media-value>
         <post-value
-          tags="tags"
-          key="postValue.key"
-          value="postValue.value"
-          attribute="form_attributes[postValue.key]"
-          type="'standard'">
+            ng-if="form_attributes[postValue.key].type !== 'media'"
+            tags="tags"
+            key="postValue.key"
+            value="postValue.value"
+            attribute="form_attributes[postValue.key]"
+            type="'standard'">
         </post-value>
       </div>
     </div>

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -23,15 +23,15 @@
               <twitter-widget ng-if="post.source==='twitter'" twitter-widget-id="post.data_source_message_id">
               </twitter-widget>
             <div
-              ng-repeat="(key,value) in post.values"
-              ng-if="isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)"
+              ng-repeat="postValue in postValues"
+              ng-if="isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
               class="postcard-field"
             >
           <post-media-value
-            ng-if="form_attributes[key].type === 'media'"
-            media-has-caption="form_attributes[key].config.hasCaption"
-            label="{{form_attributes[key].label}}"
-            media-id="value"></post-media-value>
+            ng-if="form_attributes[postValue.key].type === 'media'"
+            media-has-caption="form_attributes[postValue.key].config.hasCaption"
+            label="{{form_attributes[postValue.key].label}}"
+            media-id="postValue.value"></post-media-value>
         </div>
         <div
           ng-if="post.content"
@@ -40,11 +40,11 @@
         </div>
 
         <post-value
-          ng-repeat="(key,value) in post.values"
-          ng-if="form_attributes[key].type !== 'media' && isPostValue(key) && showType(form_attributes[key].type)"
-          key="key"
-          value="value"
-          attribute="form_attributes[key]"
+          ng-repeat="postValue in postValues"
+          ng-if="form_attributes[postValue.key].type !== 'media' && isPostValue(postValue.key) && showType(form_attributes[postValue.key].type)"
+          key="postValue.key"
+          value="postValue.value"
+          attribute="form_attributes[postValue.key]"
           tags="tags"
           type="'post'">
         </post-value>
@@ -76,26 +76,26 @@
                 <p translate="post.modify.no_task_values">There are currently no saved values for this task.</p>
           </div>
           <div
-            ng-repeat="(key,value) in post.values"
-            ng-if="form_attributes[key].type === 'media' && !isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)"
-            ng-show="form_attributes[key].form_stage_id === visibleTask"
+            ng-repeat="postValue in postValues"
+            ng-if="form_attributes[postValue.key].type === 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+            ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
             class="listing-item-primary"
             >
 
             <post-media-value
-              label="{{form_attributes[key].label}}"
-              media-id="value"></post-media-value>
+              label="{{form_attributes[postValue.key].label}}"
+              media-id="postValue.value"></post-media-value>
           </div>
           <div
-            ng-repeat="(key,value) in post.values"
-            ng-if="form_attributes[key].type !== 'media' && !isPostValue(key) && form_attributes[key] && showType(form_attributes[key].type)"
-            ng-show="form_attributes[key].form_stage_id === visibleTask"
+            ng-repeat="postValue in postValues"
+            ng-if="form_attributes[postValue.key].type !== 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+            ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
             >
             <post-value
               tags="tags"
-              key="key"
-              value="value"
-              attribute="form_attributes[key]"
+              key="postValue.key"
+              value="postValue.value"
+              attribute="form_attributes[postValue.key]"
               type="'standard'">
             </post-value>
           </div>

--- a/app/main/posts/detail/post-detail-data.html
+++ b/app/main/posts/detail/post-detail-data.html
@@ -2,105 +2,96 @@
   <layout-class layout="d"></layout-class>
   <article class="postcard" role="article">
     <button class="button-beta button-flat postcard-close" ng-click="close()">
-        <svg class="iconic">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
-        </svg>
+      <svg class="iconic">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
+      </svg>
     </button>
-        <div class="post-band"  ng-style="{backgroundColor: post.form.color}"></div>
-
-        <post-lock ng-if="post.lock" post="post"></post-lock>
-
-        <div class="postcard-body">
-            <h1 class="form-sheet-title survey-title" linkify>
-                      <bdi>{{post.title}}</bdi>
-            </h1>
-
-            <div class="postcard-header">
-                <post-metadata post="post" hide-date-this-week="true"></post-metadata>
-                <post-actions post="post"></post-actions>
-            </div>
-
-              <twitter-widget ng-if="post.source==='twitter'" twitter-widget-id="post.data_source_message_id">
-              </twitter-widget>
-            <div
-              ng-repeat="postValue in postValues"
-              ng-if="isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
-              class="postcard-field"
-            >
-          <post-media-value
-            ng-if="form_attributes[postValue.key].type === 'media'"
-            media-has-caption="form_attributes[postValue.key].config.hasCaption"
-            label="{{form_attributes[postValue.key].label}}"
-            media-id="postValue.value"></post-media-value>
-        </div>
-        <div
-          ng-if="post.content"
-          class="postcard-field">
-          <p markdown-to-html="post.content"></p>
-        </div>
-
+    <div class="post-band"  ng-style="{backgroundColor: post.form.color}"></div>
+    <post-lock ng-if="post.lock" post="post"></post-lock>
+    <div class="postcard-body">
+      <h1 class="form-sheet-title survey-title" linkify>
+        <bdi>{{post.title}}</bdi>
+      </h1>
+      <div class="postcard-header">
+        <post-metadata post="post" hide-date-this-week="true"></post-metadata>
+        <post-actions post="post"></post-actions>
+      </div>
+      <twitter-widget ng-if="post.source==='twitter'" twitter-widget-id="post.data_source_message_id">
+      </twitter-widget>
+      <div
+        ng-repeat="postValue in postValues"
+        ng-if="isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+        class="postcard-field"
+      >
+        <post-media-value
+          ng-if="form_attributes[postValue.key].type === 'media'"
+          media-has-caption="form_attributes[postValue.key].config.hasCaption"
+          label="{{form_attributes[postValue.key].label}}"
+          media-id="postValue.value"></post-media-value>
+      </div>
+      <div
+        ng-if="post.content"
+        class="postcard-field">
+        <p markdown-to-html="post.content"></p>
+      </div>
+      <post-value
+        ng-repeat="postValue in postValues"
+        ng-if="form_attributes[postValue.key].type !== 'media' && isPostValue(postValue.key) && showType(form_attributes[postValue.key].type)"
+        key="postValue.key"
+        value="postValue.value"
+        attribute="form_attributes[postValue.key]"
+        tags="tags"
+        type="'post'">
+      </post-value>
+      <post-detail-map post-id="post.id"></post-detail-map>
+    </div>
+  </article>
+  <div class="listing card init" ng-show="tasks.length">
+    <h3 class="listing-heading" translate="app.tasks">Tasks</h3>
+    <nav class="tabs-menu" data-tabs="tasks-tabs" data-tabs-hash>
+      <ul>
+        <li
+          ng-repeat="task in tasks"
+          ng-class="{'active': visibleTask == task.id}">
+          <a ng-click="activateTaskTab(task.id)">
+            <bdi>{{task.label}}</bdi>
+          </a>
+          <span class="status" ng-class="{'completed': taskIsComplete(visibleTask)}">
+          </span>
+        </li>
+      </ul>
+    </nav>
+    <div class="listing-item tasks-tabs tabs-target active">
+      <div class="alert"
+          ng-repeat="task in tasks"
+          ng-if="!taskHasValues(task)"
+          ng-show="task.id === visibleTask">
+        <p translate="post.modify.no_task_values">There are currently no saved values for this task.</p>
+      </div>
+      <div
+        ng-repeat="postValue in postValues"
+        ng-if="form_attributes[postValue.key].type === 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+        ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
+        class="listing-item-primary"
+      >
+      <post-media-value
+        label="{{form_attributes[postValue.key].label}}"
+        media-id="postValue.value"></post-media-value>
+      </div>
+      <div
+        ng-repeat="postValue in postValues"
+        ng-if="form_attributes[postValue.key].type !== 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
+        ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
+      >
         <post-value
-          ng-repeat="postValue in postValues"
-          ng-if="form_attributes[postValue.key].type !== 'media' && isPostValue(postValue.key) && showType(form_attributes[postValue.key].type)"
+          tags="tags"
           key="postValue.key"
           value="postValue.value"
           attribute="form_attributes[postValue.key]"
-          tags="tags"
-          type="'post'">
+          type="'standard'">
         </post-value>
-        <post-detail-map post-id="post.id"></post-detail-map>
-
       </div>
-  </article>
-  <div class="listing card init" ng-show="tasks.length">
-        <h3 class="listing-heading" translate="app.tasks">Tasks</h3>
-
-        <nav class="tabs-menu" data-tabs="tasks-tabs" data-tabs-hash>
-          <ul>
-            <li
-              ng-repeat="task in tasks"
-              ng-class="{'active': visibleTask == task.id}"  >
-              <a ng-click="activateTaskTab(task.id)">
-                <bdi>{{task.label}}</bdi>
-              </a>
-              <span class="status" ng-class="{'completed': taskIsComplete(visibleTask)}">
-              </span>
-            </li>
-          </ul>
-        </nav>
-        <div class="listing-item tasks-tabs tabs-target active">
-          <div class="alert"
-              ng-repeat="task in tasks"
-              ng-if="!taskHasValues(task)"
-              ng-show="task.id === visibleTask">
-                <p translate="post.modify.no_task_values">There are currently no saved values for this task.</p>
-          </div>
-          <div
-            ng-repeat="postValue in postValues"
-            ng-if="form_attributes[postValue.key].type === 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
-            ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
-            class="listing-item-primary"
-            >
-
-            <post-media-value
-              label="{{form_attributes[postValue.key].label}}"
-              media-id="postValue.value"></post-media-value>
-          </div>
-          <div
-            ng-repeat="postValue in postValues"
-            ng-if="form_attributes[postValue.key].type !== 'media' && !isPostValue(postValue.key) && form_attributes[postValue.key] && showType(form_attributes[postValue.key].type)"
-            ng-show="form_attributes[postValue.key].form_stage_id === visibleTask"
-            >
-            <post-value
-              tags="tags"
-              key="postValue.key"
-              value="postValue.value"
-              attribute="form_attributes[postValue.key]"
-              type="'standard'">
-            </post-value>
-          </div>
-        </div>
+    </div>
   </div>
-
-    <post-messages post="post" ng-if="post.contact.id && post.source !== 'twitter'"></post-messages>
+  <post-messages post="post" ng-if="post.contact.id && post.source !== 'twitter'"></post-messages>
 </div>


### PR DESCRIPTION


This pull request makes the following changes:
- Fixes issue that caused the data view to render attributes in the wrong order. 

Testing checklist:
- [x] Create a survey with a few different fields , notice the fields order 
- [x] Check the fields are displayed in the correct order in the survey form
- [x] Check the fields are displayed in the correct order in the data view

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform