### PR TITLE
#3555 save button language gets updated when saving the language

### DIFF
--- a/app/settings/site/editor.directive.js
+++ b/app/settings/site/editor.directive.js
@@ -125,6 +125,8 @@ function (
                         let userLanguage = Session.getSessionDataEntry('language');
                         if ((userLanguage === undefined || userLanguage === null) && $scope.SystemLanguage !== newSystemLanguage) {
                             TranslationService.translate(newSystemLanguage);
+                            $scope.save = $translate.instant('app.save');
+                            $scope.saving = $translate.instant('app.saving');
                         }
                         $scope.SystemLanguage = newSystemLanguage;
                         Notify.notify('notify.general_settings.save_success');


### PR DESCRIPTION
This pull request makes the following changes:
- Change language of the SAVE button to the current language. https://github.com/ushahidi/platform/issues/3555


Testing checklist:
- [ ] Go to Settings -> General . Change language to Spanish (or some other language that isn't the current site's language)
- The save button is in Spanish, not English
- [ ] I certify that I ran my checklist 

Fixes ushahidi/platform# .

Ping @ushahidi/platform