### PR TITLE
fix: 2372-platform no more button in filters

### DIFF
--- a/app/main/posts/views/filters/filter-category.html
+++ b/app/main/posts/views/filters/filter-category.html
@@ -1,17 +1,16 @@
-<fieldset ng-show="categories.length" overflow-toggle has-overflow="categories.length > 1" ng-model-options="{ updateOn: 'default' }">
+<fieldset ng-show="categories.length" ng-model-options="{ updateOn: 'default' }">
     <label translate="nav.categories">Categories</label>
-
-    <div class="form-field checkbox" ng-repeat="(index, category) in categories" ng-class="{ overflow : ($index > 1) }" ng-if="category.parent_id === null">
-        <label>
-            <input
-                type="checkbox"
-                checklist-value="category.id"
-                value="category.id"
-                checklist-model="selectedCategories"
-            >
-            <bdi>{{ ::category.tag }}</bdi>
-        </label>
-        <div
+    <div class="form-field checkbox" ng-repeat="(index, category) in categories" ng-if="category.parent_id === null">
+      <label>
+          <input
+              type="checkbox"
+              checklist-value="category.id"
+              value="category.id"
+              checklist-model="selectedCategories"
+          >
+          <bdi>{{ ::category.tag }}</bdi>
+      </label>
+      <div
           class="form-field checkbox"
           ng-repeat="child in category.children"
         >
@@ -23,14 +22,8 @@
             value="child.id"
             ng-selected="selectedCategories.indexOf(category.id) >-1"
           >
-            <bdi>{{ ::child.tag }}</bdi>
+          <bdi>{{ ::child.tag }}</bdi>
         </label>
+      </div>
     </div>
-    </div>
-      <span class="form-field-toggle">
-        <svg class="iconic">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-        </svg>
-        <span translate="nav.more">More</span>
-    </span>
 </fieldset>

--- a/app/main/posts/views/filters/filter-form.html
+++ b/app/main/posts/views/filters/filter-form.html
@@ -1,20 +1,14 @@
 <fieldset overflow-toggle has-overflow="forms.length > 1" ng-model-options="{ updateOn: 'default' }">
     <label translate="app.surveys">Survey</label>
 
-    <div class="form-field checkbox" ng-repeat="(index, form) in forms" ng-class="{ overflow : ($index > 1) }">
+    <div class="form-field checkbox" ng-repeat="(index, form) in forms">
         <label>
             <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms"> <bdi>{{ ::form.name }}</bdi>
         </label>
     </div>
-    <div class="form-field checkbox" ng-class="{ overflow : (forms.length > 1) }">
+    <div class="form-field checkbox">
         <label>
             <input checklist-value="'none'" checklist-model="selectedForms" type="checkbox" name="selectedForms" > <span translate="nav.unknown">Unknown</span>
         </label>
     </div>
-    <span class="form-field-toggle">
-        <svg class="iconic">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-        </svg>
-        <span translate="nav.more">More</span>
-    </span>
 </fieldset>

--- a/app/main/posts/views/filters/filter-status.html
+++ b/app/main/posts/views/filters/filter-status.html
@@ -1,7 +1,7 @@
-<fieldset overflow-toggle has-overflow="statuses.length > 2" ng-model-options="{ updateOn: 'default' }" ng-show="hasPermission('Manage Posts')">
+<fieldset ng-model-options="{ updateOn: 'default' }" ng-show="hasPermission('Manage Posts')">
     <label translate="global_filter.status">Status</label>
 
-    <div class="form-field checkbox icon-input" ng-repeat="(index, status) in statuses" ng-class="{ overflow: ($index > 1) }">
+    <div class="form-field checkbox icon-input" ng-repeat="(index, status) in statuses">
 
       <label>
         <svg class="iconic" ng-if="status == 'published'">
@@ -21,11 +21,4 @@
 
         </label>
     </div>
-
-    <span class="form-field-toggle">
-        <svg class="iconic">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-        </svg>
-        <span translate="nav.more">More</span>
-    </span>
 </fieldset>


### PR DESCRIPTION
This pull request makes the following changes:
- Remove the "more" overflow button in the filters dropdown per https://github.com/ushahidi/platform/issues/2372

Testing checklist:
- [x] Add many surveys, categories, and posts for all statuses (or use rominacsvsms.ushahidi.io as the backend) 
- [x] Check that the filters dropDown does not have a "more" button under each, instead they all expand without user action
See gif of expected results here. 
![no-overlflow](https://user-images.githubusercontent.com/2434401/59153537-36447f00-8a31-11e9-9e5b-1100e24d0ee1.gif)



- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
