### PR TITLE
hotfix(video-url): fix issue where a blank video url caused the video component to crash

### DIFF
--- a/app/main/posts/detail/post-video-value.directive.js
+++ b/app/main/posts/detail/post-video-value.directive.js
@@ -26,6 +26,8 @@ function PostVideoValueController(
     activate();
 
     function activate() {
-        $scope.videoUrl = $sce.trustAsResourceUrl($scope.videoUrl[0]);
+        if ($scope.videoUrl && $scope.videoUrl.length > 0) {
+            $scope.videoUrl = $sce.trustAsResourceUrl($scope.videoUrl[0]);
+        }
     }
 }

--- a/app/main/posts/detail/post-video-value.html
+++ b/app/main/posts/detail/post-video-value.html
@@ -2,7 +2,7 @@
   <h2 class="form-label">
     <bdi>{{label}}</bdi>
   </h2>
-  <div class="video_embed-fluid">
+  <div class="video_embed-fluid" ng-if="videoUrl">
     <iframe src="{{videoUrl}}" frameborder="0" allowfullscreen></iframe>
   </div>
 </div>


### PR DESCRIPTION

This pull request makes the following changes:
- If a video url field is empty, we no longer attempt to embed a video

Testing checklist:
- [ ] Create a survey with an optional video field
- [ ] Submit two posts. One with a valid video URL value,  and one with an empty video url.
- [ ] Verify both posts load the field correctly (one shows a video, the other is empty) 
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3610 .
Ping @ushahidi/platform