### PR TITLE
Browser installer helper

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -105,7 +105,6 @@ angular.module('ushahidi.common', [
 .directive('categorySelector', require('./directives/category-selector.directive.js'))
 .directive('languageSwitch', require('./directives/language-switch.directive.js'))
 .directive('loadingDots', require('./directives/loading-dots.directive.js'))
-
 // Event actions
 .constant('EVENT', {
     ACTIONS : {
@@ -128,6 +127,9 @@ angular.module('ushahidi.common', [
 .run(['$templateCache', function ($templateCache) {
     $templateCache.put('common/directives/mode-bar/ushahidi-logo.html', require('./directives/mode-bar/ushahidi-logo.html'));
 }])
+.factory('Verifier', function () {
+    return require('./verifier/verifier.js');
+})
 ;
 
 // Load submodules

--- a/app/common/common-routes.js
+++ b/app/common/common-routes.js
@@ -59,5 +59,11 @@ module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($sta
                 template: require('./auth/404.html')
             }
         )
+        .state({
+            name: 'verifier',
+            url: '/verifier',
+            controller: require('./verifier/verifier.controller.js'),
+            template: require('./verifier/verifier.html')
+        })
         ;
 }];

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -1,0 +1,62 @@
+
+module.exports = [
+    '$rootScope',
+    '$scope',
+    'Verifier',
+    function ($rootScope, $scope, Verifier) {
+        $rootScope.setLayout('layout-c');
+        $scope.networkCheck;
+        $scope.envCheck;
+        $scope.endpointChecks = [];
+        function activate() {
+            checkNetwork();
+            envCheck();
+            endpointChecks();
+            checkTransifex();
+        }
+
+        function checkNetwork() {
+            let checkDisabled = Verifier.isCheckDisabled('NETWORK');
+            if (checkDisabled) {
+                $scope.networkCheck = checkDisabled;
+                return;
+            }
+
+            Verifier.verifyStatus(`${BACKEND_URL}/api/v3/config`)
+            .then(response => {
+                $scope.networkCheck = response;
+                $scope.$apply();
+            });
+        }
+
+        function envCheck() {
+            let checkDisabled = Verifier.isCheckDisabled('ENV');
+            if (checkDisabled) {
+                $scope.envCheck = checkDisabled;
+                return;
+            }
+            $scope.envCheck = Verifier.verifyEnv();
+        }
+
+        function endpointChecks() {
+            const endpoints = ['tags', 'forms', 'config/feature', 'config/map'];
+            endpoints.forEach(function (endpoint) {
+                Verifier.verifyStatus(`${BACKEND_URL}/api/v3/${endpoint}`)
+                .then(response => {
+                    $scope.endpointChecks.push(response);
+                    $scope.$apply();
+                });
+            });
+        }
+        function checkTransifex() {
+            let checkDisabled = Verifier.isCheckDisabled('TRANSIFEX');
+            if (checkDisabled) {
+                $scope.transifexCheck = checkDisabled;
+                return;
+            }
+            $scope.transifexCheck = Verifier.verifyTransifex();
+        }
+        activate();
+    }
+];
+

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -4,10 +4,9 @@ module.exports = [
     'CONST',
     'Verifier',
     function ($scope, CONST, Verifier) {
-        $scope.networkCheck;
-        $scope.envCheck;
         $scope.endpointStatuses = [];
         $scope.endpointStructureChecks = [];
+
         function activate() {
             checkNetwork();
             envCheck();
@@ -15,6 +14,8 @@ module.exports = [
             endpointStructureCheck();
             checkTransifex();
             verifyOauth();
+            verifyDbConnection();
+            verifyAPIEnvs();
         }
 
         function checkNetwork() {
@@ -53,6 +54,7 @@ module.exports = [
         function checkTransifex() {
             $scope.transifexCheck = Verifier.verifyTransifex(CONST);
         }
+
         function verifyOauth() {
             let results = Verifier.verifyOauth(CONST);
             results.status.then(status => {
@@ -67,6 +69,22 @@ module.exports = [
             });
             results.token.then(token=> {
                 $scope.oauthToken = token;
+                $scope.$apply();
+            });
+        }
+
+        function verifyDbConnection() {
+            Verifier.verifyDbConnection(CONST)
+            .then(response => {
+                $scope.dbConnection = response;
+                $scope.$apply();
+            });
+        }
+
+        function verifyAPIEnvs() {
+            Verifier.verifyAPIEnvs(CONST)
+            .then(response => {
+                $scope.apiEnvs = response;
                 $scope.$apply();
             });
         }

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -1,0 +1,34 @@
+
+<!-- <verifier network="networkChecks" endpoints="endpointChecks"></verifier> -->
+
+<main role=main>
+        <div class="main-col">
+            <h1>Installer helper!</h1>
+            <h2>Checking network...</h2>
+            <div>
+                <strong>Status-result for {{networkCheck.url}}</strong>
+                <p>The server responded with a {{networkCheck.status}}-status code</p>    
+                <p ng-repeat="message in networkCheck.messages">{{message}}</p>
+            </div>
+            <h2>Checking endpoints...</h2>
+            <div ng-repeat="endpoint in endpointChecks">
+                <strong>Status-result for {{endpoint.url}}</strong>
+                    <p>The server responded with a {{endpoint.status}}-status code</p>    
+                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
+                </div>
+            <h2>Checking Oauth-endpoint...</h2>
+            <div></div>
+            <h2>Checking environment variables in the client...</h2>
+            <div ng-repeat="result in envCheck.messages">
+                    <p>{{result}}</p>
+                </div>
+            <h2>Checking Transifex</h2>
+            <div ng-repeat="result in transifexCheck.messages">
+                    {{result}}
+            </div>
+            <h2>Checking Database-connection</h2>
+            <div></div>
+            <h2>Checking environment-variables in the API...</h2>
+    </div>
+    </main>
+    

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -1,34 +1,56 @@
-
-<!-- <verifier network="networkChecks" endpoints="endpointChecks"></verifier> -->
-
-<main role=main>
+<div>
+    <layout-class layout="b"></layout-class>
+    <main role="main">
         <div class="main-col">
-            <h1>Installer helper!</h1>
-            <h2>Checking network...</h2>
             <div>
+                <h1>Installer helper!</h1>
+                <h2>Checking network...</h2>
                 <strong>Status-result for {{networkCheck.url}}</strong>
                 <p>The server responded with a {{networkCheck.status}}-status code</p>    
                 <p ng-repeat="message in networkCheck.messages">{{message}}</p>
             </div>
-            <h2>Checking endpoints...</h2>
-            <div ng-repeat="endpoint in endpointChecks">
-                <strong>Status-result for {{endpoint.url}}</strong>
+            <div>
+                <h2>Checking endpoints...</h2>
+                <div ng-repeat="endpoint in endpointStatuses">
+                    <strong>Status-result for {{endpoint.url}}</strong>
                     <p>The server responded with a {{endpoint.status}}-status code</p>    
                     <p ng-repeat="message in endpoint.messages">{{message}}</p>
                 </div>
-            <h2>Checking Oauth-endpoint...</h2>
-            <div></div>
-            <h2>Checking environment variables in the client...</h2>
-            <div ng-repeat="result in envCheck.messages">
-                    <p>{{result}}</p>
+                <div ng-repeat="endpoint in endpointStructureChecks">
+                    <strong>Structure-result for {{endpoint.url}}</strong>
+                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
                 </div>
-            <h2>Checking Transifex</h2>
-            <div ng-repeat="result in transifexCheck.messages">
-                    {{result}}
             </div>
-            <h2>Checking Database-connection</h2>
-            <div></div>
-            <h2>Checking environment-variables in the API...</h2>
-    </div>
+            <div>
+                <h2>Checking Oauth-endpoint...</h2>
+                <div>
+                    <strong>Status-result for {{oauthStatus.url}}</strong>
+                    <p>The server responded with a {{oauthStatus.status}}-status code</p>
+                    <p ng-repeat="message in oauthStatusCheck.messages">{{message}}</p>
+                    <strong>Checking the structure for {{oauthStructure.url}}</strong>
+                    <p ng-repeat="message in oauthStructure.messages">{{message}}</p>
+                    <strong>Checking that the oauth-token is working</strong>
+                    <p ng-repeat="message in oauthToken.messages">{{message}}</p>
+                </div>
+            <div>
+                <h2>Checking environment variables in the client...</h2>
+                <div ng-repeat="message in envCheck.messages">
+                    <p>{{message}}</p>
+                </div>
+            </div>
+            <div>
+                <h2>Checking Transifex</h2>
+                <div ng-repeat="message in transifexCheck.messages">
+                    {{message}}
+                </div>
+            </div>
+            <div>
+                <h2>Checking Database-connection</h2>
+                <div></div>
+            </div>
+            <div>
+                <h2>Checking environment-variables in the API...</h2>
+            </div>
+        </div>
     </main>
-    
+</div>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -46,10 +46,25 @@
             </div>
             <div>
                 <h2>Checking Database-connection</h2>
-                <div></div>
+                <div ng-if="dbConnection.success" ng-repeat="result in dbConnection.success">
+                    <p>{{result.message}}</p>
+                    <p>{{result.explainer}}</p>
+                </div>
+                <div ng-if="dbConnection.error" ng-repeat="result in dbConnection.error">
+                        <p>{{result.message}}</p>
+                        <p>{{result.explainer}}</p>
+                    </div>
             </div>
             <div>
                 <h2>Checking environment-variables in the API...</h2>
+                <div ng-if="apiEnvs.success" ng-repeat="result in apiEnvs.success">
+                        <p>{{result.message}}</p>
+                        <p>{{result.explainer}}</p>
+                    </div>
+                    <div ng-if="apiEnvs.error" ng-repeat="result in apiEnvs.error">
+                            <p>{{result.message}}</p>
+                            <p>{{result.explainer}}</p>
+                    </div>
             </div>
         </div>
     </main>

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -1,0 +1,104 @@
+// import log       from 'fancy-log';
+import isUrl from 'is-url';
+import fs from 'fs';
+import fetch from 'node-fetch';
+// import * as forms from '../../../../mocked_backend/api/v3/forms.json';
+// import * as tags from '../../../../mocked_backend/api/v3/tags.json';
+// import * as features from '../../../../mocked_backend/api/v3/config/features.json';
+// import * as map from '../../../../mocked_backend/api/v3/config/map.json';
+
+module.exports = {
+    verifyStatus(url, options) {
+        let results;
+        return fetch(url, options)
+            .then((response, resolve) => {
+                switch (response.status.toString()) {
+                    case '200':
+                        results = {
+                            type: 'confirmation',
+                            messages: ['All is good. This is the expected result.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '404':
+                        results = {
+                            type: 'error',
+                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '403':
+                        results = {
+                            type: 'error',
+                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '500':
+                        results = {
+                            type: 'error',
+                            messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                }
+                return results;
+            })
+            .catch(error => {
+                results = {
+                        type: 'error',
+                        messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
+                        url: `${process.env.BACKEND_URL}/${url}`
+                    };
+                return results;
+            });
+    },
+    verifyEnv() {
+        let messages = [];
+        try {
+            // fs is not working in the browser, how handle it?
+            fs.accessSync('.env');
+        } catch (e) {
+            messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
+        }
+
+        if (!process.env.BACKEND_URL) {
+            messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
+        }
+
+        if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
+            messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
+            'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
+        }
+        return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
+    },
+    verifyTransifex() {
+        if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
+            return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
+        } else {
+            return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
+        }
+    },
+    isCheckDisabled(name) {
+        if (!process.env.USH_DISABLE_CHECKS) {
+            return false;
+        }
+        const checks = process.env.USH_DISABLE_CHECKS.split(',');
+        if (checks.indexOf(name) >= 0) {
+            return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
+        }
+    },
+    checkStructure (a, b, url) {
+        const aKeys = Object.keys(a).sort();
+        const bKeys = Object.keys(b).sort();
+        if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
+            return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`]};
+        } else {
+            return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`]};
+        }
+    }
+};

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -2,103 +2,226 @@
 import isUrl from 'is-url';
 import fs from 'fs';
 import fetch from 'node-fetch';
-// import * as forms from '../../../../mocked_backend/api/v3/forms.json';
-// import * as tags from '../../../../mocked_backend/api/v3/tags.json';
-// import * as features from '../../../../mocked_backend/api/v3/config/features.json';
-// import * as map from '../../../../mocked_backend/api/v3/config/map.json';
+import * as forms from '../../../mocked_backend/api/v3/forms.json';
+import * as tags from '../../../mocked_backend/api/v3/tags.json';
+import * as features from '../../../mocked_backend/api/v3/config/features.json';
+import * as map from '../../../mocked_backend/api/v3/config/map.json';
 
-module.exports = {
-    verifyStatus(url, options) {
-        let results;
-        return fetch(url, options)
-            .then((response, resolve) => {
-                switch (response.status.toString()) {
-                    case '200':
-                        results = {
-                            type: 'confirmation',
-                            messages: ['All is good. This is the expected result.'],
-                            url: response.url,
-                            status: response.status
-                        };
+const verifyStatus = function (url, options) {
+    let results;
+    return fetch(url, options)
+        .then(response => {
+            switch (response.status.toString()) {
+                case '200':
+                    results = {
+                        type: 'confirmation',
+                        messages: ['All is good. This is the expected result.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '404':
+                    results = {
+                        type: 'error',
+                        messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '403':
+                    results = {
+                        type: 'error',
+                        messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '500':
+                    results = {
+                        type: 'error',
+                        messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+            }
+            return results;
+        })
+        .catch(error => {
+            results = {
+                    type: 'error',
+                    messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
+                    url: url
+                };
+            return results;
+        });
+};
+
+const verifyEnv = function (env) {
+    let messages = [];
+    try {
+        // fs is not working in the browser, how handle it?
+        fs.accessSync('.env');
+    } catch (e) {
+        messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
+    }
+
+    if (!env.BACKEND_URL) {
+        messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
+    }
+
+    if (env.BACKEND_URL && !isUrl(env.BACKEND_URL)) {
+        messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
+        'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
+    }
+    return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
+};
+
+const verifyTransifex = function (env) {
+    if (!env.TX_USERNAME || !env.TX_PASSWORD) {
+        return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
+    } else {
+        return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
+    }
+};
+
+const verifyEndpointStatus = function (env) {
+    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
+    return endpoints.map(function (endpoint) {
+        return verifyStatus(`${env.BACKEND_URL}/api/v3/${endpoint}`)
+        .then(response => {
+            return response;
+        });
+    });
+};
+
+const verifyEndpointStructure = function (env) {
+    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
+    const requests = endpoints.map(function (endpoint) {
+        return fetch(`${env.BACKEND_URL}/api/v3/${endpoint}`);
+    });
+
+    return Promise.all(requests)
+    .then(function (responses) {
+        return responses.map(function (response) {
+            return response.json().then(function (jsonData) {
+                let structure = {};
+                switch (response.url.substring(response.url.lastIndexOf('/') + 1)) {
+                    case 'tags':
+                        structure = tags.default;
                         break;
-                    case '404':
-                        results = {
-                            type: 'error',
-                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'forms':
+                        structure = forms.default;
                         break;
-                    case '403':
-                        results = {
-                            type: 'error',
-                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'features':
+                        structure = features.default;
                         break;
-                    case '500':
-                        results = {
-                            type: 'error',
-                            messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'map':
+                        structure = map.default;
                         break;
                 }
-                return results;
-            })
-            .catch(error => {
-                results = {
-                        type: 'error',
-                        messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
-                        url: `${process.env.BACKEND_URL}/${url}`
-                    };
-                return results;
+                return checkStructure(jsonData, structure, response.url);
             });
-    },
-    verifyEnv() {
-        let messages = [];
-        try {
-            // fs is not working in the browser, how handle it?
-            fs.accessSync('.env');
-        } catch (e) {
-            messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
-        }
+        });
+    }).catch(error => {
+        return {type: 'error', messages: ['The server could not be reached or there was an error in the request', 'Make sure your Platform API is running', error]};
+    });
+};
 
-        if (!process.env.BACKEND_URL) {
-            messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
-        }
+const verifyOauth = function (env) {
+    let body = JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: env.OAUTH_CLIENT_ID || 'ushahidiui',
+        client_secret: env.OAUTH_CLIENT_SECRET || '35e7f0bca957836d05ca0492211b0ac707671261',
+        scope: 'forms'
+    });
 
-        if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
-            messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
-            'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
-        }
-        return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
-    },
-    verifyTransifex() {
-        if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
-            return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
-        } else {
-            return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
-        }
-    },
-    isCheckDisabled(name) {
-        if (!process.env.USH_DISABLE_CHECKS) {
-            return false;
-        }
-        const checks = process.env.USH_DISABLE_CHECKS.split(',');
-        if (checks.indexOf(name) >= 0) {
-            return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
-        }
-    },
-    checkStructure (a, b, url) {
-        const aKeys = Object.keys(a).sort();
-        const bKeys = Object.keys(b).sort();
-        if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
-            return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`]};
-        } else {
-            return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`]};
-        }
+    let options = {
+        method: 'POST',
+        body: body,
+        headers: {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json'}
+    };
+    return {status: verifyStatus(`${env.BACKEND_URL}/oauth/token`, options), structure: checkTokenStructure(env, options), token: testToken(env, options)};
+};
+
+const checkTokenStructure = function (env, options) {
+    return fetch(`${env.BACKEND_URL}/oauth/token`, options)
+        .then(function (response) {
+            switch (response.status.toString()) {
+                case '200':
+                    return response.json().then(jsonData => {
+                            let preferedStructure = { token_type: 'Bearer', expires_in: '', access_token: ''};
+                            return checkStructure(jsonData, preferedStructure, response.url);
+                        });
+                case '500':
+                    return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'], url: response.url}];
+                case '401':
+                    return [{type: 'error', messages: ['Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API','If you have added your own client id and name, make sure the values in the .env file matches the database.'], url: response.url}];
+            }
+        }).catch(error => {
+            return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.', error], url: env.BACKEND_URL}];
+        });
+};
+
+const testToken = function (env, options) {
+    return fetch(`${env.BACKEND_URL}/oauth/token`, options)
+        .then(function (response) {
+            switch (response.status.toString()) {
+                case '200':
+                    return response.json().then(jsonData => {
+                        return fetch(`${env.BACKEND_URL}/api/v3/forms`, {
+                            method: 'GET',
+                            headers: {
+                                'Accept': 'application/json, text/plain, */*',
+                                'Content-Type': 'application/json',
+                                'Authorization': `Bearer ${jsonData.access_token}`
+                            }
+                        })
+                        .then(function (response) {
+                            switch (response.status.toString()) {
+                                case '200':
+                                    return {type: 'confirmation', messages: ['Token checked and is working. All good!']};
+                                case '500':
+                                    return {type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.']};
+                                case '401':
+                                    return {type: 'error', messages: ['Did you add your own client_secret and client_key?', 'Make sure you updated the database with the same values', 'If you did not add your own secret and key, check that the database-migration has ran, by running ./phinx migrate in the root directory of the Platform API.']};
+                                case '403':
+                                    return {type: 'error', messages: ['There is a problem with the oauth-scopes', 'Check that your Platform API is set up and that all migrations has ran.']};
+                            }
+                        }).catch(err => {
+                            return {type: 'error', messages: ['The server could not be reached or there was an error in the request', 'Make sure your Platform API is running', err]};
+                        });
+                    });
+                case '500':
+                    return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'], url: `${env.BACKEND_URL}/api/v3/forms`}];
+                case '401':
+                    return [{type: 'error', messages: ['Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API','If you have added your own client id and name, make sure the values in the .env file matches the database.'], url: response.url}];
+            }
+        }).catch(error => {
+            return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.', error], url: `${env.BACKEND_URL}/api/v3/forms`}];
+        });
+};
+
+const isCheckDisabled = function (env, name) {
+    if (!env.USH_DISABLE_CHECKS) {
+        return false;
     }
+    const checks = env.USH_DISABLE_CHECKS.split(',');
+    if (checks.indexOf(name) >= 0) {
+        return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
+    }
+};
+
+const checkStructure = function (a, b, url) {
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
+        return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`], url: url};
+    } else {
+        return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`], url: url};
+    }
+};
+
+module.exports = {
+    verifyStatus, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, isCheckDisabled
 };

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -1,11 +1,5 @@
-
 import log       from 'fancy-log';
 import c         from 'ansi-colors';
-import fetch from 'node-fetch';
-import * as forms from '../mocked_backend/api/v3/forms.json';
-import * as tags from '../mocked_backend/api/v3/tags.json';
-import * as features from '../mocked_backend/api/v3/config/features.json';
-import * as map from '../mocked_backend/api/v3/config/map.json';
 import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
@@ -34,8 +28,7 @@ module.exports.verifyEnv = function() {
         return;
     }
 
-    let envCheck = verifier.verifyEnv();
-
+    let envCheck = verifier.verifyEnv(process.env);
     log.info(c.bold(`Checking .env-variables:`));
     envCheck.messages.forEach(message => {
         formatMessage(message, envCheck.type);
@@ -47,7 +40,7 @@ module.exports.verifyTransifex = function() {
         log.info(c.green('USH_DISABLE_CHECKS contains TRANSIFEX, skipping TRANSIFEX verification process.'));
         return;
     }
-    let transifexCheck = verifier.verifyTransifex();
+    let transifexCheck = verifier.verifyTransifex(process.env);
     log.info(c.bold(`Checking credentials for Transifex:`));
     transifexCheck.messages.forEach(message => {
         formatMessage(message, transifexCheck.type);
@@ -61,16 +54,14 @@ module.exports.verifyEndpointStatus = function() {
         formatMessage(checkDisabled.messages, checkDisabled.type);
         return;
     }
-    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
-    endpoints.forEach(function(endpoint) {
-        verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/${endpoint}`)
-        .then(response => {
-            log.info(c.bold('Checking status for endpoints:'));
-            log.info(c.bold(`Status-result for ${response.url}:`));
-            log.info(`The server responded with a ${response.status} code.`);
-            response.messages.forEach(message => {
-                formatMessage(message, response.type);
-            });
+    verifier.verifyEndpointStatus(process.env).forEach(response => {
+            response.then(result => {
+                log.info(c.bold('Checking status for endpoints:'));
+                log.info(c.bold(`Status-result for ${result.url}:`));
+                log.info(`The server responded with a ${result.status} code.`);
+                result.messages.forEach(message => {
+                    formatMessage(message, result.type);
+                });
         });
     });
 };
@@ -80,120 +71,46 @@ module.exports.verifyEndpointStructure = function() {
             log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
             return;
     }
-    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
-    const requests = endpoints.map(function(endpoint) {
-        return fetch(`${process.env.BACKEND_URL}/api/v3/${endpoint}`);
-    });
-
-    Promise.all(requests)
-    .then(function(responses) {
-        responses.forEach(function(response) {
-            response.json().then(function(jsonData) {
-                let structure = {};
-                    switch (response.url.substring(response.url.lastIndexOf('/') + 1)) {
-                        case 'tags':
-                            structure = tags.default;
-                            break;
-                        case 'forms':
-                            structure = forms.default;
-                            break;
-                        case 'features':
-                            structure = features.default;
-                            break;
-                        case 'map':
-                            structure = map.default;
-                            break;
-                    }
-                    
-                    checkStructure(jsonData, structure, response.url);
+    verifier.verifyEndpointStructure(process.env)
+        .then(responses => {
+            responses.forEach(response => {
+                response.then(result=>{
+                    log.info(c.bold(`Structure-result for ${result.url}:`));
+                    result.messages.forEach(message => {
+                    formatMessage(message, result.type);
+                });
             });
         });
-    }).catch(error => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(error));
     });
 };
 
 module.exports.verifyOauth = function () {
-    if (isCheckDisabled('ENDPOINTS_STRUCTURE')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
+    if (isCheckDisabled('VERIFY_OAUTH')) {
+        log.info(c.green('USH_DISABLE_CHECKS contains VERIFY_OAUTH, skipping VERIFY_OAUTH verification process.'));
         return;
     }
 
-    let body = JSON.stringify({
-        grant_type: 'client_credentials',
-        client_id: process.env.OAUTH_CLIENT_ID || 'ushahidiui',
-        client_secret: process.env.OAUTH_CLIENT_SECRET || '35e7f0bca957836d05ca0492211b0ac707671261',
-        scope: 'forms'});
-
-    fetch(`${process.env.BACKEND_URL}/oauth/token`, {
-        method:'POST',
-        body: body,
-        headers: {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json'}
-    })
-    .then(function(response) {
-        log.info(c.bold(`Status-result for ${response.url}:`));
-        log.info(`The server responded with a ${response.status} code.`);        
-        switch (response.status.toString()) {
-            case '200':
-                log.info(c.green('All is good. This is the expected result.'));
-                response.json().then(jsonData=>{
-                    let preferedStructure = { token_type: 'Bearer', expires_in: '', access_token: ''};
-                    checkStructure(jsonData, preferedStructure, response.url);
-                    checkToken(jsonData.access_token);
-                });
-                break;
-            case '500':
-                log.error(c.red('Oh noes. This does not look good.'));
-                log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                break;
-            case '401':
-                log.error(c.red('Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API'));
-                log.error(c.red('If you have added your own client id and name, make sure the values in the .env file matches the database.'));
-                break;
-        }
-    }).catch(error => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(error));
+    let results = verifier.verifyOauth(process.env);
+    results.status.then(status => {
+        log.info(c.bold(`Status-result for ${status.url}:`));
+        log.info(`The server responded with a ${status.status} code.`);
+        status.messages.forEach(message => {
+            formatMessage(message, status.type);
+        });
     });
-};
 
-const checkToken = function (token) {
-    fetch(`${process.env.BACKEND_URL}/api/v3/forms`, {
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json, text/plain, */*',
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`
-        }
-    })
-    .then(function (response) {
-        log.info(c.bold(`Result for token-check:`));
-        log.info(`The server responded with a ${response.status} code.`);
-        switch (response.status.toString()) {
-            case '200':
-                log.info(c.green('All is good. This is the expected result.'));
-                break;
-            case '500':
-                log.error(c.red('Oh noes. This does not look good.'));
-                log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                break;
-            case '401':
-                log.error(c.red('Did you add your own client_secret and client_key?'));
-                log.error(c.red('Make sure you updated the database with the same values'));
-                log.error(c.red('If you did not add your own secret and key, check that the database-migration has ran, by running ./phinx migrate in the root directory of the Platform API.'));
-                break;
-            case '403':
-                log.error(c.red('There is a problem with the oauth-scopes'));
-                log.error(c.red('Check that your Platform API is set up and that all migrations has ran.'));
-                break;
-        }
-    }).catch(err => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(err));
+    results.structure.then(structure => {
+        log.info(c.bold(`Structure-result for ${structure.url}:`));
+        structure.messages.forEach(message => {
+            formatMessage(message, structure.type);
+        });
+    });
+
+    results.token.then(token => {
+        log.info(c.bold('Testing the oauth-token:'));
+        token.messages.forEach(message => {
+            formatMessage(message, token.type);
+        });
     });
 };
 
@@ -204,20 +121,6 @@ const isCheckDisabled = function(name) {
     const checks = process.env.USH_DISABLE_CHECKS.split(',');
     return checks.indexOf(name) >= 0;
 };
-
-const checkStructure = function(a, b, url) {
-    const aKeys = Object.keys(a).sort();
-    const bKeys = Object.keys(b).sort();
-    log.info(c.bold(`Structure-result for ${url}:`));
-    if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
-        log.info(c.green(`The structure for ${url} matches the expected, all good!`));
-    } else {
-        log.info(c.red(`Oh noes, the structure for ${url} does not match the expected `));
-        log.info(c.red(`Make sure you have set up the database correctly `));
-        log.info(c.red(`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`));
-    }
-};
-
 
 const formatMessage = function(message, type) {
     switch (type) {

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -1,47 +1,45 @@
 
 import log       from 'fancy-log';
 import c         from 'ansi-colors';
-import isUrl from 'is-url';
-import fs        from 'fs';
 import fetch from 'node-fetch';
 import * as forms from '../mocked_backend/api/v3/forms.json';
 import * as tags from '../mocked_backend/api/v3/tags.json';
 import * as features from '../mocked_backend/api/v3/config/features.json';
 import * as map from '../mocked_backend/api/v3/config/map.json';
+import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
-    if (isCheckDisabled('NETWORK')) {
-      log.info(c.green('USH_DISABLE_CHECKS contains NETWORK, skipping API connectivity verification process.'));
-      return;
+    let checkDisabled = verifier.isCheckDisabled('NETWORK');
+    if (checkDisabled) {
+        log.info(c.bold('Checking network:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
+        return;
     }
-    checkStatus('api/v3/config');
+
+    verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/config`)
+        .then(response => {
+        log.info(c.bold('Checking network:'));
+        log.info(`The server responded with a ${response.status} code.`);
+        response.messages.forEach(message => {
+            formatMessage(message, response.type);
+        });
+    });
 };
 
 module.exports.verifyEnv = function() {
-    if (isCheckDisabled('ENV')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains ENV, skipping ENV verification process.'));
+    let checkDisabled = verifier.isCheckDisabled('ENV');
+    if (checkDisabled) {
+        log.info(c.bold('Checking .env-variables:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
         return;
     }
-    try {
-        fs.accessSync('.env');
-    } catch (e) {
-        log.error(c.red('.env file not found. Please create the .env file in the project\'s root directory.'));
-    }
 
-    if (!process.env.BACKEND_URL) {
-        log.error(
-        c.red('BACKEND_URL not found in .env file. ' +
-                'Please add this URL to the .env file to connect to the Platform API.'
-            )
-        );
-    }
-    if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
-        log.error(
-        c.red('BACKEND_URL found in .env file. Is not a valid URL.' +
-                'Please fix the BACKEND_URL in the .env file to connect to the Platform API.'
-            )
-        );
-    }
+    let envCheck = verifier.verifyEnv();
+
+    log.info(c.bold(`Checking .env-variables:`));
+    envCheck.messages.forEach(message => {
+        formatMessage(message, envCheck.type);
+    });
 };
 
 module.exports.verifyTransifex = function() {
@@ -49,28 +47,31 @@ module.exports.verifyTransifex = function() {
         log.info(c.green('USH_DISABLE_CHECKS contains TRANSIFEX, skipping TRANSIFEX verification process.'));
         return;
     }
-    if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
-        log.warn(
-        c.yellow('TX_USERNAME and TX_PASSWORD not found in .env file.' +
-                        'This might be ok if you are only using English, ' +
-                        'but it will not allow you to use any other languages.'
-                    )
-        );
-        log.warn(
-        c.yellow('If you need languages other than English, you will need to create a transifex account ' +
-                'and setup the TX_USERNAME and TX_PASSWORD variables in the .env file')
-        );
-    }
+    let transifexCheck = verifier.verifyTransifex();
+    log.info(c.bold(`Checking credentials for Transifex:`));
+    transifexCheck.messages.forEach(message => {
+        formatMessage(message, transifexCheck.type);
+    });
 };
 
 module.exports.verifyEndpointStatus = function() {
-    if (isCheckDisabled('ENDPOINTS_STATUS')) {
-            log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STATUS, skipping ENDPOINTS_STATUS verification process.'));
-            return;
+    let checkDisabled = verifier.isCheckDisabled('ENDPOINT_STATUS');
+    if (checkDisabled) {
+        log.info(c.bold('Checking status for endpoints:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
+        return;
     }
     const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
     endpoints.forEach(function(endpoint) {
-        checkStatus(`api/v3/${endpoint}`);
+        verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/${endpoint}`)
+        .then(response => {
+            log.info(c.bold('Checking status for endpoints:'));
+            log.info(c.bold(`Status-result for ${response.url}:`));
+            log.info(`The server responded with a ${response.status} code.`);
+            response.messages.forEach(message => {
+                formatMessage(message, response.type);
+            });
+        });
     });
 };
 
@@ -217,31 +218,21 @@ const checkStructure = function(a, b, url) {
     }
 };
 
-const checkStatus = function (url) {
-    fetch(`${process.env.BACKEND_URL}/${url}`)
-            .then(response=>{
-                log.info(c.bold(`Status-result for ${response.url}:`));
-                log.info(`The server responded with a ${response.status} code.`);
-                switch (response.status.toString()) {
-                  case '200':
-                    log.info(c.green('All is good. This is the expected result.'));
-                    break;
-                  case '500':
-                    log.error(c.red('Oh noes. This does not look good.'));
-                    log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                    break;
-                  case '404':
-                    log.error(c.red('Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'));
-                    break;
-                  case '403':
-                    log.error(c.red('Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'));
-                    break;
-                }
-                return response;
-              }).catch(error => {
-                log.error(c.red('The server could not be reached or there was an error in the request'));
-                log.error(c.red(error));
-                return error;
-            });
+
+const formatMessage = function(message, type) {
+    switch (type) {
+        case 'confirmation':
+            log.info(c.green(message));
+            break;
+        case 'error':
+            log.error(c.red(message));
+            break;
+        case 'warning':
+            log.warn(c.yellow(message));
+            break;
+        default:
+            log.info(message);
+    }
 };
+
 module.exports.isCheckDisabled = isCheckDisabled;

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -73,9 +73,9 @@ module.exports.verifyEndpointStructure = function() {
     }
     verifier.verifyEndpointStructure(process.env)
         .then(responses => {
+            log.info(c.bold(`Checking endpoint-structures`));
             responses.forEach(response => {
-                response.then(result=>{
-                    log.info(c.bold(`Structure-result for ${result.url}:`));
+                response.then(result => {
                     result.messages.forEach(message => {
                     formatMessage(message, result.type);
                 });
@@ -111,6 +111,38 @@ module.exports.verifyOauth = function () {
         token.messages.forEach(message => {
             formatMessage(message, token.type);
         });
+    });
+};
+
+module.exports.verifyAPIEnvs = function() {
+    verifier.verifyAPIEnvs(process.env)
+    .then(response => {
+        log.info(c.bold(`Checking the environment variables in the API`));
+        if (response.success) {
+           response.success.forEach(result=>{
+               formatMessage(result.message, 'confirmation');
+           });
+        } else if (response.error) {
+            response.error.forEach(result=>{
+                formatMessage(result.message, 'error');
+            });
+        }
+    });
+};
+
+module.exports.verifyDbConnection = function() {
+    verifier.verifyDbConnection(process.env)
+    .then(response => {
+        log.info(c.bold('Checking the database connection'));
+        if (response.success) {
+           response.success.forEach(result=>{
+               formatMessage(result.message, 'confirmation');
+           });
+        } else if (response.error) {
+            response.error.forEach(result=>{
+                formatMessage(result.message, 'error');
+            });
+        }
     });
 };
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -265,4 +265,6 @@ gulp.task('verify', () => {
   verifier.verifyEndpointStatus();
   verifier.verifyEndpointStructure();
   verifier.verifyOauth();
+  verifier.verifyDbConnection();
+  verifier.verifyAPIEnvs();
 });

--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
     "ignore": [
       "ushahidi-platform-pattern-library"
     ]
+  },
+  "browser": {
+    "fs": false
   }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Adds basic FE-verifier with Angular, go to /verifier to see.
- Moves all verifier-tests to a specific file, that can be used both for the gulp-verifiers and browser-verifiers.
- Refactors the gulp-verifier to use the specific verifier-test-file instead
- Adds missing checks for dbConnection and env in the api (needs branch `db-installer-helper` in the api)
- This works fine as long as there are no errors :D If there are errors, the "Sorry something went wrong" message takes over.

@rowasc What I need help with/want to pair on:
I am not sure if this is the best strategy for the browser-tests. I am having problems sidetracking the "Sorry something went wrong" for this particular route (/verifier). Do you have any other ideas? I experimented a bit with other solutions like doing a plain js-file on its own route but never managed to get anything useful working... Also general sanity-check/review on the code would be appreciated! 🙏 


Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform