### PR TITLE
hot fix: Deploy close button demo

### DIFF
--- a/app/common/auth/demo-deployment.directive.js
+++ b/app/common/auth/demo-deployment.directive.js
@@ -33,8 +33,12 @@ function DemoDeploymentController(
     $scope.expired = false;
     $scope.days_remaining = 30;
     $scope.loggedin = $rootScope.loggedin;
-
     $scope.upgrade = upgrade;
+    $scope.close = function close() {
+        $rootScope.toggleModalVisible(false, true);
+        $rootScope.$emit('demoslider:close');
+    };
+
     activate();
 
     function activate() {

--- a/app/common/auth/demo-deployment.html
+++ b/app/common/auth/demo-deployment.html
@@ -12,6 +12,7 @@
             <button class="button" ui-sref="settings.plan" translate="message.button.upgrade">
                 Upgrade now
             </button>
+            <button ng-click="close()" class="right" translate="demo_warnings.close">Close</button>
         </div>
 </div>
 
@@ -22,5 +23,6 @@
     <p ng-if="expired || days_remaining <= 0" translate-values="{site_name: site_name}" translate="demo_warnings.visitor.expired">
         Deployment X is using a free trial of Ushahidi. You will only see the first 25 posts.
     </p>
+    <button ng-click="close()" translate="demo_warnings.close">Close</button>
 </div>
     

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -122,6 +122,7 @@
         }
     },
     "demo_warnings" : {
+        "close": "Close",
         "visitor": {
             "not_expired": "Deployment {{site_name}} is using a free trial of Ushahidi. You will only see the first 25 posts for the next {{days}} days.",
             "expired": "Deployment {{site_name}} is using a free trial of Ushahidi. You will only see the first 25 posts."

--- a/app/common/notifications/demo-slider.html
+++ b/app/common/notifications/demo-slider.html
@@ -22,4 +22,3 @@
     </div>
 
 </div>
-<div class="message-overlay" ng-if="expired && !upgrading"></div>


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a close button to the demo bar. This helps the user because now they can zoom in/out in the data view even if they are in a trial deployment


Testing checklist:
# Not logged in
- [x] Have a deployment in "demo" mode (I'm using a .io deployment url to test it easily 🤷‍♀ )
- [x] When the demo bar appears in the map, click the CLOSE button in the demo bar
- [x] Check that you can Zoom in
- [x] Check that you can Zoom out
- [x] Navigate to the data view. The demo bar will not appear. 
- [x] Reload the page.
- [x] The demo bar will appear
- [x] Go to another view
- [x] Close the demo bar again. 

Video :) 
https://drive.google.com/open?id=1zpiFQUADzFThHLpejxZwmw1JMTHUNA40


# Logged in
(same steps)
- [x] Have a deployment in "demo" mode (I'm using a .io deployment url to test it easily 🤷‍♀ )
- [x] When the demo bar appears in the map, click the CLOSE button in the demo bar
- [x] Check that you can Zoom in
- [x] Check that you can Zoom out
- [x] Navigate to the data view. The demo bar will not appear. 
- [x] Reload the page.
- [x] The demo bar will appear
- [x] Go to another view
- [x] Close the demo bar again. 
Video :D 
https://drive.google.com/open?id=1wu9HX2zCmBLB8Eqz3iyo_1EtLtLnKkH_

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform