### PR TITLE
Installer web checks

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -43,6 +43,8 @@
         "-event",
         "makeTestApp",
         "BACKEND_URL",
+        "USH_DISABLE_CHECKS",
+        "VERIFIER",
         "RAVEN_URL",
         "ENVIRONMENT",
         "GIT_COMMIT"

--- a/app/app.js
+++ b/app/app.js
@@ -36,6 +36,7 @@ window.ushahidi = window.ushahidi || {};
 // this 'environment variable' will be set within the gulpfile
 var backendUrl = window.ushahidi.backendUrl = (window.ushahidi.backendUrl || BACKEND_URL).replace(/\/$/, ''),
     intercomAppId = window.ushahidi.intercomAppId = window.ushahidi.intercomAppId || '',
+    ushDisableChecks = (window.ushahidi.ushDisableChecks || USH_DISABLE_CHECKS),
     verifier = window.ushahidi.verifier = (window.ushahidi.verifier || VERIFIER),
     appStoreId = window.ushahidi.appStoreId = window.ushahidi.appStoreId || '',
     apiUrl = window.ushahidi.apiUrl = backendUrl + '/api/v3',
@@ -90,12 +91,14 @@ angular.module('app',
         API_URL                  : apiUrl,
         INTERCOM_APP_ID          : intercomAppId,
         APP_STORE_ID             : appStoreId,
+        VERIFIER                 : verifier,
         DEFAULT_LOCALE           : 'en_US',
         OAUTH_CLIENT_ID          : 'ushahidiui',
         OAUTH_CLIENT_SECRET      : '35e7f0bca957836d05ca0492211b0ac707671261',
         CLAIMED_ANONYMOUS_SCOPES : claimedAnonymousScopes,
         CLAIMED_USER_SCOPES      : ['*'],
         MAPBOX_API_KEY           : window.ushahidi.mapboxApiKey || 'pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw', // Default OSS mapbox api key
+        USH_DISABLE_CHECKS       : ushDisableChecks,
         TOS_RELEASE_DATE         : new Date(window.ushahidi.tosReleaseDate).toJSON() ? new Date(window.ushahidi.tosReleaseDate) : false, // Date in UTC
         EXPORT_POLLING_INTERVAL  : window.ushahidi.export_polling_interval || 30000
     })

--- a/app/app.js
+++ b/app/app.js
@@ -36,6 +36,7 @@ window.ushahidi = window.ushahidi || {};
 // this 'environment variable' will be set within the gulpfile
 var backendUrl = window.ushahidi.backendUrl = (window.ushahidi.backendUrl || BACKEND_URL).replace(/\/$/, ''),
     intercomAppId = window.ushahidi.intercomAppId = window.ushahidi.intercomAppId || '',
+    verifier = window.ushahidi.verifier = (window.ushahidi.verifier || VERIFIER),
     appStoreId = window.ushahidi.appStoreId = window.ushahidi.appStoreId || '',
     apiUrl = window.ushahidi.apiUrl = backendUrl + '/api/v3',
     claimedAnonymousScopes = [

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -9,7 +9,7 @@ angular.lazy()
             .then(function (response) {
                 window.ushahidi.bootstrapConfig = response.data.results;
             });
-        }   
+        }
     }])
     .loading(function () {
         // Show loading

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -4,10 +4,12 @@ require('angular-lazy-bootstrap/src/bootstrap.js');
 // Load site config THEN bootstrap the app
 angular.lazy()
     .resolve(['$q', '$http', function ($q, $http) {
-        return $http.get(window.ushahidi.apiUrl + '/config')
-        .then(function (response) {
-            window.ushahidi.bootstrapConfig = response.data.results;
-        });
+        if (!window.ushahidi.verifier) {
+            return $http.get(window.ushahidi.apiUrl + '/config')
+            .then(function (response) {
+                window.ushahidi.bootstrapConfig = response.data.results;
+            });
+        }   
     }])
     .loading(function () {
         // Show loading

--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -105,7 +105,6 @@ angular.module('ushahidi.common', [
 .directive('categorySelector', require('./directives/category-selector.directive.js'))
 .directive('languageSwitch', require('./directives/language-switch.directive.js'))
 .directive('loadingDots', require('./directives/loading-dots.directive.js'))
-
 // Event actions
 .constant('EVENT', {
     ACTIONS : {
@@ -128,6 +127,9 @@ angular.module('ushahidi.common', [
 .run(['$templateCache', function ($templateCache) {
     $templateCache.put('common/directives/mode-bar/ushahidi-logo.html', require('./directives/mode-bar/ushahidi-logo.html'));
 }])
+.factory('Verifier', function () {
+    return require('./verifier/verifier.js');
+})
 ;
 
 // Load submodules

--- a/app/common/common-routes.js
+++ b/app/common/common-routes.js
@@ -59,5 +59,11 @@ module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($sta
                 template: require('./auth/404.html')
             }
         )
+        .state({
+            name: 'verifier',
+            url: '/verifier',
+            controller: require('./verifier/verifier.controller.js'),
+            template: require('./verifier/verifier.html')
+        })
         ;
 }];

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -26,7 +26,7 @@ module.exports = [
         }
 
         function checkNetwork() {
-            const verifyNetwork = Verifier.verifyNetwork(CONST.BACKEND_URL);
+            const verifyNetwork = Verifier.verifyNetwork(CONST);
             if (!verifyNetwork) {
                 $scope.networkCheck = false;
             } else {

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -5,7 +5,7 @@ module.exports = [
     function ($scope, CONST, Verifier) {
         $scope.endpointStatuses = [];
         $scope.endpointStructureChecks = [];
-
+        $scope.isCheckDisabled = isCheckDisabled;
         function activate() {
             checkNetwork();
             envCheck();
@@ -18,10 +18,8 @@ module.exports = [
         }
 
         function checkNetwork() {
-            Verifier.verifyStatus(
-                `${CONST.BACKEND_URL}/api/v3/config`,
-                CONST
-            ).then(response => {
+            Verifier.verifyNetwork(CONST.BACKEND_URL)
+            .then(response => {
                 $scope.networkCheck = response;
                 $scope.$apply();
             });
@@ -81,6 +79,9 @@ module.exports = [
                 $scope.apiEnvs = response;
                 $scope.$apply();
             });
+        }
+        function isCheckDisabled(name) {
+            return Verifier.isCheckDisabled(CONST, name);
         }
         activate();
     }

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -3,10 +3,18 @@ module.exports = [
     'CONST',
     'Verifier',
     function ($scope, CONST, Verifier) {
+        $scope.networkCheck = true;
+        $scope.envCheck = true;
         $scope.endpointStatuses = [];
         $scope.endpointStructureChecks = [];
-        $scope.isCheckDisabled = isCheckDisabled;
+        $scope.transifexCheck = true;
+        $scope.oauthCheck = true;
+        $scope.allDisabled = Verifier.isCheckDisabled(CONST, 'ALL');
+
         function activate() {
+            if ($scope.allDisabled) {
+                return;
+            }
             checkNetwork();
             envCheck();
             endpointStatusCheck();
@@ -18,11 +26,16 @@ module.exports = [
         }
 
         function checkNetwork() {
-            Verifier.verifyNetwork(CONST.BACKEND_URL)
-            .then(response => {
-                $scope.networkCheck = response;
-                $scope.$apply();
-            });
+            const verifyNetwork = Verifier.verifyNetwork(CONST.BACKEND_URL);
+            if (!verifyNetwork) {
+                $scope.networkCheck = false;
+            } else {
+                verifyNetwork
+                .then(response => {
+                    $scope.networkCheck = response;
+                    $scope.$apply();
+                });
+            }
         }
 
         function envCheck() {
@@ -30,21 +43,31 @@ module.exports = [
         }
 
         function endpointStatusCheck() {
-            Verifier.verifyEndpointStatus(CONST).forEach(response => {
-                response.then(result => {
-                    $scope.endpointStatuses.push(result);
-                    $scope.$apply();
+            const endpointStatusCheck = Verifier.verifyEndpointStatus(CONST);
+            if (!endpointStatusCheck) {
+                $scope.endpointStatuses = false;
+            } else {
+                endpointStatusCheck.forEach(response => {
+                    response.then(result => {
+                        $scope.endpointStatuses.push(result);
+                        $scope.$apply();
+                    });
                 });
-            });
+            }
         }
 
         function endpointStructureCheck() {
-            Verifier.verifyEndpointStructure(CONST).forEach(response => {
-                response.then(result => {
-                    $scope.endpointStructureChecks.push(result);
-                    $scope.$apply();
+            const endpointStructureCheck = Verifier.verifyEndpointStructure(CONST);
+            if (!endpointStructureCheck) {
+                $scope.endpointStructureChecks = false;
+            } else {
+                endpointStructureCheck.forEach(response => {
+                    response.then(result => {
+                        $scope.endpointStructureChecks.push(result);
+                        $scope.$apply();
+                    });
                 });
-            });
+            }
         }
 
         function checkTransifex() {
@@ -52,36 +75,48 @@ module.exports = [
         }
 
         function verifyOauth() {
-            let results = Verifier.verifyOauth(CONST);
-            results.status.then(status => {
-                $scope.oauthStatus = status;
-                $scope.$apply();
-            });
-            results.structure.then(structure => {
-                $scope.oauthStructure = structure;
-                $scope.$apply();
-            });
-            results.token.then(token => {
-                $scope.oauthToken = token;
-                $scope.$apply();
-            });
+            const results = Verifier.verifyOauth(CONST);
+            if (!results) {
+                $scope.oauthCheck = false;
+            } else {
+                results.status.then(status => {
+                    $scope.oauthStatus = status;
+                    $scope.$apply();
+                });
+                results.structure.then(structure => {
+                    $scope.oauthStructure = structure;
+                    $scope.$apply();
+                });
+                results.token.then(token => {
+                    $scope.oauthToken = token;
+                    $scope.$apply();
+                });
+            }
         }
 
         function verifyDbConnection() {
-            Verifier.verifyDbConnection(CONST).then(response => {
-                $scope.dbConnection = response;
-                $scope.$apply();
-            });
+            const dbCheck = Verifier.verifyDbConnection(CONST);
+            if (!dbCheck) {
+                $scope.dbConnection = false;
+            } else {
+                dbCheck
+                .then(response => {
+                    $scope.dbConnection = response;
+                    $scope.$apply();
+                });
+            }
         }
 
         function verifyAPIEnvs() {
-            Verifier.verifyAPIEnvs(CONST).then(response => {
-                $scope.apiEnvs = response;
-                $scope.$apply();
-            });
-        }
-        function isCheckDisabled(name) {
-            return Verifier.isCheckDisabled(CONST, name);
+            const apiEnvCheck = Verifier.verifyAPIEnvs(CONST);
+            if (!apiEnvCheck) {
+                $scope.apiEnvs = false;
+            } else {
+                apiEnvCheck.then(response => {
+                    $scope.apiEnvs = response;
+                    $scope.$apply();
+                });
+            }
         }
         activate();
     }

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -9,6 +9,8 @@ module.exports = [
         $scope.endpointStructureChecks = [];
         $scope.transifexCheck = true;
         $scope.oauthCheck = true;
+        $scope.dbConnection = true;
+        $scope.apiEnvs = true;
         $scope.allDisabled = Verifier.isCheckDisabled(CONST, 'ALL');
 
         function activate() {

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -1,0 +1,62 @@
+
+module.exports = [
+    '$rootScope',
+    '$scope',
+    'Verifier',
+    function ($rootScope, $scope, Verifier) {
+        $rootScope.setLayout('layout-c');
+        $scope.networkCheck;
+        $scope.envCheck;
+        $scope.endpointChecks = [];
+        function activate() {
+            checkNetwork();
+            envCheck();
+            endpointChecks();
+            checkTransifex();
+        }
+
+        function checkNetwork() {
+            let checkDisabled = Verifier.isCheckDisabled('NETWORK');
+            if (checkDisabled) {
+                $scope.networkCheck = checkDisabled;
+                return;
+            }
+
+            Verifier.verifyStatus(`${BACKEND_URL}/api/v3/config`)
+            .then(response => {
+                $scope.networkCheck = response;
+                $scope.$apply();
+            });
+        }
+
+        function envCheck() {
+            let checkDisabled = Verifier.isCheckDisabled('ENV');
+            if (checkDisabled) {
+                $scope.envCheck = checkDisabled;
+                return;
+            }
+            $scope.envCheck = Verifier.verifyEnv();
+        }
+
+        function endpointChecks() {
+            const endpoints = ['tags', 'forms', 'config/feature', 'config/map'];
+            endpoints.forEach(function (endpoint) {
+                Verifier.verifyStatus(`${BACKEND_URL}/api/v3/${endpoint}`)
+                .then(response => {
+                    $scope.endpointChecks.push(response);
+                    $scope.$apply();
+                });
+            });
+        }
+        function checkTransifex() {
+            let checkDisabled = Verifier.isCheckDisabled('TRANSIFEX');
+            if (checkDisabled) {
+                $scope.transifexCheck = checkDisabled;
+                return;
+            }
+            $scope.transifexCheck = Verifier.verifyTransifex();
+        }
+        activate();
+    }
+];
+

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -1,4 +1,3 @@
-
 module.exports = [
     '$scope',
     'CONST',
@@ -19,8 +18,10 @@ module.exports = [
         }
 
         function checkNetwork() {
-            Verifier.verifyStatus(`${CONST.BACKEND_URL}/api/v3/config`, CONST)
-            .then(response => {
+            Verifier.verifyStatus(
+                `${CONST.BACKEND_URL}/api/v3/config`,
+                CONST
+            ).then(response => {
                 $scope.networkCheck = response;
                 $scope.$apply();
             });
@@ -32,7 +33,7 @@ module.exports = [
 
         function endpointStatusCheck() {
             Verifier.verifyEndpointStatus(CONST).forEach(response => {
-                response.then(result=> {
+                response.then(result => {
                     $scope.endpointStatuses.push(result);
                     $scope.$apply();
                 });
@@ -40,15 +41,12 @@ module.exports = [
         }
 
         function endpointStructureCheck() {
-            Verifier.verifyEndpointStructure(CONST)
-            .then(responses=> {
-                    responses.map(response=> {
-                            response.then(message=> {
-                                $scope.endpointStructureChecks.push(message);
-                                $scope.$apply();
-                            });
-                        });
+            Verifier.verifyEndpointStructure(CONST).forEach(response => {
+                response.then(result => {
+                    $scope.endpointStructureChecks.push(result);
+                    $scope.$apply();
                 });
+            });
         }
 
         function checkTransifex() {
@@ -60,30 +58,26 @@ module.exports = [
             results.status.then(status => {
                 $scope.oauthStatus = status;
                 $scope.$apply();
-
             });
-            results.structure.then(structure=> {
+            results.structure.then(structure => {
                 $scope.oauthStructure = structure;
                 $scope.$apply();
-
             });
-            results.token.then(token=> {
+            results.token.then(token => {
                 $scope.oauthToken = token;
                 $scope.$apply();
             });
         }
 
         function verifyDbConnection() {
-            Verifier.verifyDbConnection(CONST)
-            .then(response => {
+            Verifier.verifyDbConnection(CONST).then(response => {
                 $scope.dbConnection = response;
                 $scope.$apply();
             });
         }
 
         function verifyAPIEnvs() {
-            Verifier.verifyAPIEnvs(CONST)
-            .then(response => {
+            Verifier.verifyAPIEnvs(CONST).then(response => {
                 $scope.apiEnvs = response;
                 $scope.$apply();
             });
@@ -91,4 +85,3 @@ module.exports = [
         activate();
     }
 ];
-

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -4,10 +4,9 @@ module.exports = [
     'CONST',
     'Verifier',
     function ($scope, CONST, Verifier) {
-        $scope.networkCheck;
-        $scope.envCheck;
         $scope.endpointStatuses = [];
         $scope.endpointStructureChecks = [];
+
         function activate() {
             checkNetwork();
             envCheck();
@@ -15,6 +14,8 @@ module.exports = [
             endpointStructureCheck();
             checkTransifex();
             verifyOauth();
+            verifyDbConnection();
+            verifyAPIEnvs();
         }
 
         function checkNetwork() {
@@ -53,6 +54,7 @@ module.exports = [
         function checkTransifex() {
             $scope.transifexCheck = Verifier.verifyTransifex(CONST);
         }
+
         function verifyOauth() {
             let results = Verifier.verifyOauth(CONST);
             results.status.then(status => {
@@ -67,6 +69,22 @@ module.exports = [
             });
             results.token.then(token=> {
                 $scope.oauthToken = token;
+                $scope.$apply();
+            });
+        }
+
+        function verifyDbConnection() {
+            Verifier.verifyDbConnection(CONST)
+            .then(response => {
+                $scope.dbConnection = response;
+                $scope.$apply();
+            });
+        }
+
+        function verifyAPIEnvs() {
+            Verifier.verifyAPIEnvs(CONST)
+            .then(response => {
+                $scope.apiEnvs = response;
                 $scope.$apply();
             });
         }

--- a/app/common/verifier/verifier.controller.js
+++ b/app/common/verifier/verifier.controller.js
@@ -95,28 +95,25 @@ module.exports = [
         }
 
         function verifyDbConnection() {
-            const dbCheck = Verifier.verifyDbConnection(CONST);
-            if (!dbCheck) {
-                $scope.dbConnection = false;
-            } else {
-                dbCheck
-                .then(response => {
-                    $scope.dbConnection = response;
+            Verifier.verifyDbConnection(CONST).then(dbCheck => {
+                if (dbCheck === 'DISABLED') {
+                    $scope.dbConnection = false;
+                } else {
+                    $scope.dbConnection = dbCheck;
                     $scope.$apply();
-                });
-            }
+                }
+            });
         }
 
         function verifyAPIEnvs() {
-            const apiEnvCheck = Verifier.verifyAPIEnvs(CONST);
-            if (!apiEnvCheck) {
-                $scope.apiEnvs = false;
-            } else {
-                apiEnvCheck.then(response => {
-                    $scope.apiEnvs = response;
+            Verifier.verifyAPIEnvs(CONST).then(apiEnvCheck => {
+                if (apiEnvCheck === 'DISABLED') {
+                    $scope.apiEnvs = false;
+                } else {
+                    $scope.apiEnvs = apiEnvCheck;
                     $scope.$apply();
-                });
-            }
+                }
+            });
         }
         activate();
     }

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -1,0 +1,34 @@
+
+<!-- <verifier network="networkChecks" endpoints="endpointChecks"></verifier> -->
+
+<main role=main>
+        <div class="main-col">
+            <h1>Installer helper!</h1>
+            <h2>Checking network...</h2>
+            <div>
+                <strong>Status-result for {{networkCheck.url}}</strong>
+                <p>The server responded with a {{networkCheck.status}}-status code</p>    
+                <p ng-repeat="message in networkCheck.messages">{{message}}</p>
+            </div>
+            <h2>Checking endpoints...</h2>
+            <div ng-repeat="endpoint in endpointChecks">
+                <strong>Status-result for {{endpoint.url}}</strong>
+                    <p>The server responded with a {{endpoint.status}}-status code</p>    
+                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
+                </div>
+            <h2>Checking Oauth-endpoint...</h2>
+            <div></div>
+            <h2>Checking environment variables in the client...</h2>
+            <div ng-repeat="result in envCheck.messages">
+                    <p>{{result}}</p>
+                </div>
+            <h2>Checking Transifex</h2>
+            <div ng-repeat="result in transifexCheck.messages">
+                    {{result}}
+            </div>
+            <h2>Checking Database-connection</h2>
+            <div></div>
+            <h2>Checking environment-variables in the API...</h2>
+    </div>
+    </main>
+    

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -1,34 +1,56 @@
-
-<!-- <verifier network="networkChecks" endpoints="endpointChecks"></verifier> -->
-
-<main role=main>
+<div>
+    <layout-class layout="b"></layout-class>
+    <main role="main">
         <div class="main-col">
-            <h1>Installer helper!</h1>
-            <h2>Checking network...</h2>
             <div>
+                <h1>Installer helper!</h1>
+                <h2>Checking network...</h2>
                 <strong>Status-result for {{networkCheck.url}}</strong>
                 <p>The server responded with a {{networkCheck.status}}-status code</p>    
                 <p ng-repeat="message in networkCheck.messages">{{message}}</p>
             </div>
-            <h2>Checking endpoints...</h2>
-            <div ng-repeat="endpoint in endpointChecks">
-                <strong>Status-result for {{endpoint.url}}</strong>
+            <div>
+                <h2>Checking endpoints...</h2>
+                <div ng-repeat="endpoint in endpointStatuses">
+                    <strong>Status-result for {{endpoint.url}}</strong>
                     <p>The server responded with a {{endpoint.status}}-status code</p>    
                     <p ng-repeat="message in endpoint.messages">{{message}}</p>
                 </div>
-            <h2>Checking Oauth-endpoint...</h2>
-            <div></div>
-            <h2>Checking environment variables in the client...</h2>
-            <div ng-repeat="result in envCheck.messages">
-                    <p>{{result}}</p>
+                <div ng-repeat="endpoint in endpointStructureChecks">
+                    <strong>Structure-result for {{endpoint.url}}</strong>
+                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
                 </div>
-            <h2>Checking Transifex</h2>
-            <div ng-repeat="result in transifexCheck.messages">
-                    {{result}}
             </div>
-            <h2>Checking Database-connection</h2>
-            <div></div>
-            <h2>Checking environment-variables in the API...</h2>
-    </div>
+            <div>
+                <h2>Checking Oauth-endpoint...</h2>
+                <div>
+                    <strong>Status-result for {{oauthStatus.url}}</strong>
+                    <p>The server responded with a {{oauthStatus.status}}-status code</p>
+                    <p ng-repeat="message in oauthStatusCheck.messages">{{message}}</p>
+                    <strong>Checking the structure for {{oauthStructure.url}}</strong>
+                    <p ng-repeat="message in oauthStructure.messages">{{message}}</p>
+                    <strong>Checking that the oauth-token is working</strong>
+                    <p ng-repeat="message in oauthToken.messages">{{message}}</p>
+                </div>
+            <div>
+                <h2>Checking environment variables in the client...</h2>
+                <div ng-repeat="message in envCheck.messages">
+                    <p>{{message}}</p>
+                </div>
+            </div>
+            <div>
+                <h2>Checking Transifex</h2>
+                <div ng-repeat="message in transifexCheck.messages">
+                    {{message}}
+                </div>
+            </div>
+            <div>
+                <h2>Checking Database-connection</h2>
+                <div></div>
+            </div>
+            <div>
+                <h2>Checking environment-variables in the API...</h2>
+            </div>
+        </div>
     </main>
-    
+</div>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -2,11 +2,16 @@
     <layout-class layout="b"></layout-class>
     <main role="main">
         <div class="main-col">
-            <div class="listing card init">
+                <div class="listing card init" ng-if="isCheckDisabled('ALL')">
+
+                <strong>USH_DISABLE_CHECKS is set to ALL, all verification processes is turned off.</strong>
+                <p>If you believe this is wrong, check the .env file for the variable USH_DISABLE_CHECKS.</p>
+                </div>
+            <div class="listing card init" ng-if="!isCheckDisabled('ALL')">
                 <h1>Installer helper</h1>
                 <p>Check the messages below to get hints while installing the Ushahidi-platform!</p>
                 <div class="listing-item"></div>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!isCheckDisabled('NETWORK')">
                     <h3 class="list-item-title">Checking network...</h3>
                     <div class="listing-item">
                         <div class="listing-item-primary">
@@ -25,7 +30,7 @@
             </div>
             <div class="listing-item">
                 <h3 class="list-item-title">Checking endpoints...</h3>
-                <div class="listing-item" ng-repeat="endpoint in endpointStatuses">
+                <div class="listing-item" ng-repeat="endpoint in endpointStatuses" ng-if="!isCheckDisabled('ENDPOINT_STATUS')">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">
@@ -39,7 +44,7 @@
                         <p ng-repeat="message in endpoint.messages">{{message}}</p>
                     </div>
                 </div>
-                <div class="listing-item" ng-repeat="endpoint in endpointStructureChecks">
+                <div class="listing-item" ng-repeat="endpoint in endpointStructureChecks" ng-if="!isCheckDisabled('ENDPOINT_STRUCTURE')">
                     <div class="listing-item-primary">
                             <div class="listing-item-image">
                                 <svg class="iconic"   >
@@ -53,7 +58,7 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item">
+            <div class="listing-item" ng-if="!isCheckDisabled('OAUTH')">
                 <h3>Checking Oauth-endpoint...</h3>
                 <div class="listing-item">
                     <div class="listing-item-primary">
@@ -96,7 +101,7 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item">
+            <div class="listing-item" ng-if="!isCheckDisabled('ENV')">
                 <h3>Checking environment variables in the client...</h3>
                 <div class="listing-item">
                     <div class="listing-item-primary">
@@ -113,7 +118,7 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item">
+            <div class="listing-item" ng-if="!isCheckDisabled('TRANSIFEX')">
                 <h3>Checking Transifex</h3>
                 <div class="listing-item">
                     <div class="listing-item-primary">
@@ -130,7 +135,7 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item">
+            <div class="listing-item" ng-if="!isCheckDisabled('DBCONNECTION')">
                 <h3>Checking Database-connection</h3>
                 <div class="listing-item">
                     <div class="listing-item-primary">
@@ -151,7 +156,7 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item">
+            <div class="listing-item" ng-if="!isCheckDisabled('API_ENVS')">
                 <h3>Checking environment-variables in the API...</h3>
                 <div class="listing-item">
                     <div class="listing-item-primary">

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -2,69 +2,177 @@
     <layout-class layout="b"></layout-class>
     <main role="main">
         <div class="main-col">
-            <div>
-                <h1>Installer helper!</h1>
-                <h2>Checking network...</h2>
-                <strong>Status-result for {{networkCheck.url}}</strong>
-                <p>The server responded with a {{networkCheck.status}}-status code</p>    
-                <p ng-repeat="message in networkCheck.messages">{{message}}</p>
-            </div>
-            <div>
-                <h2>Checking endpoints...</h2>
-                <div ng-repeat="endpoint in endpointStatuses">
-                    <strong>Status-result for {{endpoint.url}}</strong>
-                    <p>The server responded with a {{endpoint.status}}-status code</p>    
-                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
-                </div>
-                <div ng-repeat="endpoint in endpointStructureChecks">
-                    <strong>Structure-result for {{endpoint.url}}</strong>
-                    <p ng-repeat="message in endpoint.messages">{{message}}</p>
-                </div>
-            </div>
-            <div>
-                <h2>Checking Oauth-endpoint...</h2>
-                <div>
-                    <strong>Status-result for {{oauthStatus.url}}</strong>
-                    <p>The server responded with a {{oauthStatus.status}}-status code</p>
-                    <p ng-repeat="message in oauthStatusCheck.messages">{{message}}</p>
-                    <strong>Checking the structure for {{oauthStructure.url}}</strong>
-                    <p ng-repeat="message in oauthStructure.messages">{{message}}</p>
-                    <strong>Checking that the oauth-token is working</strong>
-                    <p ng-repeat="message in oauthToken.messages">{{message}}</p>
-                </div>
-            <div>
-                <h2>Checking environment variables in the client...</h2>
-                <div ng-repeat="message in envCheck.messages">
-                    <p>{{message}}</p>
+            <div class="listing card init">
+                <h1>Installer helper</h1>
+                <p>Check the messages below to get hints while installing the Ushahidi-platform!</p>
+                <div class="listing-item"></div>
+                <div class="listing-item">
+                    <h3 class="list-item-title">Checking network...</h3>
+                    <div class="listing-item">
+                        <div class="listing-item-primary">
+                            <div class="listing-item-image">
+                                <svg class="iconic">
+                                    <use style="fill: #de0000" ng-if="networkCheck.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                    <use style="fill: #4fab2f" ng-if="networkCheck.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                    <use style="fill: #FFC334" ng-if="networkCheck.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                </svg>
+                            </div>
+                        <strong class="list-item-secondary" ng-if="networkCheck.url">Status-result for {{networkCheck.url}}</strong>
+                        <p ng-if="networkCheck.status">The server responded with a {{networkCheck.status}}-status code</p>
+                        <p class="class="list-item-secondary" ng-repeat="message in networkCheck.messages">{{message}}</p>
+                    </div>
                 </div>
             </div>
-            <div>
-                <h2>Checking Transifex</h2>
-                <div ng-repeat="message in transifexCheck.messages">
-                    {{message}}
+            <div class="listing-item">
+                <h3 class="list-item-title">Checking endpoints...</h3>
+                <div class="listing-item" ng-repeat="endpoint in endpointStatuses">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="endpoint.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="endpoint.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #FFC334" ng-if="endpoint.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="endpoint.url">Status-result for {{endpoint.url}}</strong>
+                        <p ng-if="endpoint.status">The server responded with a {{endpoint.status}}-status code</p>
+                        <p ng-repeat="message in endpoint.messages">{{message}}</p>
+                    </div>
+                </div>
+                <div class="listing-item" ng-repeat="endpoint in endpointStructureChecks">
+                    <div class="listing-item-primary">
+                            <div class="listing-item-image">
+                                <svg class="iconic"   >
+                                    <use style="fill: #de0000" ng-if="endpoint.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                    <use style="fill: #4fab2f" ng-if="endpoint.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                    <use style="fill: #FFC334" ng-if="endpoint.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                </svg>
+                            </div>
+                        <strong class="list-item-secondary" ng-if="endpoint.url">Structure-result for {{endpoint.url}}</strong>
+                        <p ng-repeat="message in endpoint.messages">{{message}}</p>
+                    </div>
                 </div>
             </div>
-            <div>
-                <h2>Checking Database-connection</h2>
-                <div ng-if="dbConnection.success" ng-repeat="result in dbConnection.success">
-                    <p>{{result.message}}</p>
-                    <p>{{result.explainer}}</p>
+            <div class="listing-item">
+                <h3>Checking Oauth-endpoint...</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic"   >
+                                <use style="fill: #de0000" ng-if="oauthStatus.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="oauthStatus.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #FFC334" ng-if="oauthStatus.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="oauthStatus.url">Status-result for {{oauthStatus.url}}</strong>
+                        <p>The server responded with a {{oauthStatus.status}}-status code</p>
+                        <p ng-repeat="message in oauthStatusCheck.messages">{{message}}</p>
+                    </div>
+                    <div class="listing-item">
+                        <div class="listing-item-primary">
+                            <div class="listing-item-image">
+                                <svg class="iconic"   >
+                                    <use style="fill: #de0000" ng-if="oauthStructure.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                    <use style="fill: #4fab2f" ng-if="oauthStructure.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                    <use style="fill: #FFC334" ng-if="oauthStructure.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                </svg>
+                            </div>
+                            <strong class="list-item-secondary" ng-if="oauthStructure.url">Checking the structure for {{oauthStructure.url}}</strong>
+                            <p ng-repeat="message in oauthStructure.messages">{{message}}</p>
+                        </div>
+                    </div>
+                    <div class="listing-item">
+                        <div class="listing-item-primary">
+                            <div class="listing-item-image">
+                                <svg class="iconic">
+                                    <use style="fill: #de0000" ng-if="oauthToken.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                    <use style="fill: #4fab2f" ng-if="oauthToken.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                    <use style="fill: #FFC334" ng-if="oauthToken.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                                </svg>
+                            </div>
+                            <strong class="list-item-secondary" ng-if="oauthToken.messages">Checking that the oauth-token is working</strong>
+                            <p ng-repeat="message in oauthToken.messages">{{message}}</p>
+                        </div>
+                    </div>
                 </div>
-                <div ng-if="dbConnection.errors" ng-repeat="result in dbConnection.errors">
+            </div>
+            <div class="listing-item">
+                <h3>Checking environment variables in the client...</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="envCheck.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="envCheck.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #FFC334" ng-if="envCheck.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="envCheck.messages">Checking that there is an .env file in the client </strong>
+
+                        <p ng-repeat="message in envCheck.messages">{{message}}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="listing-item">
+                <h3>Checking Transifex</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="transifexCheck.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="transifexCheck.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #FFC334" ng-if="transifexCheck.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="transifexCheck">Checking if there are credentials for Transifex</strong>
+
+                        <p ng-repeat="message in transifexCheck.messages">{{message}}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="listing-item">
+                <h3>Checking Database-connection</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="dbConnection.errors" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="dbConnection.success" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="dbConnection">Checking that the database is connected</strong>
+                    <div ng-if="dbConnection.success" ng-repeat="result in dbConnection.success">
                         <p>{{result.message}}</p>
                         <p>{{result.explainer}}</p>
                     </div>
-            </div>
-            <div>
-                <h2>Checking environment-variables in the API...</h2>
-                <div ng-if="apiEnvs.success" ng-repeat="result in apiEnvs.success">
+                    <div ng-if="dbConnection.errors" ng-repeat="result in dbConnection.errors">
                         <p>{{result.message}}</p>
                         <p>{{result.explainer}}</p>
                     </div>
-                    <div ng-if="apiEnvs.errors" ng-repeat="result in apiEnvs.errors">
+                </div>
+            </div>
+            <div class="listing-item">
+                <h3>Checking environment-variables in the API...</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="apiEnvs.errors" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="apiEnvs.success" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                            </svg>
+                        </div>
+                        <strong class="list-item-secondary" ng-if="apiEnvs">Checking that there is an .env file in the backend</strong>
+
+                        <div ng-if="apiEnvs.success" ng-repeat="result in apiEnvs.success">
                             <p>{{result.message}}</p>
                             <p>{{result.explainer}}</p>
+                        </div>
+                        <div ng-if="apiEnvs.errors" ng-repeat="result in apiEnvs.errors">
+                            <p>{{result.message}}</p>
+                            <p>{{result.explainer}}</p>
+                        </div>
                     </div>
+                </div>
             </div>
         </div>
     </main>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -50,7 +50,7 @@
                     <p>{{result.message}}</p>
                     <p>{{result.explainer}}</p>
                 </div>
-                <div ng-if="dbConnection.error" ng-repeat="result in dbConnection.error">
+                <div ng-if="dbConnection.errors" ng-repeat="result in dbConnection.errors">
                         <p>{{result.message}}</p>
                         <p>{{result.explainer}}</p>
                     </div>
@@ -61,7 +61,7 @@
                         <p>{{result.message}}</p>
                         <p>{{result.explainer}}</p>
                     </div>
-                    <div ng-if="apiEnvs.error" ng-repeat="result in apiEnvs.error">
+                    <div ng-if="apiEnvs.errors" ng-repeat="result in apiEnvs.errors">
                             <p>{{result.message}}</p>
                             <p>{{result.explainer}}</p>
                     </div>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -15,15 +15,15 @@
                 <div class="listing-item" ng-if="!networkCheck">
                     <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
                 </div>
-                    <div class="listing-item" ng-if="networkCheck">
-                        <div class="listing-item-primary">
-                            <div class="listing-item-image">
-                                <svg class="iconic">
-                                    <use style="fill: #de0000" ng-if="networkCheck.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
-                                    <use style="fill: #4fab2f" ng-if="networkCheck.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
-                                    <use style="fill: #FFC334" ng-if="networkCheck.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
-                                </svg>
-                            </div>
+                <div class="listing-item" ng-if="networkCheck">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #de0000" ng-if="networkCheck.type === 'error'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
+                                <use style="fill: #4fab2f" ng-if="networkCheck.type === 'confirmation'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #FFC334" ng-if="networkCheck.type === 'warning'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
                         <strong class="list-item-secondary" ng-if="networkCheck.url">Status-result for {{networkCheck.url}}</strong>
                         <p ng-if="networkCheck.status">The server responded with a {{networkCheck.status}}-status code</p>
                         <p class="class="list-item-secondary" ng-repeat="message in networkCheck.messages">{{message}}</p>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -46,10 +46,25 @@
             </div>
             <div>
                 <h2>Checking Database-connection</h2>
-                <div></div>
+                <div ng-if="dbConnection.success" ng-repeat="result in dbConnection.success">
+                    <p>{{result.message}}</p>
+                    <p>{{result.explainer}}</p>
+                </div>
+                <div ng-if="dbConnection.error" ng-repeat="result in dbConnection.error">
+                        <p>{{result.message}}</p>
+                        <p>{{result.explainer}}</p>
+                    </div>
             </div>
             <div>
                 <h2>Checking environment-variables in the API...</h2>
+                <div ng-if="apiEnvs.success" ng-repeat="result in apiEnvs.success">
+                        <p>{{result.message}}</p>
+                        <p>{{result.explainer}}</p>
+                    </div>
+                    <div ng-if="apiEnvs.error" ng-repeat="result in apiEnvs.error">
+                            <p>{{result.message}}</p>
+                            <p>{{result.explainer}}</p>
+                    </div>
             </div>
         </div>
     </main>

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -2,18 +2,20 @@
     <layout-class layout="b"></layout-class>
     <main role="main">
         <div class="main-col">
-                <div class="listing card init" ng-if="isCheckDisabled('ALL')">
-
+                <div class="listing card init" ng-if="allDisabled">
                 <strong>USH_DISABLE_CHECKS is set to ALL, all verification processes is turned off.</strong>
                 <p>If you believe this is wrong, check the .env file for the variable USH_DISABLE_CHECKS.</p>
                 </div>
-            <div class="listing card init" ng-if="!isCheckDisabled('ALL')">
+            <div class="listing card init" ng-if="!allDisabled">
                 <h1>Installer helper</h1>
                 <p>Check the messages below to get hints while installing the Ushahidi-platform!</p>
                 <div class="listing-item"></div>
-                <div class="listing-item" ng-if="!isCheckDisabled('NETWORK')">
+                <div class="listing-item">
                     <h3 class="list-item-title">Checking network...</h3>
-                    <div class="listing-item">
+                <div class="listing-item" ng-if="!networkCheck">
+                    <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                    <div class="listing-item" ng-if="networkCheck">
                         <div class="listing-item-primary">
                             <div class="listing-item-image">
                                 <svg class="iconic">
@@ -30,7 +32,11 @@
             </div>
             <div class="listing-item">
                 <h3 class="list-item-title">Checking endpoints...</h3>
-                <div class="listing-item" ng-repeat="endpoint in endpointStatuses" ng-if="!isCheckDisabled('ENDPOINT_STATUS')">
+                <h4 class="list-item-title">Checking status for endpoints...</h4>
+                <div class="listing-item" ng-if="!endpointStatuses">
+                        <p>Check for endpoint-status is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-repeat="endpoint in endpointStatuses" ng-if="endpointStatuses">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">
@@ -43,6 +49,10 @@
                         <p ng-if="endpoint.status">The server responded with a {{endpoint.status}}-status code</p>
                         <p ng-repeat="message in endpoint.messages">{{message}}</p>
                     </div>
+                </div>
+                <h4 class="list-item-title">Checking structure for endpoints...</h4>
+                <div class="listing-item" ng-if="!endpointStructureChecks">
+                        <p>Check for endpoint-status is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
                 </div>
                 <div class="listing-item" ng-repeat="endpoint in endpointStructureChecks" ng-if="!isCheckDisabled('ENDPOINT_STRUCTURE')">
                     <div class="listing-item-primary">
@@ -58,9 +68,12 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item" ng-if="!isCheckDisabled('OAUTH')">
+            <div class="listing-item">
                 <h3>Checking Oauth-endpoint...</h3>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!oauthStatus">
+                        <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-if="oauthStatus">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic"   >
@@ -101,9 +114,12 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item" ng-if="!isCheckDisabled('ENV')">
+            <div class="listing-item">
                 <h3>Checking environment variables in the client...</h3>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!envCheck">
+                        <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-if="envCheck">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">
@@ -118,9 +134,12 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item" ng-if="!isCheckDisabled('TRANSIFEX')">
+            <div class="listing-item">
                 <h3>Checking Transifex</h3>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!transifexCheck">
+                        <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-if="transifexCheck">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">
@@ -135,9 +154,12 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item" ng-if="!isCheckDisabled('DBCONNECTION')">
+            <div class="listing-item" >
                 <h3>Checking Database-connection</h3>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!dbConnection">
+                        <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-if="dbConnection">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">
@@ -156,9 +178,12 @@
                     </div>
                 </div>
             </div>
-            <div class="listing-item" ng-if="!isCheckDisabled('API_ENVS')">
+            <div class="listing-item">
                 <h3>Checking environment-variables in the API...</h3>
-                <div class="listing-item">
+                <div class="listing-item" ng-if="!apiEnvs">
+                        <p>Check is disabled. If you think this is incorrect, please check USH_DISABLED_CHECKS in your .env-file.</p>
+                </div>
+                <div class="listing-item" ng-if="apiEnvs">
                     <div class="listing-item-primary">
                         <div class="listing-item-image">
                             <svg class="iconic">

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -161,14 +161,14 @@ const verifyOauth = function (env) {
 
 const verifyAPIEnvs = function (env) {
     if (isCheckDisabled(env, 'API_ENVS')) {
-        return;
+        return new Promise((resolve, reject) => resolve('DISABLED'));
     }
     return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/env`);
 };
 
 const verifyDbConnection = function (env) {
     if (isCheckDisabled(env, 'DB_CONNECTION')) {
-        return;
+        return new Promise((resolve, reject) => resolve('DISABLED'));
     }
     return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/db`);
 };
@@ -176,13 +176,29 @@ const verifyDbConnection = function (env) {
 const checkAPI = function (url) {
     return fetch(url)
     .then(response => {
-        return response.json()
-        .then(jsonData => {
-            return jsonData;
-        })
-        .catch(error => {
-            return {type: 'error', messages: ['The server could not be reached or there was an error in the request', 'Make sure your Platform API is running', error]};
-        });
+        return response.json();
+    })
+    .then(jsonData => {
+        return jsonData;
+    })
+    .catch(error => {
+        console.log(error);
+
+        const errors = {
+            errors: [
+                {
+                    type: 'error',
+                    message: 'The server could not be reached or there was an error in the request',
+                    explainer: 'Make sure your Platform API is running. <br/>' +
+                                'Check the storage/logs/lumen.log file in the API server root ' +
+                                'directory for details'
+                }
+            ]
+        };
+        if (error !== 'Unexpected token < in JSON at position 0') {
+            errors.errors.push(error);
+        }
+        return errors;
     });
 };
 

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -54,8 +54,20 @@ const verifyStatus = function (url, options) {
             return results;
         });
 };
+const verifyNetwork = function (env) {
+    const disabledCheck = isCheckDisabled(env, 'NETWORK');
+    if (disabledCheck) {
+        return disabledCheck;
+    }
+    return verifyStatus(`${env}/api/v3/config`);
+};
 
 const verifyEnv = function (env) {
+    const disabledCheck = isCheckDisabled(env, 'ENV');
+    if (disabledCheck) {
+        return disabledCheck;
+    }
+
     let messages = [];
 
     if (!env.BACKEND_URL) {
@@ -227,9 +239,7 @@ const isCheckDisabled = function (env, name) {
         return false;
     }
     const checks = env.USH_DISABLE_CHECKS.split(',');
-    if (checks.indexOf(name) >= 0) {
-        return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
-    }
+    return checks.indexOf(name) >= 0;
 };
 
 const checkStructure = function (a, b, url) {
@@ -243,4 +253,4 @@ const checkStructure = function (a, b, url) {
 };
 
 module.exports = {
-    verifyStatus, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, verifyDbConnection, verifyAPIEnvs, isCheckDisabled};
+    verifyNetwork, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, verifyDbConnection, verifyAPIEnvs, isCheckDisabled};

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -189,7 +189,7 @@ const checkAPI = function (url) {
                 {
                     type: 'error',
                     message: 'The server could not be reached or there was an error in the request',
-                    explainer: 'Make sure your Platform API is running. <br/>' +
+                    explainer: 'Make sure your Platform API is running.' +
                                 'Check the storage/logs/lumen.log file in the API server root ' +
                                 'directory for details'
                 },

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -273,14 +273,10 @@ const isCheckDisabled = function (env, name) {
 };
 
 const checkStructure = function (a, b, url) {
-    delete a.$promise;
-    delete a.$resolved;
-    delete b.$promise;
-    delete a.$resolved;
-
-    const aKeys = Object.keys(a).sort();
-    const bKeys = Object.keys(b).sort();
-
+    let aKeys = Object.keys(a).sort();
+    let bKeys = Object.keys(b).sort();
+    aKeys = aKeys.filter(key=> key !== '$promise' && key !== '$resolved');
+    bKeys = bKeys.filter(key=> key !== '$promise' && key !== '$resolved');
     if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
         return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`], url: url};
     } else {

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -55,17 +55,15 @@ const verifyStatus = function (url, options) {
         });
 };
 const verifyNetwork = function (env) {
-    const disabledCheck = isCheckDisabled(env, 'NETWORK');
-    if (disabledCheck) {
-        return disabledCheck;
+    if (isCheckDisabled(env, 'NETWORK')) {
+        return;
     }
-    return verifyStatus(`${env}/api/v3/config`);
+    return verifyStatus(`${env.BACKEND_URL}/api/v3/config`);
 };
 
 const verifyEnv = function (env) {
-    const disabledCheck = isCheckDisabled(env, 'ENV');
-    if (disabledCheck) {
-        return disabledCheck;
+    if (isCheckDisabled(env, 'ENV')) {
+        return;
     }
 
     let messages = [];
@@ -83,6 +81,9 @@ const verifyEnv = function (env) {
 };
 
 const verifyTransifex = function (env) {
+    if (isCheckDisabled(env, 'TRANSIFEX')) {
+        return;
+    }
     if (!env.TX_USERNAME || !env.TX_PASSWORD) {
         return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
     } else {
@@ -91,6 +92,9 @@ const verifyTransifex = function (env) {
 };
 
 const verifyEndpointStatus = function (env) {
+    if (isCheckDisabled(env, 'ENDPOINT_STATUS')) {
+        return;
+    }
     const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
     return endpoints.map(function (endpoint) {
         return verifyStatus(`${env.BACKEND_URL}/api/v3/${endpoint}`)
@@ -101,6 +105,9 @@ const verifyEndpointStatus = function (env) {
 };
 
 const verifyEndpointStructure = function (env) {
+    if (isCheckDisabled(env, 'ENDPOINT_STRUCTURE')) {
+        return;
+    }
     const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
     return endpoints.map(function (endpoint) {
         return fetch(`${env.BACKEND_URL}/api/v3/${endpoint}`)
@@ -134,6 +141,9 @@ const verifyEndpointStructure = function (env) {
 };
 
 const verifyOauth = function (env) {
+    if (isCheckDisabled(env, 'OAUTH')) {
+        return;
+    }
     let body = JSON.stringify({
         grant_type: 'client_credentials',
         client_id: env.OAUTH_CLIENT_ID || 'ushahidiui',
@@ -150,10 +160,16 @@ const verifyOauth = function (env) {
 };
 
 const verifyAPIEnvs = function (env) {
+    if (isCheckDisabled(env, 'API_ENVS')) {
+        return;
+    }
     return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/env`);
 };
 
 const verifyDbConnection = function (env) {
+    if (isCheckDisabled(env, 'DB_CONNECTION')) {
+        return;
+    }
     return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/db`);
 };
 
@@ -239,7 +255,7 @@ const isCheckDisabled = function (env, name) {
         return false;
     }
     const checks = env.USH_DISABLE_CHECKS.split(',');
-    return checks.indexOf(name) >= 0;
+    return checks.indexOf(name) >= 0 || checks.indexOf('ALL') >= 0;
 };
 
 const checkStructure = function (a, b, url) {

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -1,0 +1,104 @@
+// import log       from 'fancy-log';
+import isUrl from 'is-url';
+import fs from 'fs';
+import fetch from 'node-fetch';
+// import * as forms from '../../../../mocked_backend/api/v3/forms.json';
+// import * as tags from '../../../../mocked_backend/api/v3/tags.json';
+// import * as features from '../../../../mocked_backend/api/v3/config/features.json';
+// import * as map from '../../../../mocked_backend/api/v3/config/map.json';
+
+module.exports = {
+    verifyStatus(url, options) {
+        let results;
+        return fetch(url, options)
+            .then((response, resolve) => {
+                switch (response.status.toString()) {
+                    case '200':
+                        results = {
+                            type: 'confirmation',
+                            messages: ['All is good. This is the expected result.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '404':
+                        results = {
+                            type: 'error',
+                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '403':
+                        results = {
+                            type: 'error',
+                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                    case '500':
+                        results = {
+                            type: 'error',
+                            messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
+                            url: response.url,
+                            status: response.status
+                        };
+                        break;
+                }
+                return results;
+            })
+            .catch(error => {
+                results = {
+                        type: 'error',
+                        messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
+                        url: `${process.env.BACKEND_URL}/${url}`
+                    };
+                return results;
+            });
+    },
+    verifyEnv() {
+        let messages = [];
+        try {
+            // fs is not working in the browser, how handle it?
+            fs.accessSync('.env');
+        } catch (e) {
+            messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
+        }
+
+        if (!process.env.BACKEND_URL) {
+            messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
+        }
+
+        if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
+            messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
+            'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
+        }
+        return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
+    },
+    verifyTransifex() {
+        if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
+            return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
+        } else {
+            return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
+        }
+    },
+    isCheckDisabled(name) {
+        if (!process.env.USH_DISABLE_CHECKS) {
+            return false;
+        }
+        const checks = process.env.USH_DISABLE_CHECKS.split(',');
+        if (checks.indexOf(name) >= 0) {
+            return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
+        }
+    },
+    checkStructure (a, b, url) {
+        const aKeys = Object.keys(a).sort();
+        const bKeys = Object.keys(b).sort();
+        if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
+            return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`]};
+        } else {
+            return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`]};
+        }
+    }
+};

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -273,8 +273,14 @@ const isCheckDisabled = function (env, name) {
 };
 
 const checkStructure = function (a, b, url) {
+    delete a.$promise;
+    delete a.$resolved;
+    delete b.$promise;
+    delete a.$resolved;
+
     const aKeys = Object.keys(a).sort();
     const bKeys = Object.keys(b).sort();
+
     if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
         return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`], url: url};
     } else {

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -175,11 +175,11 @@ const verifyDbConnection = function (env) {
 
 const checkAPI = function (url) {
     return fetch(url)
+    .then(json => {
+        return json;
+    })
     .then(response => {
         return response.json();
-    })
-    .then(jsonData => {
-        return jsonData;
     })
     .catch(error => {
         console.log(error);
@@ -192,12 +192,10 @@ const checkAPI = function (url) {
                     explainer: 'Make sure your Platform API is running. <br/>' +
                                 'Check the storage/logs/lumen.log file in the API server root ' +
                                 'directory for details'
-                }
+                },
+                error
             ]
         };
-        if (error !== 'Unexpected token < in JSON at position 0') {
-            errors.errors.push(error);
-        }
         return errors;
     });
 };

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -2,103 +2,226 @@
 import isUrl from 'is-url';
 import fs from 'fs';
 import fetch from 'node-fetch';
-// import * as forms from '../../../../mocked_backend/api/v3/forms.json';
-// import * as tags from '../../../../mocked_backend/api/v3/tags.json';
-// import * as features from '../../../../mocked_backend/api/v3/config/features.json';
-// import * as map from '../../../../mocked_backend/api/v3/config/map.json';
+import * as forms from '../../../mocked_backend/api/v3/forms.json';
+import * as tags from '../../../mocked_backend/api/v3/tags.json';
+import * as features from '../../../mocked_backend/api/v3/config/features.json';
+import * as map from '../../../mocked_backend/api/v3/config/map.json';
 
-module.exports = {
-    verifyStatus(url, options) {
-        let results;
-        return fetch(url, options)
-            .then((response, resolve) => {
-                switch (response.status.toString()) {
-                    case '200':
-                        results = {
-                            type: 'confirmation',
-                            messages: ['All is good. This is the expected result.'],
-                            url: response.url,
-                            status: response.status
-                        };
+const verifyStatus = function (url, options) {
+    let results;
+    return fetch(url, options)
+        .then(response => {
+            switch (response.status.toString()) {
+                case '200':
+                    results = {
+                        type: 'confirmation',
+                        messages: ['All is good. This is the expected result.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '404':
+                    results = {
+                        type: 'error',
+                        messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '403':
+                    results = {
+                        type: 'error',
+                        messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+                case '500':
+                    results = {
+                        type: 'error',
+                        messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
+                        url: response.url,
+                        status: response.status
+                    };
+                    break;
+            }
+            return results;
+        })
+        .catch(error => {
+            results = {
+                    type: 'error',
+                    messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
+                    url: url
+                };
+            return results;
+        });
+};
+
+const verifyEnv = function (env) {
+    let messages = [];
+    try {
+        // fs is not working in the browser, how handle it?
+        fs.accessSync('.env');
+    } catch (e) {
+        messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
+    }
+
+    if (!env.BACKEND_URL) {
+        messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
+    }
+
+    if (env.BACKEND_URL && !isUrl(env.BACKEND_URL)) {
+        messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
+        'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
+    }
+    return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
+};
+
+const verifyTransifex = function (env) {
+    if (!env.TX_USERNAME || !env.TX_PASSWORD) {
+        return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
+    } else {
+        return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
+    }
+};
+
+const verifyEndpointStatus = function (env) {
+    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
+    return endpoints.map(function (endpoint) {
+        return verifyStatus(`${env.BACKEND_URL}/api/v3/${endpoint}`)
+        .then(response => {
+            return response;
+        });
+    });
+};
+
+const verifyEndpointStructure = function (env) {
+    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
+    const requests = endpoints.map(function (endpoint) {
+        return fetch(`${env.BACKEND_URL}/api/v3/${endpoint}`);
+    });
+
+    return Promise.all(requests)
+    .then(function (responses) {
+        return responses.map(function (response) {
+            return response.json().then(function (jsonData) {
+                let structure = {};
+                switch (response.url.substring(response.url.lastIndexOf('/') + 1)) {
+                    case 'tags':
+                        structure = tags.default;
                         break;
-                    case '404':
-                        results = {
-                            type: 'error',
-                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'forms':
+                        structure = forms.default;
                         break;
-                    case '403':
-                        results = {
-                            type: 'error',
-                            messages: ['Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'features':
+                        structure = features.default;
                         break;
-                    case '500':
-                        results = {
-                            type: 'error',
-                            messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'],
-                            url: response.url,
-                            status: response.status
-                        };
+                    case 'map':
+                        structure = map.default;
                         break;
                 }
-                return results;
-            })
-            .catch(error => {
-                results = {
-                        type: 'error',
-                        messages: ['The server could not be reached or there was an error in the request', 'Make sure the BACKEND_URL is in your .env-file', error],
-                        url: `${process.env.BACKEND_URL}/${url}`
-                    };
-                return results;
+                return checkStructure(jsonData, structure, response.url);
             });
-    },
-    verifyEnv() {
-        let messages = [];
-        try {
-            // fs is not working in the browser, how handle it?
-            fs.accessSync('.env');
-        } catch (e) {
-            messages.push('.env file not found. Please create the .env file in the project\'s root directory.');
-        }
+        });
+    }).catch(error => {
+        return {type: 'error', messages: ['The server could not be reached or there was an error in the request', 'Make sure your Platform API is running', error]};
+    });
+};
 
-        if (!process.env.BACKEND_URL) {
-            messages.push('BACKEND_URL not found in .env file.', 'Please add this URL to the .env file to connect to the Platform API.');
-        }
+const verifyOauth = function (env) {
+    let body = JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: env.OAUTH_CLIENT_ID || 'ushahidiui',
+        client_secret: env.OAUTH_CLIENT_SECRET || '35e7f0bca957836d05ca0492211b0ac707671261',
+        scope: 'forms'
+    });
 
-        if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
-            messages.push('BACKEND_URL found in .env file. Is not a valid URL.',
-            'Please fix the BACKEND_URL in the .env file to connect to the Platform API.');
-        }
-        return messages.length > 0 ? {type: 'error', messages: messages} : {type: 'confirmation', messages: ['All good, the .env file contains required variables']};
-    },
-    verifyTransifex() {
-        if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
-            return {type: 'warning', messages: ['TX_USERNAME and TX_PASSWORD not found in .env file. This might be ok if you are only using English, but it will not allow you to use any other languages.', 'If you need languages other than English, you will need to create a transifex account and setup the TX_USERNAME and TX_PASSWORD variables in the .env file']};
-        } else {
-            return {type: 'confirmation', messages: ['All good, TX_USERNAME and TX_PASSWORD found in .env file.']};
-        }
-    },
-    isCheckDisabled(name) {
-        if (!process.env.USH_DISABLE_CHECKS) {
-            return false;
-        }
-        const checks = process.env.USH_DISABLE_CHECKS.split(',');
-        if (checks.indexOf(name) >= 0) {
-            return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
-        }
-    },
-    checkStructure (a, b, url) {
-        const aKeys = Object.keys(a).sort();
-        const bKeys = Object.keys(b).sort();
-        if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
-            return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`]};
-        } else {
-            return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`]};
-        }
+    let options = {
+        method: 'POST',
+        body: body,
+        headers: {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json'}
+    };
+    return {status: verifyStatus(`${env.BACKEND_URL}/oauth/token`, options), structure: checkTokenStructure(env, options), token: testToken(env, options)};
+};
+
+const checkTokenStructure = function (env, options) {
+    return fetch(`${env.BACKEND_URL}/oauth/token`, options)
+        .then(function (response) {
+            switch (response.status.toString()) {
+                case '200':
+                    return response.json().then(jsonData => {
+                            let preferedStructure = { token_type: 'Bearer', expires_in: '', access_token: ''};
+                            return checkStructure(jsonData, preferedStructure, response.url);
+                        });
+                case '500':
+                    return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'], url: response.url}];
+                case '401':
+                    return [{type: 'error', messages: ['Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API','If you have added your own client id and name, make sure the values in the .env file matches the database.'], url: response.url}];
+            }
+        }).catch(error => {
+            return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.', error], url: env.BACKEND_URL}];
+        });
+};
+
+const testToken = function (env, options) {
+    return fetch(`${env.BACKEND_URL}/oauth/token`, options)
+        .then(function (response) {
+            switch (response.status.toString()) {
+                case '200':
+                    return response.json().then(jsonData => {
+                        return fetch(`${env.BACKEND_URL}/api/v3/forms`, {
+                            method: 'GET',
+                            headers: {
+                                'Accept': 'application/json, text/plain, */*',
+                                'Content-Type': 'application/json',
+                                'Authorization': `Bearer ${jsonData.access_token}`
+                            }
+                        })
+                        .then(function (response) {
+                            switch (response.status.toString()) {
+                                case '200':
+                                    return {type: 'confirmation', messages: ['Token checked and is working. All good!']};
+                                case '500':
+                                    return {type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.']};
+                                case '401':
+                                    return {type: 'error', messages: ['Did you add your own client_secret and client_key?', 'Make sure you updated the database with the same values', 'If you did not add your own secret and key, check that the database-migration has ran, by running ./phinx migrate in the root directory of the Platform API.']};
+                                case '403':
+                                    return {type: 'error', messages: ['There is a problem with the oauth-scopes', 'Check that your Platform API is set up and that all migrations has ran.']};
+                            }
+                        }).catch(err => {
+                            return {type: 'error', messages: ['The server could not be reached or there was an error in the request', 'Make sure your Platform API is running', err]};
+                        });
+                    });
+                case '500':
+                    return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.'], url: `${env.BACKEND_URL}/api/v3/forms`}];
+                case '401':
+                    return [{type: 'error', messages: ['Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API','If you have added your own client id and name, make sure the values in the .env file matches the database.'], url: response.url}];
+            }
+        }).catch(error => {
+            return [{type: 'error', messages: ['Oh noes. This does not look good.', 'Please check storage/logs in the Platform API, and see what the logs say about this error.', error], url: `${env.BACKEND_URL}/api/v3/forms`}];
+        });
+};
+
+const isCheckDisabled = function (env, name) {
+    if (!env.USH_DISABLE_CHECKS) {
+        return false;
     }
+    const checks = env.USH_DISABLE_CHECKS.split(',');
+    if (checks.indexOf(name) >= 0) {
+        return {type: 'warning', messages: `USH_DISABLE_CHECKS contains ${name}, skipping ${name} verification process.`};
+    }
+};
+
+const checkStructure = function (a, b, url) {
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
+        return {type: 'confirmation', messages: [`The structure for ${url} matches the expected, all good!`], url: url};
+    } else {
+        return {type: 'error', messages: [`Oh noes, the structure for ${url} does not match the expected `,`Make sure you have set up the database correctly `,`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`], url: url};
+    }
+};
+
+module.exports = {
+    verifyStatus, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, isCheckDisabled
 };

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -122,8 +122,8 @@ module.exports.verifyAPIEnvs = function() {
            response.success.forEach(result=>{
                formatMessage(result.message, 'confirmation');
            });
-        } else if (response.error) {
-            response.error.forEach(result=>{
+        } else if (response.errors) {
+            response.errors.forEach(result=>{
                 formatMessage(result.message, 'error');
             });
         }
@@ -138,8 +138,8 @@ module.exports.verifyDbConnection = function() {
            response.success.forEach(result=>{
                formatMessage(result.message, 'confirmation');
            });
-        } else if (response.error) {
-            response.error.forEach(result=>{
+        } else if (response.errors) {
+            response.errors.forEach(result=>{
                 formatMessage(result.message, 'error');
             });
         }

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -1,11 +1,5 @@
-
 import log       from 'fancy-log';
 import c         from 'ansi-colors';
-import fetch from 'node-fetch';
-import * as forms from '../mocked_backend/api/v3/forms.json';
-import * as tags from '../mocked_backend/api/v3/tags.json';
-import * as features from '../mocked_backend/api/v3/config/features.json';
-import * as map from '../mocked_backend/api/v3/config/map.json';
 import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
@@ -34,8 +28,7 @@ module.exports.verifyEnv = function() {
         return;
     }
 
-    let envCheck = verifier.verifyEnv();
-
+    let envCheck = verifier.verifyEnv(process.env);
     log.info(c.bold(`Checking .env-variables:`));
     envCheck.messages.forEach(message => {
         formatMessage(message, envCheck.type);
@@ -47,7 +40,7 @@ module.exports.verifyTransifex = function() {
         log.info(c.green('USH_DISABLE_CHECKS contains TRANSIFEX, skipping TRANSIFEX verification process.'));
         return;
     }
-    let transifexCheck = verifier.verifyTransifex();
+    let transifexCheck = verifier.verifyTransifex(process.env);
     log.info(c.bold(`Checking credentials for Transifex:`));
     transifexCheck.messages.forEach(message => {
         formatMessage(message, transifexCheck.type);
@@ -61,16 +54,14 @@ module.exports.verifyEndpointStatus = function() {
         formatMessage(checkDisabled.messages, checkDisabled.type);
         return;
     }
-    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
-    endpoints.forEach(function(endpoint) {
-        verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/${endpoint}`)
-        .then(response => {
-            log.info(c.bold('Checking status for endpoints:'));
-            log.info(c.bold(`Status-result for ${response.url}:`));
-            log.info(`The server responded with a ${response.status} code.`);
-            response.messages.forEach(message => {
-                formatMessage(message, response.type);
-            });
+    verifier.verifyEndpointStatus(process.env).forEach(response => {
+            response.then(result => {
+                log.info(c.bold('Checking status for endpoints:'));
+                log.info(c.bold(`Status-result for ${result.url}:`));
+                log.info(`The server responded with a ${result.status} code.`);
+                result.messages.forEach(message => {
+                    formatMessage(message, result.type);
+                });
         });
     });
 };
@@ -80,120 +71,46 @@ module.exports.verifyEndpointStructure = function() {
             log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
             return;
     }
-    const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
-    const requests = endpoints.map(function(endpoint) {
-        return fetch(`${process.env.BACKEND_URL}/api/v3/${endpoint}`);
-    });
-
-    Promise.all(requests)
-    .then(function(responses) {
-        responses.forEach(function(response) {
-            response.json().then(function(jsonData) {
-                let structure = {};
-                    switch (response.url.substring(response.url.lastIndexOf('/') + 1)) {
-                        case 'tags':
-                            structure = tags.default;
-                            break;
-                        case 'forms':
-                            structure = forms.default;
-                            break;
-                        case 'features':
-                            structure = features.default;
-                            break;
-                        case 'map':
-                            structure = map.default;
-                            break;
-                    }
-                    
-                    checkStructure(jsonData, structure, response.url);
+    verifier.verifyEndpointStructure(process.env)
+        .then(responses => {
+            responses.forEach(response => {
+                response.then(result=>{
+                    log.info(c.bold(`Structure-result for ${result.url}:`));
+                    result.messages.forEach(message => {
+                    formatMessage(message, result.type);
+                });
             });
         });
-    }).catch(error => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(error));
     });
 };
 
 module.exports.verifyOauth = function () {
-    if (isCheckDisabled('ENDPOINTS_STRUCTURE')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
+    if (isCheckDisabled('VERIFY_OAUTH')) {
+        log.info(c.green('USH_DISABLE_CHECKS contains VERIFY_OAUTH, skipping VERIFY_OAUTH verification process.'));
         return;
     }
 
-    let body = JSON.stringify({
-        grant_type: 'client_credentials',
-        client_id: process.env.OAUTH_CLIENT_ID || 'ushahidiui',
-        client_secret: process.env.OAUTH_CLIENT_SECRET || '35e7f0bca957836d05ca0492211b0ac707671261',
-        scope: 'forms'});
-
-    fetch(`${process.env.BACKEND_URL}/oauth/token`, {
-        method:'POST',
-        body: body,
-        headers: {'Accept': 'application/json, text/plain, */*', 'Content-Type': 'application/json'}
-    })
-    .then(function(response) {
-        log.info(c.bold(`Status-result for ${response.url}:`));
-        log.info(`The server responded with a ${response.status} code.`);        
-        switch (response.status.toString()) {
-            case '200':
-                log.info(c.green('All is good. This is the expected result.'));
-                response.json().then(jsonData=>{
-                    let preferedStructure = { token_type: 'Bearer', expires_in: '', access_token: ''};
-                    checkStructure(jsonData, preferedStructure, response.url);
-                    checkToken(jsonData.access_token);
-                });
-                break;
-            case '500':
-                log.error(c.red('Oh noes. This does not look good.'));
-                log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                break;
-            case '401':
-                log.error(c.red('Make sure your database-migrations has ran by running ./phinx migrate in the root directory of the platform API'));
-                log.error(c.red('If you have added your own client id and name, make sure the values in the .env file matches the database.'));
-                break;
-        }
-    }).catch(error => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(error));
+    let results = verifier.verifyOauth(process.env);
+    results.status.then(status => {
+        log.info(c.bold(`Status-result for ${status.url}:`));
+        log.info(`The server responded with a ${status.status} code.`);
+        status.messages.forEach(message => {
+            formatMessage(message, status.type);
+        });
     });
-};
 
-const checkToken = function (token) {
-    fetch(`${process.env.BACKEND_URL}/api/v3/forms`, {
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json, text/plain, */*',
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`
-        }
-    })
-    .then(function (response) {
-        log.info(c.bold(`Result for token-check:`));
-        log.info(`The server responded with a ${response.status} code.`);
-        switch (response.status.toString()) {
-            case '200':
-                log.info(c.green('All is good. This is the expected result.'));
-                break;
-            case '500':
-                log.error(c.red('Oh noes. This does not look good.'));
-                log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                break;
-            case '401':
-                log.error(c.red('Did you add your own client_secret and client_key?'));
-                log.error(c.red('Make sure you updated the database with the same values'));
-                log.error(c.red('If you did not add your own secret and key, check that the database-migration has ran, by running ./phinx migrate in the root directory of the Platform API.'));
-                break;
-            case '403':
-                log.error(c.red('There is a problem with the oauth-scopes'));
-                log.error(c.red('Check that your Platform API is set up and that all migrations has ran.'));
-                break;
-        }
-    }).catch(err => {
-        log.error(c.red('The server could not be reached or there was an error in the request'));
-        log.error(c.red('Make sure your Platform API is running'));
-        log.error(c.red(err));
+    results.structure.then(structure => {
+        log.info(c.bold(`Structure-result for ${structure.url}:`));
+        structure.messages.forEach(message => {
+            formatMessage(message, structure.type);
+        });
+    });
+
+    results.token.then(token => {
+        log.info(c.bold('Testing the oauth-token:'));
+        token.messages.forEach(message => {
+            formatMessage(message, token.type);
+        });
     });
 };
 
@@ -204,20 +121,6 @@ const isCheckDisabled = function(name) {
     const checks = process.env.USH_DISABLE_CHECKS.split(',');
     return checks.indexOf(name) >= 0;
 };
-
-const checkStructure = function(a, b, url) {
-    const aKeys = Object.keys(a).sort();
-    const bKeys = Object.keys(b).sort();
-    log.info(c.bold(`Structure-result for ${url}:`));
-    if (JSON.stringify(aKeys) === JSON.stringify(bKeys)) {
-        log.info(c.green(`The structure for ${url} matches the expected, all good!`));
-    } else {
-        log.info(c.red(`Oh noes, the structure for ${url} does not match the expected `));
-        log.info(c.red(`Make sure you have set up the database correctly `));
-        log.info(c.red(`Check that all migrations has ran. You can check this by running ./phinx migrate in the root directory of the Platform API.`));
-    }
-};
-
 
 const formatMessage = function(message, type) {
     switch (type) {

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -3,11 +3,13 @@ import c         from 'ansi-colors';
 import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
-    if (verifier.isCheckDisabled(process.env, 'NETWORK')) {
+    const verifyNetwork = verifier.verifyNetwork(process.env);
+    if (!verifyNetwork) {
+        log.info(c.bold('Checking network:'));
+        log.info('Network-check disabled in .env. Skipping check.');
         return;
-    }
-
-    verifier.verifyNetwork(process.env)
+    } else {
+        verifyNetwork
         .then(response => {
             log.info(c.bold('Checking network:'));
             log.info(`The server responded with a ${response.status} code.`);
@@ -15,125 +17,150 @@ module.exports.verifyNetwork = function() {
                 formatMessage(message, response.type);
             });
         });
+    }
 };
 
 module.exports.verifyEnv = function() {
-    if (verifier.isCheckDisabled(process.env, 'ENV')) {
-        return;
-    }
     let envCheck = verifier.verifyEnv(process.env);
-    log.info(c.bold(`Checking .env-variables:`));
-    envCheck.messages.forEach(message => {
-        formatMessage(message, envCheck.type);
-    });
+    log.info(c.bold(`Checking .env-variables in the client:`));
+    if (!envCheck) {
+        log.info('Check for environment-variables in client is disabled in .env. Skipping check.');
+        return;
+    } else {
+        envCheck.messages.forEach(message => {
+            formatMessage(message, envCheck.type);
+        });
+    }
 };
 
 module.exports.verifyTransifex = function() {
-    if (verifier.isCheckDisabled(process.env, 'TRANSIFEX')) {
-        return;
-    }
     let transifexCheck = verifier.verifyTransifex(process.env);
     log.info(c.bold(`Checking credentials for Transifex:`));
-    transifexCheck.messages.forEach(message => {
-        formatMessage(message, transifexCheck.type);
-    });
+    if (!transifexCheck) {
+        log.info('Check for Transifex credentials is disabled in .env. Skipping check.');
+        return;
+    } else {
+        transifexCheck.messages.forEach(message => {
+            formatMessage(message, transifexCheck.type);
+        });
+    }
 };
 
 module.exports.verifyEndpointStatus = function() {
-    if (verifier.isCheckDisabled('ENDPOINT_STATUS')) {
+    let verifyEndpointStatus = verifier.verifyEndpointStatus(process.env);
+    if (!verifyEndpointStatus) {
+        log.info(c.bold('Checking status for endpoints:'));
+        log.info('Check for endpoint-status is disabled in .env. Skipping check.');
         return;
-    }
-    verifier.verifyEndpointStatus(process.env).forEach(response => {
+    } else {
+        verifyEndpointStatus
+        .forEach(response => {
             response.then(result => {
-                log.info(c.bold('Checking status for endpoints:'));
-                log.info(c.bold(`Status-result for ${result.url}:`));
+                log.info(c.bold('Checking status for endpoint:'));
+                log.info(`Status-result for ${result.url}:`);
                 log.info(`The server responded with a ${result.status} code.`);
                 result.messages.forEach(message => {
                     formatMessage(message, result.type);
                 });
+            });
         });
-    });
+    }
 };
 
 module.exports.verifyEndpointStructure = function() {
-    if (verifier.isCheckDisabled('ENDPOINT_STRUCTURE')) {
+    const verifyEndpointStructure = verifier.verifyEndpointStructure(process.env);
+    if (!verifyEndpointStructure) {
+        log.info(c.bold('Checking Structure for endpoints:'));
+        log.info('Check for endpoint-structure is disabled in .env. Skipping check.');
         return;
-    }
-    verifier.verifyEndpointStructure(process.env).forEach(response => {
-                response.then(result => {
-                    log.info(c.bold(`Structure-result for ${result.url}`));
-                    result.messages.forEach(message => {
+    } else {
+        verifyEndpointStructure.forEach(response => {
+            response.then(result => {
+                log.info(c.bold('Checking structure for endpoint:'));
+                log.info(`Structure-result for ${result.url}`);
+                result.messages.forEach(message => {
                     formatMessage(message, result.type);
                 });
             });
         });
+    }
 };
 
 module.exports.verifyOauth = function () {
-    if (verifier.isCheckDisabled(process.env, 'OAUTH')) {
-        return;
-    }
-
     let results = verifier.verifyOauth(process.env);
-    results.status.then(status => {
-        log.info(c.bold(`Status-result for ${status.url}:`));
-        log.info(`The server responded with a ${status.status} code.`);
-        status.messages.forEach(message => {
-            formatMessage(message, status.type);
+    if (!results) {
+        log.info(c.bold('Checking Oauth-endpoint:'));
+        log.info('Check for oauth endpoint is disabled in .env. Skipping check.');
+        return;
+    } else {
+        results.status.then(status => {
+            log.info(c.bold(`Status-result for ${status.url}:`));
+            log.info(`The server responded with a ${status.status} code.`);
+            status.messages.forEach(message => {
+                formatMessage(message, status.type);
+            });
         });
-    });
 
-    results.structure.then(structure => {
-        log.info(c.bold(`Structure-result for ${structure.url}:`));
-        structure.messages.forEach(message => {
-            formatMessage(message, structure.type);
+        results.structure.then(structure => {
+            log.info(c.bold(`Structure-result for ${structure.url}:`));
+            structure.messages.forEach(message => {
+                formatMessage(message, structure.type);
+            });
         });
-    });
 
-    results.token.then(token => {
-        log.info(c.bold('Testing the oauth-token:'));
-        token.messages.forEach(message => {
-            formatMessage(message, token.type);
+        results.token.then(token => {
+            log.info(c.bold('Testing the oauth-token:'));
+            token.messages.forEach(message => {
+                formatMessage(message, token.type);
+            });
         });
-    });
+    }
 };
 
 module.exports.verifyAPIEnvs = function() {
-    if (verifier.isCheckDisabled(process.env, 'API_ENVS')) {
+    const verifyAPIEnvs = verifier.verifyAPIEnvs(process.env);
+    if (!verifyAPIEnvs) {
+        log.info(c.bold(`Checking the environment variables in the API:`));
+        log.info('Check for the environment variables in the API is disabled in .env. Skipping check.');
         return;
-    }
-    verifier.verifyAPIEnvs(process.env)
-    .then(response => {
-        log.info(c.bold(`Checking the environment variables in the API`));
-        if (response.success) {
-           response.success.forEach(result=>{
-               formatMessage(result.message, 'confirmation');
-           });
-        } else if (response.errors) {
-            response.errors.forEach(result=>{
-                formatMessage(result.message, 'error');
+    } else {
+        verifyAPIEnvs
+        .then(response => {
+            log.info(c.bold(`Checking the environment variables in the API:`));
+            if (response.success) {
+            response.success.forEach(result=>{
+                formatMessage(result.message, 'confirmation');
             });
-        }
-    });
+            } else if (response.errors) {
+                response.errors.forEach(result=>{
+                    formatMessage(result.message, 'error');
+                });
+            }
+        });
+    }
 };
 
 module.exports.verifyDbConnection = function() {
-    if (verifier.isCheckDisabled(process.env, 'DBCONNECTION')) {
+    const verifyDbConnection = verifier.verifyDbConnection(process.env);
+    if (!verifyDbConnection) {
+        log.info(c.bold('Checking the database connection:'));
+        log.info('Check for the database connection in the API is disabled in .env. Skipping check.');
         return;
-    }
-    verifier.verifyDbConnection(process.env)
-    .then(response => {
-        log.info(c.bold('Checking the database connection'));
-        if (response.success) {
-           response.success.forEach(result=>{
-               formatMessage(result.message, 'confirmation');
-           });
-        } else if (response.errors) {
-            response.errors.forEach(result=>{
-                formatMessage(result.message, 'error');
+    } else {
+        verifyDbConnection
+        .then(response => {
+            log.info(c.bold('Checking the database connection:'));
+            if (response.success) {
+            response.success.forEach(result=>{
+                formatMessage(result.message, 'confirmation');
             });
-        }
-    });
+            } else if (response.errors) {
+                response.errors.forEach(result=>{
+                    formatMessage(result.message, 'error');
+                });
+            }
+        });
+    }
 };
 
 module.exports.isCheckDisabled = function(name) {

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -71,17 +71,14 @@ module.exports.verifyEndpointStructure = function() {
             log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
             return;
     }
-    verifier.verifyEndpointStructure(process.env)
-        .then(responses => {
-            log.info(c.bold(`Checking endpoint-structures`));
-            responses.forEach(response => {
+    verifier.verifyEndpointStructure(process.env).forEach(response => {
                 response.then(result => {
+                    log.info(c.bold(`Structure-result for ${result.url}`));
                     result.messages.forEach(message => {
                     formatMessage(message, result.type);
                 });
             });
         });
-    });
 };
 
 module.exports.verifyOauth = function () {

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -1,47 +1,45 @@
 
 import log       from 'fancy-log';
 import c         from 'ansi-colors';
-import isUrl from 'is-url';
-import fs        from 'fs';
 import fetch from 'node-fetch';
 import * as forms from '../mocked_backend/api/v3/forms.json';
 import * as tags from '../mocked_backend/api/v3/tags.json';
 import * as features from '../mocked_backend/api/v3/config/features.json';
 import * as map from '../mocked_backend/api/v3/config/map.json';
+import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
-    if (isCheckDisabled('NETWORK')) {
-      log.info(c.green('USH_DISABLE_CHECKS contains NETWORK, skipping API connectivity verification process.'));
-      return;
+    let checkDisabled = verifier.isCheckDisabled('NETWORK');
+    if (checkDisabled) {
+        log.info(c.bold('Checking network:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
+        return;
     }
-    checkStatus('api/v3/config');
+
+    verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/config`)
+        .then(response => {
+        log.info(c.bold('Checking network:'));
+        log.info(`The server responded with a ${response.status} code.`);
+        response.messages.forEach(message => {
+            formatMessage(message, response.type);
+        });
+    });
 };
 
 module.exports.verifyEnv = function() {
-    if (isCheckDisabled('ENV')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains ENV, skipping ENV verification process.'));
+    let checkDisabled = verifier.isCheckDisabled('ENV');
+    if (checkDisabled) {
+        log.info(c.bold('Checking .env-variables:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
         return;
     }
-    try {
-        fs.accessSync('.env');
-    } catch (e) {
-        log.error(c.red('.env file not found. Please create the .env file in the project\'s root directory.'));
-    }
 
-    if (!process.env.BACKEND_URL) {
-        log.error(
-        c.red('BACKEND_URL not found in .env file. ' +
-                'Please add this URL to the .env file to connect to the Platform API.'
-            )
-        );
-    }
-    if (process.env.BACKEND_URL && !isUrl(process.env.BACKEND_URL)) {
-        log.error(
-        c.red('BACKEND_URL found in .env file. Is not a valid URL.' +
-                'Please fix the BACKEND_URL in the .env file to connect to the Platform API.'
-            )
-        );
-    }
+    let envCheck = verifier.verifyEnv();
+
+    log.info(c.bold(`Checking .env-variables:`));
+    envCheck.messages.forEach(message => {
+        formatMessage(message, envCheck.type);
+    });
 };
 
 module.exports.verifyTransifex = function() {
@@ -49,28 +47,31 @@ module.exports.verifyTransifex = function() {
         log.info(c.green('USH_DISABLE_CHECKS contains TRANSIFEX, skipping TRANSIFEX verification process.'));
         return;
     }
-    if (!process.env.TX_USERNAME || !process.env.TX_PASSWORD) {
-        log.warn(
-        c.yellow('TX_USERNAME and TX_PASSWORD not found in .env file.' +
-                        'This might be ok if you are only using English, ' +
-                        'but it will not allow you to use any other languages.'
-                    )
-        );
-        log.warn(
-        c.yellow('If you need languages other than English, you will need to create a transifex account ' +
-                'and setup the TX_USERNAME and TX_PASSWORD variables in the .env file')
-        );
-    }
+    let transifexCheck = verifier.verifyTransifex();
+    log.info(c.bold(`Checking credentials for Transifex:`));
+    transifexCheck.messages.forEach(message => {
+        formatMessage(message, transifexCheck.type);
+    });
 };
 
 module.exports.verifyEndpointStatus = function() {
-    if (isCheckDisabled('ENDPOINTS_STATUS')) {
-            log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STATUS, skipping ENDPOINTS_STATUS verification process.'));
-            return;
+    let checkDisabled = verifier.isCheckDisabled('ENDPOINT_STATUS');
+    if (checkDisabled) {
+        log.info(c.bold('Checking status for endpoints:'));
+        formatMessage(checkDisabled.messages, checkDisabled.type);
+        return;
     }
     const endpoints = ['tags', 'forms', 'config/features', 'config/map'];
     endpoints.forEach(function(endpoint) {
-        checkStatus(`api/v3/${endpoint}`);
+        verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/${endpoint}`)
+        .then(response => {
+            log.info(c.bold('Checking status for endpoints:'));
+            log.info(c.bold(`Status-result for ${response.url}:`));
+            log.info(`The server responded with a ${response.status} code.`);
+            response.messages.forEach(message => {
+                formatMessage(message, response.type);
+            });
+        });
     });
 };
 
@@ -217,31 +218,21 @@ const checkStructure = function(a, b, url) {
     }
 };
 
-const checkStatus = function (url) {
-    fetch(`${process.env.BACKEND_URL}/${url}`)
-            .then(response=>{
-                log.info(c.bold(`Status-result for ${response.url}:`));
-                log.info(`The server responded with a ${response.status} code.`);
-                switch (response.status.toString()) {
-                  case '200':
-                    log.info(c.green('All is good. This is the expected result.'));
-                    break;
-                  case '500':
-                    log.error(c.red('Oh noes. This does not look good.'));
-                    log.eror(c.red('Please check storage/logs in the Platform API, and see what the logs say about this error.'));
-                    break;
-                  case '404':
-                    log.error(c.red('Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'));
-                    break;
-                  case '403':
-                    log.error(c.red('Make sure the API\'s BACKEND_URL in the .env file is the base URL to your Platform API.'));
-                    break;
-                }
-                return response;
-              }).catch(error => {
-                log.error(c.red('The server could not be reached or there was an error in the request'));
-                log.error(c.red(error));
-                return error;
-            });
+
+const formatMessage = function(message, type) {
+    switch (type) {
+        case 'confirmation':
+            log.info(c.green(message));
+            break;
+        case 'error':
+            log.error(c.red(message));
+            break;
+        case 'warning':
+            log.warn(c.yellow(message));
+            break;
+        default:
+            log.info(message);
+    }
 };
+
 module.exports.isCheckDisabled = isCheckDisabled;

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -73,9 +73,9 @@ module.exports.verifyEndpointStructure = function() {
     }
     verifier.verifyEndpointStructure(process.env)
         .then(responses => {
+            log.info(c.bold(`Checking endpoint-structures`));
             responses.forEach(response => {
-                response.then(result=>{
-                    log.info(c.bold(`Structure-result for ${result.url}:`));
+                response.then(result => {
                     result.messages.forEach(message => {
                     formatMessage(message, result.type);
                 });
@@ -111,6 +111,38 @@ module.exports.verifyOauth = function () {
         token.messages.forEach(message => {
             formatMessage(message, token.type);
         });
+    });
+};
+
+module.exports.verifyAPIEnvs = function() {
+    verifier.verifyAPIEnvs(process.env)
+    .then(response => {
+        log.info(c.bold(`Checking the environment variables in the API`));
+        if (response.success) {
+           response.success.forEach(result=>{
+               formatMessage(result.message, 'confirmation');
+           });
+        } else if (response.error) {
+            response.error.forEach(result=>{
+                formatMessage(result.message, 'error');
+            });
+        }
+    });
+};
+
+module.exports.verifyDbConnection = function() {
+    verifier.verifyDbConnection(process.env)
+    .then(response => {
+        log.info(c.bold('Checking the database connection'));
+        if (response.success) {
+           response.success.forEach(result=>{
+               formatMessage(result.message, 'confirmation');
+           });
+        } else if (response.error) {
+            response.error.forEach(result=>{
+                formatMessage(result.message, 'error');
+            });
+        }
     });
 };
 

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -3,31 +3,24 @@ import c         from 'ansi-colors';
 import * as verifier from '../app/common/verifier/verifier.js';
 
 module.exports.verifyNetwork = function() {
-    let checkDisabled = verifier.isCheckDisabled('NETWORK');
-    if (checkDisabled) {
-        log.info(c.bold('Checking network:'));
-        formatMessage(checkDisabled.messages, checkDisabled.type);
+    if (verifier.isCheckDisabled(process.env, 'NETWORK')) {
         return;
     }
 
-    verifier.verifyStatus(`${process.env.BACKEND_URL}/api/v3/config`)
+    verifier.verifyNetwork(process.env)
         .then(response => {
-        log.info(c.bold('Checking network:'));
-        log.info(`The server responded with a ${response.status} code.`);
-        response.messages.forEach(message => {
-            formatMessage(message, response.type);
+            log.info(c.bold('Checking network:'));
+            log.info(`The server responded with a ${response.status} code.`);
+            response.messages.forEach(message => {
+                formatMessage(message, response.type);
+            });
         });
-    });
 };
 
 module.exports.verifyEnv = function() {
-    let checkDisabled = verifier.isCheckDisabled('ENV');
-    if (checkDisabled) {
-        log.info(c.bold('Checking .env-variables:'));
-        formatMessage(checkDisabled.messages, checkDisabled.type);
+    if (verifier.isCheckDisabled(process.env, 'ENV')) {
         return;
     }
-
     let envCheck = verifier.verifyEnv(process.env);
     log.info(c.bold(`Checking .env-variables:`));
     envCheck.messages.forEach(message => {
@@ -36,8 +29,7 @@ module.exports.verifyEnv = function() {
 };
 
 module.exports.verifyTransifex = function() {
-    if (isCheckDisabled('TRANSIFEX')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains TRANSIFEX, skipping TRANSIFEX verification process.'));
+    if (verifier.isCheckDisabled(process.env, 'TRANSIFEX')) {
         return;
     }
     let transifexCheck = verifier.verifyTransifex(process.env);
@@ -48,10 +40,7 @@ module.exports.verifyTransifex = function() {
 };
 
 module.exports.verifyEndpointStatus = function() {
-    let checkDisabled = verifier.isCheckDisabled('ENDPOINT_STATUS');
-    if (checkDisabled) {
-        log.info(c.bold('Checking status for endpoints:'));
-        formatMessage(checkDisabled.messages, checkDisabled.type);
+    if (verifier.isCheckDisabled('ENDPOINT_STATUS')) {
         return;
     }
     verifier.verifyEndpointStatus(process.env).forEach(response => {
@@ -67,9 +56,8 @@ module.exports.verifyEndpointStatus = function() {
 };
 
 module.exports.verifyEndpointStructure = function() {
-    if (isCheckDisabled('ENDPOINTS_STRUCTURE')) {
-            log.info(c.green('USH_DISABLE_CHECKS contains ENDPOINTS_STRUCTURE, skipping ENDPOINTS_STRUCTURE verification process.'));
-            return;
+    if (verifier.isCheckDisabled('ENDPOINT_STRUCTURE')) {
+        return;
     }
     verifier.verifyEndpointStructure(process.env).forEach(response => {
                 response.then(result => {
@@ -82,8 +70,7 @@ module.exports.verifyEndpointStructure = function() {
 };
 
 module.exports.verifyOauth = function () {
-    if (isCheckDisabled('VERIFY_OAUTH')) {
-        log.info(c.green('USH_DISABLE_CHECKS contains VERIFY_OAUTH, skipping VERIFY_OAUTH verification process.'));
+    if (verifier.isCheckDisabled(process.env, 'OAUTH')) {
         return;
     }
 
@@ -112,6 +99,9 @@ module.exports.verifyOauth = function () {
 };
 
 module.exports.verifyAPIEnvs = function() {
+    if (verifier.isCheckDisabled(process.env, 'API_ENVS')) {
+        return;
+    }
     verifier.verifyAPIEnvs(process.env)
     .then(response => {
         log.info(c.bold(`Checking the environment variables in the API`));
@@ -128,6 +118,9 @@ module.exports.verifyAPIEnvs = function() {
 };
 
 module.exports.verifyDbConnection = function() {
+    if (verifier.isCheckDisabled(process.env, 'DBCONNECTION')) {
+        return;
+    }
     verifier.verifyDbConnection(process.env)
     .then(response => {
         log.info(c.bold('Checking the database connection'));
@@ -143,12 +136,8 @@ module.exports.verifyDbConnection = function() {
     });
 };
 
-const isCheckDisabled = function(name) {
-    if (!process.env.USH_DISABLE_CHECKS) {
-        return false;
-    }
-    const checks = process.env.USH_DISABLE_CHECKS.split(',');
-    return checks.indexOf(name) >= 0;
+module.exports.isCheckDisabled = function(name) {
+    return verifier.isCheckDisabled(process.env, name);
 };
 
 const formatMessage = function(message, type) {
@@ -166,5 +155,3 @@ const formatMessage = function(message, type) {
             log.info(message);
     }
 };
-
-module.exports.isCheckDisabled = isCheckDisabled;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -30,6 +30,7 @@ let root = 'app';
 dotenv.config({silent: true});
 // Grab backend-url from gulp options
 process.env.BACKEND_URL = argv['backend-url'] || process.env.BACKEND_URL;
+
 // helper method for resolving paths
 let resolveToApp = (glob = '') => {
   return path.join(root, glob); // app/{glob}
@@ -90,6 +91,11 @@ gulp.task('build', ['dist']);
  * Task `heroku:dev` - builds app for heroku
  */
 gulp.task('heroku:dev', ['dist']);
+
+gulp.task('dev:verifier', () => {
+  process.env.VERIFIER = true;
+  gulp.run('dev');
+});
 
 gulp.task('dev', () => {
   const config = require('./webpack.dev.config');
@@ -253,6 +259,7 @@ gulp.task('release', (done) => {
 
 gulp.task('default', ['watch']);
 
+// gulp.task('watch:verify', ['watch:verify']);
 
 gulp.task('verify', () => {
   if (verifier.isCheckDisabled('ALL')) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -92,6 +92,11 @@ gulp.task('build', ['dist']);
  */
 gulp.task('heroku:dev', ['dist']);
 
+gulp.task('watch:verifier', () => {
+  process.env.VERIFIER = true;
+  gulp.run('dev');
+});
+
 gulp.task('dev:verifier', () => {
   process.env.VERIFIER = true;
   gulp.run('dev');

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -265,4 +265,6 @@ gulp.task('verify', () => {
   verifier.verifyEndpointStatus();
   verifier.verifyEndpointStructure();
   verifier.verifyOauth();
+  verifier.verifyDbConnection();
+  verifier.verifyAPIEnvs();
 });

--- a/mocked_backend/api/v3/config/map.json
+++ b/mocked_backend/api/v3/config/map.json
@@ -16,7 +16,5 @@
     "allowed_privileges": [
         "read",
         "search"
-    ],
-    "$promise": [],
-    "$resolved": true
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "protractor": "protractor test/protractor-conf.js",
     "jshint": "jshint .",
     "jscs": "gulp jscs",
-    "jscs-fix": "gulp jscsfix"
+    "jscs-fix": "gulp jscsfix",
+    "verify": "gulp verify"
   },
   "pre-commit": [
     "jshint",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "gulp dist",
     "watch": "gulp",
+    "watch:verify": "gulp dev:verifier",
     "start": "gulp serve:static",
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",

--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
     "ignore": [
       "ushahidi-platform-pattern-library"
     ]
+  },
+  "browser": {
+    "fs": false
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = {
         ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
         VERIFIER: JSON.stringify(process.env.VERIFIER || false),
         GIT_COMMIT: JSON.stringify(GIT_COMMIT || false),
-        USH_DISABLE_CHECKS: JSON.stringify(process.env.USH_DISABLE_CHECKS) || ' '
+        USH_DISABLE_CHECKS: JSON.stringify(process.env.USH_DISABLE_CHECKS) || false
     }),
 
     // Injects bundles in your index.html instead of wiring all manually.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = {
         ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
         VERIFIER: JSON.stringify(process.env.VERIFIER || false),
         GIT_COMMIT: JSON.stringify(GIT_COMMIT || false),
-        USH_DISABLE_CHECKS: JSON.stringify(process.env.USH_DISABLE_CHECKS) || ''
+        USH_DISABLE_CHECKS: JSON.stringify(process.env.USH_DISABLE_CHECKS) || ' '
     }),
 
     // Injects bundles in your index.html instead of wiring all manually.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,7 +100,8 @@ module.exports = {
         BACKEND_URL: JSON.stringify(process.env.BACKEND_URL || 'http://backend.url.undefined'),
         ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
         VERIFIER: JSON.stringify(process.env.VERIFIER || false),
-        GIT_COMMIT: JSON.stringify(GIT_COMMIT || false)
+        GIT_COMMIT: JSON.stringify(GIT_COMMIT || false),
+        USH_DISABLE_CHECKS: JSON.stringify(process.env.USH_DISABLE_CHECKS) || ''
     }),
 
     // Injects bundles in your index.html instead of wiring all manually.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = {
     new webpack.DefinePlugin({
         BACKEND_URL: JSON.stringify(process.env.BACKEND_URL || 'http://backend.url.undefined'),
         ENVIRONMENT: JSON.stringify(process.env.ENVIRONMENT || 'dev'),
+        VERIFIER: JSON.stringify(process.env.VERIFIER || false),
         GIT_COMMIT: JSON.stringify(GIT_COMMIT || false)
     }),
 


### PR DESCRIPTION
This pull request makes the following changes:

- Adds FE-verifier with Angular, go to /verifier to see.
- Moves all verifier-tests to a specific file, that can be used both for the gulp-verifiers and browser-verifiers.
-Refactors the gulp-verifier to use the specific verifier-test-file instead
-Adds missing checks for dbConnection and env in the api (needs branch db-installer-helper in the api)

Testing checklist:
- in the cli, run "gulp verify"
- [x] A list with checks and statuses is listed
- run gulp dev:verifier
- go to /verifier
- [x] A list with checks and statuses is listed
- Destroy something, like stopping the database or remove the BACKEND_URL from the .env-file
- [x] Reload, the browser, it should show the checks, with errors
- Go to the cli again, run gulp verify
- [ ] It should list the same errors as in the browser

 I certify that I ran my checklist
Ping @ushahidi/platform