### PR TITLE
checking if post is a tweet

### DIFF
--- a/app/main/posts/views/card.html
+++ b/app/main/posts/views/card.html
@@ -14,7 +14,7 @@
             <div class="postcard-title">
                 <div class="postcard-field">
                 <div class="tweet-container">
-                  <twitter-widget ng-if="post.data_source_message_id" twitter-widget-id="post.data_source_message_id">
+                  <twitter-widget ng-if="post.data_source_message_id && post.source === 'twitter'" twitter-widget-id="post.data_source_message_id">
                   </twitter-widget>
                 </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Checks if a post really is a tweet before showing the twitter-widget.

Testing checklist:
- [ ] Go to a deployment with tweets and emails
- [ ] Emails should show up as emails, without a tweet embedded (check many emails, this only happens if the message_id happens to correspond with an existing tweet)
- [ ] Tweets should show up as tweets.

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3438 .

Ping @ushahidi/platform
