### PR TITLE
 Changes the name to helper/Platform-installation-helper

### DIFF
--- a/app/common/common-routes.js
+++ b/app/common/common-routes.js
@@ -60,8 +60,8 @@ module.exports = ['$stateProvider', '$urlMatcherFactoryProvider', function ($sta
             }
         )
         .state({
-            name: 'verifier',
-            url: '/verifier',
+            name: 'helper',
+            url: '/helper',
             controller: require('./verifier/verifier.controller.js'),
             template: require('./verifier/verifier.html')
         })

--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -7,7 +7,7 @@
                 <p>If you believe this is wrong, check the .env file for the variable USH_DISABLE_CHECKS.</p>
                 </div>
             <div class="listing card init" ng-if="!allDisabled">
-                <h1>Installer helper</h1>
+                <h1>The Platform-installation helper</h1>
                 <p>Check the messages below to get hints while installing the Ushahidi-platform!</p>
                 <div class="listing-item"></div>
                 <div class="listing-item">

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -92,12 +92,12 @@ gulp.task('build', ['dist']);
  */
 gulp.task('heroku:dev', ['dist']);
 
-gulp.task('watch:verifier', () => {
+gulp.task('watch:helper', () => {
   process.env.VERIFIER = true;
   gulp.run('dev');
 });
 
-gulp.task('dev:verifier', () => {
+gulp.task('dev:helper', () => {
   process.env.VERIFIER = true;
   gulp.run('dev');
 });
@@ -264,9 +264,9 @@ gulp.task('release', (done) => {
 
 gulp.task('default', ['watch']);
 
-// gulp.task('watch:verify', ['watch:verify']);
+// gulp.task('watch:helper', ['watch:helper']);
 
-gulp.task('verify', () => {
+gulp.task('helper', () => {
   if (verifier.isCheckDisabled('ALL')) {
     log.info(c.green('USH_DISABLE_CHECKS is ALL, skipping verification process.'));
     return;


### PR DESCRIPTION
This pull request makes the following changes:
-After discussion on dial-call, I have updated the naming in the gulp-commands/web-check-page

Testing checklist:
- [ ] run `gulp helper`
- [ ] It should run the helper in the commandline
- [ ] run `gulp dev:helper`
- [ ] It should run the helper in the browser (localhost:3000/helper)

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
