### PR TITLE
verifier: handle API install debug mode switch

### DIFF
--- a/app/common/verifier/verifier.html
+++ b/app/common/verifier/verifier.html
@@ -165,6 +165,7 @@
                             <svg class="iconic">
                                 <use style="fill: #de0000" ng-if="dbConnection.errors" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                                 <use style="fill: #4fab2f" ng-if="dbConnection.success" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #5294ff" ng-if="dbConnection.type === 'info'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#info"></use>
                             </svg>
                         </div>
                         <strong class="list-item-secondary" ng-if="dbConnection">Checking that the database is connected</strong>
@@ -175,6 +176,9 @@
                     <div ng-if="dbConnection.errors" ng-repeat="result in dbConnection.errors">
                         <p>{{result.message}}</p>
                         <p>{{result.explainer}}</p>
+                    </div>
+                    <div ng-if="dbConnection.type === 'info'">
+                        <p>{{dbConnection.message}}</p>
                     </div>
                 </div>
             </div>
@@ -189,6 +193,7 @@
                             <svg class="iconic">
                                 <use style="fill: #de0000" ng-if="apiEnvs.errors" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-x"></use>
                                 <use style="fill: #4fab2f" ng-if="apiEnvs.success" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#circle-check"></use>
+                                <use style="fill: #5294ff" ng-if="apiEnvs.type === 'info'" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#info"></use>
                             </svg>
                         </div>
                         <strong class="list-item-secondary" ng-if="apiEnvs">Checking that there is an .env file in the backend</strong>
@@ -200,6 +205,25 @@
                         <div ng-if="apiEnvs.errors" ng-repeat="result in apiEnvs.errors">
                             <p>{{result.message}}</p>
                             <p>{{result.explainer}}</p>
+                        </div>
+                        <div ng-if="apiEnvs.type === 'info'">
+                            <p>{{apiEnvs.message}}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="listing-item" ng-if="(apiEnvs || dbConnection) && (!apiEnvs || apiEnvs.success) && (!dbConnection || dbConnection.success)">
+                <h3>Checking if API Install Debug mode should be disabled...</h3>
+                <div class="listing-item">
+                    <div class="listing-item-primary">
+                        <div class="listing-item-image">
+                            <svg class="iconic">
+                                <use style="fill: #FFC334" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#warning"></use>
+                            </svg>
+                        </div>
+                        <div>
+                            <p>For security reasons, we recommend NOT leaving some check routines enabled in the API.</p>
+                            <p>You may disable those checks now by running the "composer installdebug:disable" command in the API folder.</p>
                         </div>
                     </div>
                 </div>

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -163,23 +163,31 @@ const verifyAPIEnvs = function (env) {
     if (isCheckDisabled(env, 'API_ENVS')) {
         return new Promise((resolve, reject) => resolve('DISABLED'));
     }
-    return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/env`);
+    return checkVerifierAPI(`${env.BACKEND_URL}/api/v3/verifier/env`);
 };
 
 const verifyDbConnection = function (env) {
     if (isCheckDisabled(env, 'DB_CONNECTION')) {
         return new Promise((resolve, reject) => resolve('DISABLED'));
     }
-    return checkAPI(`${env.BACKEND_URL}/api/v3/verifier/db`);
+    return checkVerifierAPI(`${env.BACKEND_URL}/api/v3/verifier/db`);
 };
 
-const checkAPI = function (url) {
+const checkVerifierAPI = function (url) {
     return fetch(url)
     .then(json => {
         return json;
     })
     .then(response => {
-        return response.json();
+        if (response.status.toString() === '204') {
+            return {
+                type: 'info',
+                message: 'This check has been disabled in the Platform API. ' +
+                          'You may enable it by running "composer installdebug:enable" in the API folder.'
+            };
+        } else {
+            return response.json();
+        }
     })
     .catch(error => {
         console.log(error);

--- a/gulp/verifier.js
+++ b/gulp/verifier.js
@@ -118,6 +118,9 @@ module.exports.verifyOauth = function () {
 };
 
 module.exports.verifyAPIEnvs = function() {
+    const disableRecommend =
+        'For security reasons, we recommend NOT leaving this check routine enabled in the API. ' +
+        'You may disable the check by running the "composer installdebug:disable" command in the API folder.';
     const verifyAPIEnvs = verifier.verifyAPIEnvs(process.env);
     if (!verifyAPIEnvs) {
         log.info(c.bold(`Checking the environment variables in the API:`));
@@ -127,10 +130,14 @@ module.exports.verifyAPIEnvs = function() {
         verifyAPIEnvs
         .then(response => {
             log.info(c.bold(`Checking the environment variables in the API:`));
+            if (response.type === 'info') {
+                formatMessage(response.message, 'info');
+            }
             if (response.success) {
-            response.success.forEach(result=>{
-                formatMessage(result.message, 'confirmation');
-            });
+                response.success.forEach(result=>{
+                    formatMessage(result.message, 'confirmation');
+                });
+                formatMessage(disableRecommend, 'warning');
             } else if (response.errors) {
                 response.errors.forEach(result=>{
                     formatMessage(result.message, 'error');
@@ -141,6 +148,9 @@ module.exports.verifyAPIEnvs = function() {
 };
 
 module.exports.verifyDbConnection = function() {
+    const disableRecommend =
+        'For security reasons, we recommend NOT leaving this check routine enabled in the API. ' +
+        'You may disable the check by running the "composer installdebug:disable" command in the API folder.';
     const verifyDbConnection = verifier.verifyDbConnection(process.env);
     if (!verifyDbConnection) {
         log.info(c.bold('Checking the database connection:'));
@@ -150,10 +160,14 @@ module.exports.verifyDbConnection = function() {
         verifyDbConnection
         .then(response => {
             log.info(c.bold('Checking the database connection:'));
+            if (response.type === 'info') {
+                formatMessage(response.message, 'info');
+            }
             if (response.success) {
-            response.success.forEach(result=>{
-                formatMessage(result.message, 'confirmation');
-            });
+                response.success.forEach(result=>{
+                    formatMessage(result.message, 'confirmation');
+                });
+                formatMessage(disableRecommend, 'warning');
             } else if (response.errors) {
                 response.errors.forEach(result=>{
                     formatMessage(result.message, 'error');
@@ -177,6 +191,9 @@ const formatMessage = function(message, type) {
             break;
         case 'warning':
             log.warn(c.yellow(message));
+            break;
+        case 'info':
+            log.info(c.cyan(message));
             break;
         default:
             log.info(message);


### PR DESCRIPTION
This pull request makes the following changes:
- handles some checks being disabled in the API side
- introduces an "info" message display
- introduces a reminder to disable checks in the API , if they are successful

this is tied together to the changes in https://github.com/ushahidi/platform/pull/3704

Testing checklist:
- [x] Run with API checks disabled. Should fail gracefully with a message informing how to enable the checks
- [x] Run with API checks enabled. Should either fail or succeed. If both database and env checks succeed, a reminder to disable the checks in the API is produced in the screen.
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
