### PR TITLE
adding notification-bar with warning if debug is switch on

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -172,12 +172,6 @@ angular.module('app',
         angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
         DemoDeploymentService.demoCheck();
     }])
-    .run(['Verifier','Notify', function (Verifier, Notify) {
-        Verifier.checkDebugMode(BACKEND_URL)
-        .then(function (result) {
-            if (result) {
-                Notify.notifyPermanent(`You have debug-mode switched on, for security reasons, we recommend NOT leaving this check routine enabled in the API. 
-                    You may disable the check by running the "composer installdebug:disable" command in the API folder.`);
-            }
-        });
+    .run(['VerifierService', function (VerifierService) {
+        VerifierService.debugModeCheck();
     }]);

--- a/app/app.js
+++ b/app/app.js
@@ -171,4 +171,13 @@ angular.module('app',
         angular.element(document.getElementById('bootstrap-app')).removeClass('hidden');
         angular.element(document.getElementById('bootstrap-loading')).addClass('hidden');
         DemoDeploymentService.demoCheck();
+    }])
+    .run(['Verifier','Notify', function (Verifier, Notify) {
+        Verifier.checkDebugMode(BACKEND_URL)
+        .then(function (result) {
+            if (result) {
+                Notify.notifyPermanent(`You have debug-mode switched on, for security reasons, we recommend NOT leaving this check routine enabled in the API. 
+                    You may disable the check by running the "composer installdebug:disable" command in the API folder.`);
+            }
+        });
     }]);

--- a/app/common/auth/authentication-events.run.js
+++ b/app/common/auth/authentication-events.run.js
@@ -1,7 +1,7 @@
 module.exports = AuthenticationEvents;
 
-AuthenticationEvents.$inject = ['$rootScope', '$location', 'Authentication', 'Session', '_', '$state', 'TermsOfService', 'Notify', 'PostFilters', 'DataExport', 'DataImport', 'DemoDeploymentService'];
-function AuthenticationEvents($rootScope, $location, Authentication, Session, _, $state, TermsOfService, Notify, PostFilters, DataExport, DataImport, DemoDeploymentService) {
+AuthenticationEvents.$inject = ['$rootScope', '$location', 'Authentication', 'Session', '_', '$state', 'TermsOfService', 'Notify', 'PostFilters', 'DataExport', 'DataImport', 'DemoDeploymentService', 'VerifierService'];
+function AuthenticationEvents($rootScope, $location, Authentication, Session, _, $state, TermsOfService, Notify, PostFilters, DataExport, DataImport, DemoDeploymentService, VerifierService) {
 
     let loginPath = null;
     $rootScope.currentUser = null;
@@ -96,6 +96,8 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
                 loadSessionData();
                 $rootScope.loggedin = true;
                 DemoDeploymentService.demoCheck();
+                VerifierService.debugModeCheck();
+
 
                 /**
                  * adminUserSetup is called AFRTER the user has agreed to terms of service.

--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -80,6 +80,7 @@ angular.module('ushahidi.common', [
 .service('DataExport', require('./services/data-export.service.js'))
 .service('HxlExport', require('./services/hxl-export.service.js'))
 .service('DataImport', require('./services/data-import.service.js'))
+.service('VerifierService', require('./verifier/verifier.service.js'))
 // Global directives
 .directive('publishSelector', require('./directives/publish-selector.js'))
 

--- a/app/common/verifier/verifier.js
+++ b/app/common/verifier/verifier.js
@@ -230,6 +230,17 @@ const checkTokenStructure = function (env, options) {
         });
 };
 
+const checkDebugMode = function (url) {
+    return fetch(`${url}/api/v3/verifier/db`)
+    .then(response=> {
+        if (response.status === 200) {
+            return true;
+        } else {
+            return false;
+        }
+    });
+};
+
 const testToken = function (env, options) {
     return fetch(`${env.BACKEND_URL}/oauth/token`, options)
         .then(function (response) {
@@ -293,4 +304,4 @@ const checkStructure = function (a, b, url) {
 };
 
 module.exports = {
-    verifyNetwork, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, verifyDbConnection, verifyAPIEnvs, isCheckDisabled};
+    verifyNetwork, verifyEndpointStatus, verifyEndpointStructure, verifyEnv, verifyOauth, verifyTransifex, verifyDbConnection, verifyAPIEnvs, isCheckDisabled, checkDebugMode};

--- a/app/common/verifier/verifier.service.js
+++ b/app/common/verifier/verifier.service.js
@@ -1,0 +1,23 @@
+module.exports = [
+    'Verifier',
+    'Notify',
+    '$rootScope',
+function (
+    Verifier,
+    Notify,
+    $rootScope
+) {
+    return {
+        debugModeCheck: function () {
+                Verifier.checkDebugMode(BACKEND_URL)
+                    .then(function (result) {
+                        if (result && $rootScope.isAdmin()) {
+                            Notify.notifyPermanent(`You have debug-mode switched on, for security reasons, we recommend NOT leaving this check routine enabled in the API. 
+                        You may disable the check by running the "composer installdebug:disable" command in the API folder.`);
+                        }
+                    });
+            }
+    };
+}
+];
+

--- a/app/common/verifier/verifier.service.js
+++ b/app/common/verifier/verifier.service.js
@@ -12,7 +12,8 @@ function (
                 Verifier.checkDebugMode(BACKEND_URL)
                     .then(function (result) {
                         if (result) {
-                            Notify.notifyPermanent(`You have debug-mode switched on, for security reasons, we recommend NOT leaving this check routine enabled in the API. 
+                            Notify.notifyPermanent(`You have debug-mode switched on. If you are an admin of this deployment, 
+                            we recommend you disable this check and NOT leaving it enabled in the API. 
                         You may disable the check by running the "composer installdebug:disable" command in the API folder.`);
                         }
                     });

--- a/app/common/verifier/verifier.service.js
+++ b/app/common/verifier/verifier.service.js
@@ -11,7 +11,7 @@ function (
         debugModeCheck: function () {
                 Verifier.checkDebugMode(BACKEND_URL)
                     .then(function (result) {
-                        if (result && $rootScope.isAdmin()) {
+                        if (result) {
                             Notify.notifyPermanent(`You have debug-mode switched on, for security reasons, we recommend NOT leaving this check routine enabled in the API. 
                         You may disable the check by running the "composer installdebug:disable" command in the API folder.`);
                         }

--- a/test/unit/common/auth/authentication-events.run.spec.js
+++ b/test/unit/common/auth/authentication-events.run.spec.js
@@ -5,6 +5,7 @@ describe('global event handlers', function () {
         mockedAuthenticationData,
         mockedAuthenticationService,
         mockedDemoDeploymentService,
+        verifierService,
         mockTOS,
         $rootScope,
         $location,
@@ -56,6 +57,10 @@ describe('global event handlers', function () {
         {
             demoCheck: function () {}
         };
+        verifierService =
+        {
+            debugModeCheck: function () {}
+        };
 
         spyOn(mockedAuthenticationService, 'openLogin');
 
@@ -88,6 +93,9 @@ describe('global event handlers', function () {
         .run(require('app/common/auth/authentication-events.run.js'))
         .service('$state', function () {
             return mockState;
+        })
+        .service('VerifierService', function () {
+            return verifierService;
         });
 
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a notify-bar if debug-mode is switched-on in the backend

Testing checklist:
- [ ] Disable debug-mode in the backend (composer installdebug:disable)
- [ ] Reload client, a demo-bar should not appear
- [ ] Enable debug-mode in the backend (composer installdebug:enable)
- [ ] Reload client, a demo-bar should appear with a warning.

NOTE This only shows up at login + at reload if user already is logged in and the bar can be dismissed. Do we want to always show it?

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
