### PR TITLE
Category Selector Field Bug Fix - Resolves #2455

### DIFF
--- a/app/common/directives/category-selector.html
+++ b/app/common/directives/category-selector.html
@@ -1,4 +1,4 @@
-<div class="form-fieldgroup checkbox" overflow-toggle has-overflow="categories.length > 2">
+<div class="form-fieldgroup checkbox" ng-if="categories.length > 0" overflow-toggle has-overflow="categories.length > 2">
     <div class="form-field checkbox">
         <label>
             <input

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -234,7 +234,7 @@
             <p><bdi>{{attribute.instructions}}</bdi></p>
 
             <!-- attributes which use the form-field structure -->
-            <div ng-switch="attribute.input">
+            <div ng-switch="attribute.input" ng-if="attribute.options.length > 0">
                 <!-- type: radio -->
                 <div ng-switch-when="radio">
                     <div ng-repeat="(key, value) in post.values[attribute.key] track by key">


### PR DESCRIPTION
This pull request makes the following changes:
- Added an ng-if condition to the category selector html file to render only if categories.length > 0.

Fixes ushahidi/platform#2455 .

Ping @ushahidi/platform @rowasc 
