### PR TITLE
Fix sortablejs version to 1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "nvd3": "^1.8.4",
     "raven-js": "^3.26.3",
     "socket.io-client": "2.0.3",
-    "sortablejs": "^1.7.0",
+    "sortablejs": "1.10.0",
     "underscore": "^1.7.0",
     "ushahidi-platform-pattern-library": "^3.12.3"
   },


### PR DESCRIPTION
This pull request makes the following changes:
- Pins sortablejs to version 1.10.0 due to greenkeeper filing an issue after testing the build with sortablejs version 1.10.1 (on ##1343)

Testing checklist:
- [x] Run `npm install` with the new package.json in order to check that the dependencies are installed successfuly

- [X] I certify that I ran my checklist

Fixes ushahidi/platform-client#1343 (issue #1343).

Ping @ushahidi/platform
