### PR TITLE
fixed issue #2383 dual dropdowns

### DIFF
--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -63,13 +63,10 @@
 </div>
 <div class="tool">
     <h6 class="tool-heading" translate="app.language">Language</h6>
-    <span class="tool-trigger init" ng-class="{'active': showLanguage}" ng-click="languageToggle()">
-        <svg class="iconic">
-            <use xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
-        </svg>
-        <span class="label hidden">Show/hide</span>
+    <span class="tool-trigger init" ng-class="{'active': showLanguage}">
     </span>
+    <language-switch></language-switch>
     <div class="toggle-content" ng-class="{'active': showLanguage}">
-        <language-switch></language-switch>
+
     </div>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- removed dual dropdown when selecting languages
- removed toggle for first language selection option and svg

Testing checklist:
- [x] verified I could still reach and see second dropdown, first drop down toggle id now disabled

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
