### PR TITLE
Fix: sortableJS fix for v1.10.0 of sortableJS added in #1351

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -149,7 +149,7 @@ angular.module('app',
             { map: {}, site: {}, features: {} };
     }])
     .factory('Sortable', function () {
-        return require('sortablejs');
+        return require('sortablejs/Sortable');
     })
     // inject the router instance into a `run` block by name
     //.run(['$uiRouter', '$trace', '$location', function ($uiRouter, $trace, $location) {


### PR DESCRIPTION
The new version of SortableJS has to be called with `require(sortablejs/Sortable)`.  
Merging this to fix an issue with https://github.com/ushahidi/platform-client/pull/1351 that I didn't see when testing (I think I forgot to restart my server at that point) 