### PR TITLE
moving ng-if check to parent-div

### DIFF
--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -217,7 +217,7 @@
             </div>
         </div>
         <!-- Container for fieldset structured elements -->
-        <fieldset ng-if="isFieldSetStructure(attribute)">
+        <fieldset ng-if="isFieldSetStructure(attribute) && attribute.options.length > 0">
             <!-- Attribute Label -->
             <label ng-class="{
                 'error': form['values_' + attribute.key].$invalid && form['values_' + attribute.key].$dirty,
@@ -234,7 +234,7 @@
             <p><bdi>{{attribute.instructions}}</bdi></p>
 
             <!-- attributes which use the form-field structure -->
-            <div ng-switch="attribute.input" ng-if="attribute.options.length > 0">
+            <div ng-switch="attribute.input">
                 <!-- type: radio -->
                 <div ng-switch-when="radio">
                     <div ng-repeat="(key, value) in post.values[attribute.key] track by key">


### PR DESCRIPTION
This pull request makes the following changes:
- moving ng-if check to hide the category-label to correct div (my bad, I had confused our contributor)

Testing checklist:
- [ ] Add categories that only admins can see  to a survey
- [ ] Go to add-post-view as an admin, categories + the label of the category-field is visible
- [ ] Logout and go to the add-post-view again
- [ ] Categories + the label of the category-field is NOT visible

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2455 .

Ping @ushahidi/platform
