### PR TITLE
Fix for 'There's a random hover state for the time metadata' #2277

### DIFF
--- a/app/main/posts/common/post-metadata.html
+++ b/app/main/posts/common/post-metadata.html
@@ -26,7 +26,7 @@
     </li>
     <li class="tooltip">
         <span class="label">{{timeago}}</span>
-        <span class="bug" title="{{ displayTimeFull }}">{{ displayTime }}</span>
+        <span class="bug tooltip-visible-el" aria-label="Post added {{ displayTimeFull }}" role="tooltip" title="{{ displayTimeFull }}">{{ displayTimeFull }}</span>
 
     </li>
     <li>

--- a/sass/overrides/_modal.scss
+++ b/sass/overrides/_modal.scss
@@ -12,6 +12,4 @@ modal {
     }
 }
 
-.tooltip-visible-el {
-    color: #FEFEFE;
-}
+

--- a/sass/overrides/_modal.scss
+++ b/sass/overrides/_modal.scss
@@ -11,3 +11,7 @@ modal {
         pointer-events: none;
     }
 }
+
+.tooltip-visible-el {
+    color: #FEFEFE;
+}


### PR DESCRIPTION
**Expected behaviour**
hover state on postcard should show full date and time

**Actual behaviour**

![image](https://user-images.githubusercontent.com/15007255/68962520-cb972c80-07a2-11ea-9af5-8fd30e0968fc.png)

**New behaviour**

![image](https://user-images.githubusercontent.com/15007255/68962604-f6818080-07a2-11ea-935d-d6db226bd184.png)



This pull request makes the following changes:
- Add aria-label for accessibility
- Change font color slightly for better contrast
- Now displays full date and time in tooltip on hover

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
