### PR TITLE
fix: When deleting a post, the total post number updates immediately,…

### DIFF
--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -66,7 +66,7 @@
         <div class="listing timeline init">
 
         <div class="bulk-action" ng-if="posts.length > 0 || !isLoading()">
-            <div class="bulk-action-primary" translate="post.posts_total" translate-values="{'posts': posts.length, 'total_nb': totalItems }"></div>
+            <div class="bulk-action-primary" translate="post.posts_total" translate-values="{'posts': posts.length, 'total_nb': posts.length }"></div>
             <button id="bulk-action" ng-disabled="{{!totalItems}}" class="button-link bulk-action-secondary" ng-click="selectBulkActions()" ng-if="$root.loggedin" translate="post.modify.bulk_actions">Bulk Actions</button>
         </div>
             <post-card


### PR DESCRIPTION
This pull request makes the following changes:
When deleting a post, the total number of posts updates immediately, not only after refresh.

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
