### PR TITLE
3781 validating img

### DIFF
--- a/app/common/directives/file-upload.directive.js
+++ b/app/common/directives/file-upload.directive.js
@@ -7,29 +7,42 @@ function FileUpload() {
         replace: true,
         scope: {
             container: '=',
-            model: '='
+            model: '=',
+            validation: '='
         },
         controller: [
-            '$scope', '$attrs',
+            '$scope', '$attrs', 'Notify',
             function (
-                $scope, $attrs
+                $scope, $attrs, Notify
             ) {
                 $scope.required = typeof $attrs.required !== 'undefined';
                 $scope.uploadFile = function ($event) {
-                    $scope.container.file = $event.target.files[0];
-                    var reader = new FileReader();
-                    reader.onload = function () {
-                        var dataURL = reader.result;
-                        $scope.container.dataURI = dataURL;
-                        $scope.container.changed = true;
-                        $scope.container.deleted = false;
-                        $scope.model = 'changed';
-                        $scope.$apply();
-                    };
-                    reader.readAsDataURL($event.target.files[0]);
-
-
+                    if (validateFile($event.target.files[0])) {
+                        $scope.container.file = $event.target.files[0];
+                        var reader = new FileReader();
+                        reader.onload = function () {
+                            var dataURL = reader.result;
+                            $scope.container.dataURI = dataURL;
+                            $scope.container.changed = true;
+                            $scope.container.deleted = false;
+                            $scope.model = 'changed';
+                            $scope.$apply();
+                        };
+                        reader.readAsDataURL($event.target.files[0]);
+                    } else {
+                        Notify.error('post.media.error_in_upload');
+                    }
                 };
+
+                function validateFile(container) {
+                    if ($scope.validation === 'image') {
+                        var mimeReg = /[\/.](gif|jpg|jpeg|png)$/i;
+                        var mimeCheck = mimeReg.test(container.type);
+                        var sizeCheck = container.size < 1000000;
+                        return mimeCheck && sizeCheck;
+                    }
+                    return true;
+                }
             }]
     };
 }

--- a/app/common/directives/file-upload.directive.js
+++ b/app/common/directives/file-upload.directive.js
@@ -38,7 +38,7 @@ function FileUpload() {
                     if ($scope.validation === 'image') {
                         var mimeReg = /[\/.](gif|jpg|jpeg|png)$/i;
                         var mimeCheck = mimeReg.test(container.type);
-                        var sizeCheck = container.size < 1000000;
+                        var sizeCheck = container.size < 1048576;
                         return mimeCheck && sizeCheck;
                     }
                     return true;

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -841,7 +841,7 @@
             "add_photo": "Add photo",
             "delete_photo": "Delete photo",
             "replace_image": "Replace image",
-            "error_in_upload": "Your image is too large or has the wrong format, please check and try again!"
+            "error_in_upload": "Your image is too large (maximum size is 1MB) or has the wrong format (allowed formats are gif, png, jpg and jpeg), please check and try again!"
         },
         "video" : {
             "enter_a" : "Enter a",

--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -840,7 +840,8 @@
             "upload" : "Upload",
             "add_photo": "Add photo",
             "delete_photo": "Delete photo",
-            "replace_image": "Replace image"
+            "replace_image": "Replace image",
+            "error_in_upload": "Your image is too large or has the wrong format, please check and try again!"
         },
         "video" : {
             "enter_a" : "Enter a",

--- a/app/main/posts/modify/media.html
+++ b/app/main/posts/modify/media.html
@@ -1,7 +1,7 @@
 
 <form>
     <div class="form-field file">
-      <file-upload id="{{name}}" container="media" model="mediaId">
+      <file-upload id="{{name}}" validation="'image'" validation=true container="media" model="mediaId">
       </file-upload>
 
       <label for="{{name}}" class="button button-gamma" ng-show="showAdd()">
@@ -23,7 +23,7 @@
              <span class="hidden" translate="post.media.delete_photo"></span>
           </button>
 
-          <file-upload id="{{name}}" container="media" model="mediaId"></file-upload>
+          <file-upload id="{{name}}" validation="'image'" container="media" model="mediaId"></file-upload>
             <label for="{{name}}" class="button button-gamma">
               <svg class="iconic">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#image"></use>

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -242,10 +242,6 @@ function PostDataEditorController(
             attributes.map(function (attr) {
                 // Create associated media entity
                 if (attr.input === 'upload') {
-                    var media = {};
-                    if ($scope.post.values[attr.key]) {
-                        media = $scope.post.values[attr.key][0];
-                    }
                     $scope.medias[attr.key] = {};
                 }
                 if (attr.input === 'tags') {

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -141,10 +141,6 @@ function PostEditorController(
             attributes.map(function (attr) {
                 // Create associated media entity
                 if (attr.input === 'upload') {
-                    var media = {};
-                    if ($scope.post.values[attr.key]) {
-                        media = $scope.post.values[attr.key][0];
-                    }
                     $scope.medias[attr.key] = {};
                 }
                 if (attr.input === 'tags') {

--- a/app/main/posts/modify/post-media.directive.js
+++ b/app/main/posts/modify/post-media.directive.js
@@ -50,7 +50,6 @@ function (
             function renderViewValue() {
                 if (ngModel.$viewValue) {
                     $scope.mediaId = parseInt(ngModel.$viewValue);
-
                     // Load the media from the API
                     if ($scope.media.id !== $scope.mediaId) {
                         MediaEndpoint.get({id: $scope.mediaId}).$promise.then(function (media) {
@@ -65,6 +64,7 @@ function (
             function handleMediaChange(changed) {
                 if (changed) {
                     // Make sure the model is set dirty if media changes
+                    ngModel.$setViewValue($scope.mediaId);
                     ngModel.$setDirty();
                 }
             }
@@ -72,6 +72,7 @@ function (
             function handleMediaIdChange(id) {
                 if (id === 'changed') {
                     // Make sure the model is set dirty if media changes
+                    ngModel.$setViewValue($scope.mediaId);
                     ngModel.$setDirty();
                 }
             }
@@ -85,7 +86,7 @@ function (
             }
 
             function showDelete() {
-                return $scope.media.id;
+                return $scope.media.id || ($scope.media.changed && !$scope.media.deleted);
             }
 
             function deleteMedia(mediaId) {


### PR DESCRIPTION
This pull request makes the following changes:
- connects the imageId to ngModel in post-media-directive (in order to check if an image is there or not)
- adds a very basic validation on mime-type and size

Testing checklist:
-  Start with a survey with 1 image, make the image-field required
- Add a post with an image with a size < 1 MB
- [ ] It should display the image
- Go to data-view or map-view
- [ ] The image should be visible
- Click on edit. The image should be visible
- [ ] Click on delete
- [ ] There should be a warning, click delete again
- [ ] The image should disappear
- [ ] Click on "add new"
- Select an image < 1 MB
- [ ] It should display the image
-  Click on "replace image"
- [ ] Select an image with a size > 1MB
- [ ] The image should not appear
- [ ] There should be a notification-bar telling you that the image was too  big
- Select an image < 1 MB
- [ ] It should display the image
- Click on save
- [ ] It should save
- [ ] Add a post with an image with a size > 1MB
- [ ] The image should not appear
- [ ] There should be a notification-bar telling you that the image was too  big
- [ ] There should be an error-label below the field saying this field is required
- [ ] Add an image < 1MB, the error-label should disappear

- Repeat with a survey with 2 or more fields

NOTE: This is the first step in fixing the image-upload in the client
Things to do are listed in #3781

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
