### PR TITLE
updating pattern-library to v3.12.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "sortablejs": "1.10.0",
     "tui-editor": "^1.4.7",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "^3.12.3"
+    "ushahidi-platform-pattern-library": "^3.12.5"
   },
   "engines": {
     "node": ">=4.0"


### PR DESCRIPTION
This pull request makes the following changes:
- New release of the pattern-library
- Fixes pixly images for youtube and vimeo
- Fixes width of images in posts

Testing checklist:
- Go to a survey with an embed-video field
- [ ] The icons for youtube and vimeo should not be pixly
- Add a small image (less than 40 px or so) to a survey with an image-field
- Look at the post in dataview
- [ ] The image should keep its size and not be the full width of the post-card
- Look at the post in map-view
- [ ] The image should keep its size and not be the full width of the post-card
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
