### PR TITLE
3781 delete image

### DIFF
--- a/app/main/posts/modify/post-media.directive.js
+++ b/app/main/posts/modify/post-media.directive.js
@@ -104,9 +104,7 @@ function (
 
             function deleteMedia(mediaId) {
                 // Mark for deletion
-                $scope.media = {id: mediaId};
-                $scope.media.changed = true;
-                $scope.media.deleted = true;
+                $scope.media = {id: mediaId, changed: true, deleted: true};
             }
         }
     };

--- a/app/main/posts/modify/post-media.directive.js
+++ b/app/main/posts/modify/post-media.directive.js
@@ -43,6 +43,9 @@ function (
                 // Watch for media changes
                 $scope.$watch('mediaId', handleMediaIdChange);
 
+                // Watch for deleted images
+                $scope.$watch('media.deleted', handleMediaDeleted);
+
                 // Set up rendering any model changes
                 ngModel.$render = renderViewValue;
             }
@@ -67,6 +70,7 @@ function (
                     ngModel.$setViewValue($scope.mediaId);
                     ngModel.$setDirty();
                 }
+
             }
 
             function handleMediaIdChange(id) {
@@ -77,12 +81,21 @@ function (
                 }
             }
 
+            function handleMediaDeleted(deleted) {
+                // Make sure we update the view-value both if an image is deleted and deleted and then replaced
+                if (deleted) {
+                    ngModel.$setViewValue(null);
+                } else {
+                    ngModel.$setViewValue($scope.mediaId);
+                }
+            }
+
             function showAdd() {
                 return (!$scope.media.id && !$scope.media.changed || $scope.media.deleted);
             }
 
             function showReplace() {
-                return $scope.media.dataURI || $scope.media.id;
+                return $scope.media.dataURI || ($scope.media.id && !$scope.media.deleted);
             }
 
             function showDelete() {

--- a/app/main/posts/modify/post-media.directive.js
+++ b/app/main/posts/modify/post-media.directive.js
@@ -82,7 +82,7 @@ function (
             }
 
             function handleMediaDeleted(deleted) {
-                // Make sure we update the view-value both if an image is deleted and deleted and then replaced
+                // // Make sure we update the view-value both if an image is deleted and deleted and then replaced
                 if (deleted) {
                     ngModel.$setViewValue(null);
                 } else {
@@ -104,7 +104,7 @@ function (
 
             function deleteMedia(mediaId) {
                 // Mark for deletion
-                $scope.media = {};
+                $scope.media = {id: mediaId};
                 $scope.media.changed = true;
                 $scope.media.deleted = true;
             }


### PR DESCRIPTION
This pull request makes the following changes:
- Detects changes on media.deleted. This will make the viewValue update if both deleted and deleted and then replaced
- Sends media-id for deletion if an image is deleted.

Testing checklist:
- Delete an image in a survey with required images
- [ ] You should immediately get a red box that a required field is missing
- [ ] Try saving, you should immediately get a message that a required field is missing
- Add a new image
- Delete the new image, 
- [ ] You should immediately get a red box that a required field is missing
- [ ] Try saving, you should immediately get a message that a required field is missing

- [x ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
