### PR TITLE
Fixing saving posts for non-admins

### DIFF
--- a/app/main/posts/common/post-metadata.service.js
+++ b/app/main/posts/common/post-metadata.service.js
@@ -3,13 +3,15 @@ module.exports = PostMetadataService;
 PostMetadataService.$inject = [
     'Util',
     'UserEndpoint',
-    'ContactEndpoint'
+    'ContactEndpoint',
+    '$rootScope'
 ];
 
 function PostMetadataService(
     Util,
     UserEndpoint,
-    ContactEndpoint
+    ContactEndpoint,
+    $rootScope
 ) {
     var PostMetadataService = {
         // Format source (fixme!)
@@ -24,7 +26,7 @@ function PostMetadataService(
             }
         },
         loadUser: function (post) {
-            if (post.user && post.user.id) {
+            if (post.user && post.user.id && $rootScope.hasPermission('Manage Users')) {
                 return UserEndpoint.get({id: post.user.id});
             } else {
                 return post.user;

--- a/test/unit/main/post/common/post-metadata.service.spec.js
+++ b/test/unit/main/post/common/post-metadata.service.spec.js
@@ -3,7 +3,8 @@ describe('Post Metadata Service', function () {
     var PostMetadataService,
         UserEndpoint,
         post,
-        ContactEndpoint;
+        ContactEndpoint,
+        $rootScope;
 
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
@@ -19,11 +20,11 @@ describe('Post Metadata Service', function () {
         angular.mock.module('testApp');
     });
 
-    beforeEach(angular.mock.inject(function (_PostMetadataService_, _ContactEndpoint_, _UserEndpoint_) {
+    beforeEach(angular.mock.inject(function (_PostMetadataService_, _ContactEndpoint_, _UserEndpoint_, _$rootScope_) {
         PostMetadataService = _PostMetadataService_;
         ContactEndpoint = _ContactEndpoint_;
         UserEndpoint = _UserEndpoint_;
-
+        $rootScope = _$rootScope_;
         post = fixture.load('posts/120.json');
     }));
 
@@ -40,7 +41,8 @@ describe('Post Metadata Service', function () {
             var result = PostMetadataService.formatSource();
             expect(result).toEqual('Web');
         });
-        it('should load a user', function () {
+        it('should load a user if Manage Users permission', function () {
+            $rootScope.hasPermission = ()=>true;
             post = {
                 user: {
                     id: 1
@@ -50,6 +52,18 @@ describe('Post Metadata Service', function () {
             spyOn(UserEndpoint, 'get').and.callThrough();
             PostMetadataService.loadUser(post);
             expect(UserEndpoint.get).toHaveBeenCalled();
+        });
+        it('should not attempt to load a user if not Manage Users permission', function () {
+            $rootScope.hasPermission = ()=>false;
+            post = {
+                user: {
+                    id: 1
+                }
+            };
+
+            spyOn(UserEndpoint, 'get').and.callThrough();
+            PostMetadataService.loadUser(post);
+            expect(UserEndpoint.get).not.toHaveBeenCalled();
         });
         it('should load a contact', function () {
             post = {


### PR DESCRIPTION
This pull request makes the following changes:
- Checks if the user has Manage Users permissions before requesting user-info
- Adds test

Testing checklist:
- [ ] Log in as a user with Manage Posts permissions, but without admin or Manage Users permissions
- [ ] Go to data-view
- [ ] Select a post added by another user than the current logged in one
- [ ] Click on edit, make a change
- [ ] Click on save, post should save without error-message

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3826 (part of) .

Ping @ushahidi/platform
