### PR TITLE
removing lock-id from post-lock endpoint

### DIFF
--- a/app/common/services/endpoints/post-lock-endpoint.js
+++ b/app/common/services/endpoints/post-lock-endpoint.js
@@ -12,9 +12,8 @@ function (
     $http
 ) {
 
-    var PostLockEndpoint = $resource(Util.apiUrl('/posts/:post_id/lock/:id'), {
-        post_id: '@post_id',
-        id: '@id'
+    var PostLockEndpoint = $resource(Util.apiUrl('/posts/:post_id/lock/'), {
+        post_id: '@post_id'
     }, {
         getLock: {
             method: 'PUT'

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -132,7 +132,6 @@ function PostDataEditorController(
              **/
             if ($scope.post.lock) {
                 PostLockEndpoint.unlock({
-                    id: $scope.post.lock.id,
                     post_id: $scope.post.id
                 }).$promise.then(resolve, reject);
             } else {


### PR DESCRIPTION
This pull request makes the following changes:
- Removes post-lock-id from post-lock endpoint
- This makes the unlocking of posts when leaving editmode without  saving work.

Testing checklist:
- Login as one user, go to editmode for a post
- Make a change, and then click cancel and leave the post
- Login as another user, go to the same post
- [ ] It should be unlocked.

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3830 .

Ping @ushahidi/platform
