### PR TITLE
Adding Accept-Language-header to interceptor

### DIFF
--- a/app/common/auth/authentication-interceptor.config.js
+++ b/app/common/auth/authentication-interceptor.config.js
@@ -85,6 +85,8 @@ function AuthInterceptor($rootScope, $injector, $q, CONST, Session, _) {
         var deferred = $q.defer();
 
         config.ignorable = shouldIgnoreAuthError(config);
+        // Revisit and possibly move out to own inceptor
+        config.headers['Accept-Language'] = Session.getSessionDataEntry('language') ? Session.getSessionDataEntry('language') : 'en-US';
 
         if (config.url.indexOf(CONST.API_URL) === -1) {
             deferred.resolve(config);


### PR DESCRIPTION
This pull request makes the following changes:
-Adding Accept-Language header to send the user-selected language to Auth-interceptor

Testing checklist:
- [ ] Switch language to Spanish (Spanish is the only translations we have right now)
- [ ] Try signing up with an email address already known
- [ ] The Error-message should be in Spanish
- [ ] GO to settings-categories
- [ ] Add a category with the same name as one that already exists
- [ ] The error message (or part of it, its not all translated yet) should be in Spanish
- [ ] Any other error-messages showing up as the error-toast-bar should be translated (it there are corresponding translations in the backend)

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
