### PR TITLE
clearing input-bar in user-search

### DIFF
--- a/app/common/directives/filter-system/filter-searchbar.js
+++ b/app/common/directives/filter-system/filter-searchbar.js
@@ -36,7 +36,7 @@ function ($timeout) {
 
             $scope.onClear = function () {
                 $scope.hideSearchResults();
-                $scope.form.q.$setViewValue('');
+                $scope.form.q.$setViewValue(null);
                 $scope.model.q = null;
             };
         };


### PR DESCRIPTION
This pull request makes the following changes:
- Clears the input-bar when clicking on 'x' in user-search

Testing checklist:
- Go to 'Settings-Users'
- Click on search bar to enter name to search for
- Enter something
- Click on the x in the searchbar
- [ ] The input-field is emptied
- Click on search bar to enter name to search for
- Enter something
- Perform search through enter or click button
- Search-results appear
- Click on the x in the searchbar
- [ ] The input-field is emptied
- [ ] The userlist is back to its initial state

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
