### PR TITLE
Display Name in placeholder inside roles

### DIFF
--- a/app/settings/roles/roles-edit.html
+++ b/app/settings/roles/roles-edit.html
@@ -42,7 +42,7 @@
                 <div class="form-sheet">
                    <div class="form-field">
                        <label translate>role.name</label>
-                       <input type="text" placeholder="{{'role.name'}}" ng-minlength="3" ng-maxlength="150" ng-model="role.display_name" required>
+                       <input type="text" placeholder="{{'role.name' | translate}}" ng-minlength="3" ng-maxlength="150" ng-model="role.display_name" required>
                    </div>
 
                     <div class="form-field">


### PR DESCRIPTION
This pull request makes the following changes:
- Display `Name` in placeholder inside roles instead of `role.name` 
- Before Changes
![Screenshot from 2020-02-05 18-57-11](https://user-images.githubusercontent.com/55590415/73846581-c3530880-484a-11ea-8e61-ac7a30fe5873.png)
- After Changes
![Screenshot from 2020-02-05 19-08-53](https://user-images.githubusercontent.com/55590415/73846709-fbf2e200-484a-11ea-81e2-896529b4aab7.png)


Testing checklist:
- [X] I certify that I ran my checklist

Fixes ushahidi/platform#3835 .

Ping @ushahidi/platform
