### PR TITLE
Cancel button in post edit page

### DIFF
--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -89,6 +89,10 @@ function PostDataEditorController(
     $scope.selectForm = selectForm;
     $scope.isSaving = LoadingProgress.getSavingState;
 
+    $scope.cancel = function () {
+        $location.path('/views/data');
+    };
+
     var ignoreCancelEvent = false;
     // Need state management
     $scope.$on('event:edit:post:reactivate', function () {

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -83,15 +83,12 @@ function PostDataEditorController(
     $scope.tagKeys = [];
     $scope.save = $translate.instant('app.save');
     $scope.saving = $translate.instant('app.saving');
+    $scope.cancel = cancel;
     $scope.submit = $translate.instant('app.submit');
     $scope.submitting = $translate.instant('app.submitting');
     $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
     $scope.selectForm = selectForm;
     $scope.isSaving = LoadingProgress.getSavingState;
-
-    $scope.cancel = function () {
-        $location.path('/views/data');
-    };
 
     var ignoreCancelEvent = false;
     // Need state management
@@ -409,5 +406,9 @@ function PostDataEditorController(
 
             });
         });
+    }
+        
+    function cancel() {
+        $state.go('posts.data.detail',{postId: $scope.post.id});
     }
 }

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -69,7 +69,7 @@
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
 
-          <button class="button-flat" ng-click="leavePost()" translate>app.cancel</button>
+          <button class="button-flat" ng-click="cancel()" translate>app.cancel</button>
           <button class="button button-alpha" ng-click="savePost()" ng-if="!isSaving()" translate="">app.save</button>
           <loading-dots button-class="'button-alpha'" ng-if="isSaving()" disabled=true label="'app.saving'"></loading-dots>
         </div>


### PR DESCRIPTION
This pull request makes the following changes:

<b>Before Changes:</b>

The cancel button in the post edit page was not working.

<b>After Changes:</b>

As the cancel button is clicked the edit mode is cancelled and it goes back to post view.

Testing checklist:

- [X ] I certify that I ran my checklist

Fixes ushahidi/platform#3828 .

Ping @ushahidi/platform
