### PR TITLE
cancel button in post edit page fixes #3828

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
   - node_js: stable
   include:
   # Run everything with v5 (match production)
-  - node_js: 8
+  - node_js: 5
     env: TEST_SUITE=lint
-  - node_js: 8
+  - node_js: 5
     env: TEST_SUITE=unit
-  - node_js: 8
+  - node_js: 6
     env: TEST_SUITE=unit
   - node_js: stable
     env: TEST_SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
   - node_js: stable
   include:
   # Run everything with v5 (match production)
-  - node_js: 5
+  - node_js: 8
     env: TEST_SUITE=lint
-  - node_js: 5
+  - node_js: 8
     env: TEST_SUITE=unit
-  - node_js: 6
+  - node_js: 8
     env: TEST_SUITE=unit
   - node_js: stable
     env: TEST_SUITE=unit

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -88,6 +88,7 @@ function PostDataEditorController(
     $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
     $scope.selectForm = selectForm;
     $scope.isSaving = LoadingProgress.getSavingState;
+    $scope.cancel = cancel;
 
     var ignoreCancelEvent = false;
     // Need state management
@@ -325,6 +326,10 @@ function PostDataEditorController(
 
     function resolveMedia() {
         return MediaEditService.saveMedia($scope.medias, $scope.post);
+    }
+
+    function cancel() {
+        $state.go('posts.data');
     }
 
     function savePost() {

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -69,7 +69,7 @@
       <div class="toolbar toolbar-secondary">
         <div class="button-group">
 
-          <button class="button-flat" ng-click="leavePost()" translate>app.cancel</button>
+          <button class="button-flat" ng-click="cancel()" translate>app.cancel</button>
           <button class="button button-alpha" ng-click="savePost()" ng-if="!isSaving()" translate="">app.save</button>
           <loading-dots button-class="'button-alpha'" ng-if="isSaving()" disabled=true label="'app.saving'"></loading-dots>
         </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Cancel button on post-edit page closes the current page.

Testing checklist:
- [x] Verified code style using jscs
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3828 .

Ping @ushahidi/platform
