### PR TITLE
Dropdown error in search bar fixed (fixes #3846)

### DIFF
--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -17,7 +17,7 @@
             <div class="input-with-icon">
                 <input name="q" type="search" autocomplete="off"
                 placeholder="{{ 'toolbar.searchbar.search_entity' | translate }}"
-                ng-model="filters.q" ng-model-options="{ debounce: 300 }" ng-focus="showDropdown()" ng-keyup="showDropdown()">
+                ng-model="filters.q" ng-model-options="{ debounce: 300 }" ng-click = "showDropdown()" ng-keyup="($event.keyCode === 27)  ? hideDropdown(): showDropdown()" ng-keypress="($event.keyCode === 27) ? hideDropdown(): showDropdown()">
                 <svg class="iconic" ng-show="!postFiltersFormOpen.q.$viewValue.length">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>


### PR DESCRIPTION
This pull request makes the following changes:
**Before** : Dropdown search menu was popping out again after pressing `esc` key.
**After**    :Dropdown now closed without coming out again.  

Testing checklist:
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3846 .

