### PR TITLE
Select all button in the filter

### DIFF
--- a/app/main/posts/views/filters/filter-form.html
+++ b/app/main/posts/views/filters/filter-form.html
@@ -1,7 +1,7 @@
 <fieldset overflow-toggle has-overflow="forms.length > 1" ng-model-options="{ updateOn: 'default' }">
     <label translate="app.surveys">Survey</label>
    
-    <div class="form-field checkbox">
+    <div class="form-field checkbox" ng-show="forms.length > 5">
         <label>
             <input  type="checkbox" name="selectedForms" ng-model="all"><em><span translate="category.select_all"></span></em>
         </label>

--- a/app/main/posts/views/filters/filter-form.html
+++ b/app/main/posts/views/filters/filter-form.html
@@ -3,12 +3,17 @@
 
     <div class="form-field checkbox" ng-repeat="(index, form) in forms">
         <label>
-            <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms"> <bdi>{{ ::form.name }}</bdi>
+            <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms" ng-checked="all"> <bdi>{{ ::form.name }}</bdi>
         </label>
     </div>
     <div class="form-field checkbox">
         <label>
-            <input checklist-value="'none'" checklist-model="selectedForms" type="checkbox" name="selectedForms" > <span translate="nav.unknown">Unknown</span>
+            <input checklist-value="'none'" checklist-model="selectedForms" type="checkbox" name="selectedForms" ng-checked="all" > <span translate="nav.unknown">Unknown</span>
+        </label>
+    </div>
+    <div class="form-field checkbox">
+        <label>
+            <input  type="checkbox" name="selectedForms" ng-model="all"> <span >Select/Unselect All</span>
         </label>
     </div>
 </fieldset>

--- a/app/main/posts/views/filters/filter-form.html
+++ b/app/main/posts/views/filters/filter-form.html
@@ -1,6 +1,11 @@
 <fieldset overflow-toggle has-overflow="forms.length > 1" ng-model-options="{ updateOn: 'default' }">
     <label translate="app.surveys">Survey</label>
-
+   
+    <div class="form-field checkbox">
+        <label>
+            <input  type="checkbox" name="selectedForms" ng-model="all"><em><span translate="category.select_all"></span></em>
+        </label>
+    </div>
     <div class="form-field checkbox" ng-repeat="(index, form) in forms">
         <label>
             <input checklist-value="form.id" checklist-model="selectedForms" type="checkbox" name="selectedForms" ng-checked="all"> <bdi>{{ ::form.name }}</bdi>
@@ -9,11 +14,6 @@
     <div class="form-field checkbox">
         <label>
             <input checklist-value="'none'" checklist-model="selectedForms" type="checkbox" name="selectedForms" ng-checked="all" > <span translate="nav.unknown">Unknown</span>
-        </label>
-    </div>
-    <div class="form-field checkbox">
-        <label>
-            <input  type="checkbox" name="selectedForms" ng-model="all"> <span >Select/Unselect All</span>
         </label>
     </div>
 </fieldset>


### PR DESCRIPTION
This pull request makes the following changes:

**Before Changes**
-Multiple select fields didn't have a select all button. 

![Screenshot from 2020-03-10 11-55-45](https://user-images.githubusercontent.com/55590415/76286087-41318600-62c7-11ea-90bc-4815866da577.png)

**After Changes**
-A select all button is there using which all the fields can be selected at once.

![Screenshot from 2020-03-10 12-02-14](https://user-images.githubusercontent.com/55590415/76286165-61f9db80-62c7-11ea-8474-0a3b52d6fa8f.png)


Testing checklist:

- [X] I certify that I ran my checklist

Fixes ushahidi/platform#2376 .

Ping @ushahidi/platform
