### PR TITLE
Fix updating no of post after deleting a post and load-more button

### DIFF
--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -326,7 +326,7 @@ function PostViewDataController(
             limit: $scope.itemsPerPage
         });
         if (useOffset === true) {
-            postQuery.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
+            postQuery.offset = $scope.posts.length;
         }
         PostEndpoint.query(postQuery).$promise.then(function (postsResponse) {
             //Clear posts


### PR DESCRIPTION
This pull request makes the following changes:
- ~~fixes updating the post counter when deleting a post~~
- loading the correct amount of posts when a post was deleted and then more posts are loaded
- ~~UI end-to-end test infrastructure with tests for the fixes in this PR~~

Testing checklist:
- [x] 22 Scenarios about deleting posts and showing more posts, see .feature files in this PR. All tests are implemented in CI and are passing, see #1473

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3861 &  ~~ushahidi/platform#3326~~

Ping @ushahidi/platform
