### PR TITLE
bringing back svg-url-loader to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sass-loader": "^8.0.0",
     "style-loader": "^1.1.2",
     "supports-color": "^3.1.2",
-    "svg-url-loader": "^4.0.0",
+    "svg-url-loader": "^3.0.3",
     "transifex": "^1.6.6",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "url-loader": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,8 +64,7 @@ module.exports = {
       {
         test: /\.svg/,
         use: {
-          loader: 'svg-url-loader?limit=1',
-          options: {esModule: false }
+          loader: 'svg-url-loader?limit=1'
         }
       },
       {


### PR DESCRIPTION
This pull request makes the following changes:
- Bringing back svg-url-loader to 3.0.3

Testing checklist:
- [ ] Smoke-tests, svgs should be visible in all browsers

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
