### PR TITLE
adding demo and basic to tier-names + fixing tabs in table

### DIFF
--- a/app/settings/plans/plan.html
+++ b/app/settings/plans/plan.html
@@ -30,7 +30,7 @@
             <div class="tiers" role="article">
                 <nav class="tabs-menu init" data-tabs="pricing-tabs">
                     <ul>
-                        <li id="basic-li" >
+                        <li id="basic-li" class="active" >
                             <a href="#" ng-click="switchTab('basic')">
                                 Ushahidi Basic
                                 <span class="tabs-label">Self Service</span>
@@ -47,7 +47,7 @@
                     </ul>
                 </nav>
 
-                <div class="tier pricing-tabs tabs-target" id="basic">
+                <div class="tier pricing-tabs tabs-target active" id="basic">
                     <span class="tier-label">Self Service</span>
                     <div class="tier-summary">
                         <div class="tier-description">

--- a/app/settings/plans/plans.controller.js
+++ b/app/settings/plans/plans.controller.js
@@ -38,7 +38,7 @@ function (
     $rootScope.setLayout('layout-c');
     window.scrollTo(0, 0);
     $scope.switchTab = switchTab;
-    $scope.activeTab = 'demo';
+    $scope.activeTab = 'basic';
     $translate('nav.plan_settings').then(function (title) {
         $scope.title = title;
         $rootScope.$emit('setPageTitle', title);

--- a/app/settings/settings-list.controller.js
+++ b/app/settings/settings-list.controller.js
@@ -27,7 +27,9 @@ function (
         'surveyor': 'Surveyor',
         'responder': 'Responder',
         'free-pre-jun-2016': 'Mapper (Legacy)',
-        'zerorated': 'Social Impact'
+        'zerorated': 'Social Impact',
+        'demo_1' : 'Ushahidi Demo',
+        'level_1': 'Ushahidi Basic'
     };
     $scope.dataExportTitle = 'settings.settings_list.export';
     $scope.dataExportDescription = 'settings.settings_list.export_desc';


### PR DESCRIPTION
This pull request makes the following changes:
- Adding plan-name to settings-list

Testing checklist:
- Go to settings
- Look at the Plans-option
- [ ] The note should say what plan you currently have.
-  Click on plans
-  Make window smaller so only one plan is visible
- [ ] Plan-description should be visible
- Click on the tab that is not visible
- [ ] Plan visible should switch
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
