### PR TITLE
(Fix) User search - X button does not clear contents in search field.

### DIFF
--- a/app/common/directives/filter-system/filter-searchbar.html
+++ b/app/common/directives/filter-system/filter-searchbar.html
@@ -11,7 +11,7 @@
                 ng-model="model.q"
                 ng-focus="showSearchResults()"
                 ng-keyup="detectSubmit($event)"
-                ng-value="model.q"
+                ng-value="model.q=''"
             >
             <svg class="iconic" ng-show="!form.q.$viewValue.length">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- User search -X button clears contents in search field even when used multiple times.

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3656 .

Ping @ushahidi/platform
