### PR TITLE
Fix - Number of selected user(s) remains same even after deletion.

### DIFF
--- a/app/settings/users/users.controller.js
+++ b/app/settings/users/users.controller.js
@@ -92,6 +92,7 @@ function (
 
             $q.all(calls).then(function () {
                 Notify.notify('notify.user.bulk_destroy_success');
+                $scope.selectedUsers.length = 0;
                 $scope.getUsersForPagination();
             }, handleResponseErrors)
             .finally($scope.filterRole);


### PR DESCRIPTION
This pull request makes the following changes:
- The selected user count is now set to zero when the users are deleted in bulk action which was previously not updated.

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3853 .

Ping @ushahidi/platform
