### PR TITLE
Removed share button from post creation page

### DIFF
--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -35,7 +35,6 @@
               </button>
           </div>
           <div class="button-group" ng-show="!post.id">
-              <post-share button="true" ng-show="!post.id"></post-share>
               <button type="submit" class="button-alpha"  ng-if="!saving_post">{{submit}}</button>
               <button type="submit" class="button-alpha"  disabled ng-if="saving_post">{{submitting}}
                 <div class="loading">


### PR DESCRIPTION
This pull request makes the following changes:
- Removes the share button from the post creation page.

Testing checklist:

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3897 .

Screenshot:
![Screenshot from 2020-03-24 23-24-51](https://user-images.githubusercontent.com/33249010/77460140-b902c300-6e26-11ea-89a6-d861d5ef7cb9.png)

