### PR TITLE
fix: csv column titles not shown in FF

### DIFF
--- a/app/settings/data-import/data-import.html
+++ b/app/settings/data-import/data-import.html
@@ -150,7 +150,9 @@
                                 <div class="form-field select" data-fieldgroup-target="status-model-columns" ng-show="isStatusOption('defined_column')">
                                     <div class="custom-select">
                                       <select ng-model="selectedStatus">
-                                         <option ng-repeat="column in csv.columns track by $index" value="{{$index}}" label="{{column}}" >
+                                          <option ng-repeat="column in csv.columns track by $index" value="{{$index}}">
+                                              {{column}}
+                                          </option>
                                       </select>
                                     </div>
                                     <p><em translate="data_import.status_explanation">Ushahidi recognizes one of three post statuses: Published, Under review, and Archived. So be sure that each entry in the column you select has one of those three values.</em></p>
@@ -183,7 +185,9 @@
                                                 <option selected="selected" value="" translate="data_import.leave_empty">
                                                     Leave empty
                                                 </option>
-                                                 <option ng-repeat="column in csv.columns track by $index" value="{{$index}}" label="{{column}}" >
+                                                <option ng-repeat="column in csv.columns track by $index" value="{{$index}}">
+                                                      {{column}}
+                                                </option>
                                               </select>
                                           </div>
                                       </td>


### PR DESCRIPTION
This pull request makes the following changes:
- makes sure the dropdown list is shown correctly in all browsers

Testing checklist:
- [x] check the import in Chrome
- [x] check the import in Firefox

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3903 .

Ping @ushahidi/platform
