### PR TITLE
Fix - Tell user video link is broken even though valid.

### DIFF
--- a/app/main/posts/modify/post-video.directive.js
+++ b/app/main/posts/modify/post-video.directive.js
@@ -64,6 +64,7 @@ function PostVideoController(
             // NOTE: It is very important to pay special attention to the santization needs of this regex if it is changed.
             // It is important that it does not allow subdomains other than player or www in order to ensure that a malicious user
             // can not exploit this field to insert malicious content in an iframe
+            console.log($scope.api_key);
             var match = url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
             var testUrl = undefined;
             $scope.videoUrl = undefined;
@@ -71,7 +72,7 @@ function PostVideoController(
                 if (match[3].indexOf('youtu') > -1) {
                     // Here we make a statement of trust of the URL based on having pulled out just the id
                     $scope.videoUrl = 'https://www.youtube.com/embed/' + match[6];
-                    testUrl = 'https://www.youtube.com/oembed?url=' + $scope.videoUrl + '&format=json';
+                    testUrl = 'https://www.googleapis.com/youtube/v3/videos?id=' + match[6] + '&key=' + $scope.api_key + '&part=snippet';
                     $.ajax({
                         url: testUrl,
                         type: 'GET',

--- a/app/main/posts/modify/post-video.directive.js
+++ b/app/main/posts/modify/post-video.directive.js
@@ -64,7 +64,6 @@ function PostVideoController(
             // NOTE: It is very important to pay special attention to the santization needs of this regex if it is changed.
             // It is important that it does not allow subdomains other than player or www in order to ensure that a malicious user
             // can not exploit this field to insert malicious content in an iframe
-            console.log($scope.api_key);
             var match = url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
             var testUrl = undefined;
             $scope.videoUrl = undefined;
@@ -72,18 +71,19 @@ function PostVideoController(
                 if (match[3].indexOf('youtu') > -1) {
                     // Here we make a statement of trust of the URL based on having pulled out just the id
                     $scope.videoUrl = 'https://www.youtube.com/embed/' + match[6];
-                    testUrl = 'https://www.googleapis.com/youtube/v3/videos?id=' + match[6] + '&key=' + $scope.api_key + '&part=snippet';
-                    $.ajax({
-                        url: testUrl,
-                        type: 'GET',
-                        success: function(data) {
-                            $scope.video = $sce.trustAsResourceUrl($scope.videoUrl);
-                        },
-                        error: function() {
-                            $scope.videoUrl = undefined;
-                            urlError(url);
-                        }
-                    });
+                    // testUrl = 'https://www.googleapis.com/youtube/v3/videos?id=' + match[6] + '&key=' + $scope.api_key + '&part=snippet';
+                    // $.ajax({
+                    //     url: testUrl,
+                    //     type: 'GET',
+                    //     success: function(data) {
+                    //         $scope.video = $sce.trustAsResourceUrl($scope.videoUrl);
+                    //     },
+                    //     error: function() {
+                    //         $scope.videoUrl = undefined;
+                    //         urlError(url);
+                    //     }
+                    // });
+                    $scope.video = $sce.trustAsResourceUrl($scope.videoUrl);
                 } else if (match[3].indexOf('vimeo') > -1) {
                     // Here we make a statement of trust of the URL based on having pulled out just the id
                     $scope.videoUrl = 'https://player.vimeo.com/video/' + match[6];

--- a/app/main/posts/modify/video.html
+++ b/app/main/posts/modify/video.html
@@ -10,7 +10,7 @@
       <img src="/img/vimeo.png" class="wordmark-replace">
       <span translate="post.video.video_url"> video URL</span>
     </p>
-    <input type="text" ng-model="videoUrl" ng-change="constructIframe(videoUrl)" placeholder="https://youtu.be/123456">
+    <input type="text" ng-model="videoUrl" ng-blur="constructIframe(videoUrl)" placeholder="https://youtu.be/123456">
 
     <div id="{{previewId}}" class="form-field-preview" ng-show="videoUrl">
       <div class="video_embed-fluid">


### PR DESCRIPTION
This pull request makes the following changes:
- This tells user if video url is playable or not even though it matches youtube/vimeo url.

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3612 .

Ping @ushahidi/platform
