### PR TITLE
Video label

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -844,10 +844,7 @@
             "error_in_upload": "Your image is too large (maximum size is 1MB) or has the wrong format (allowed formats are gif, png, jpg and jpeg), please check and try again!"
         },
         "video" : {
-            "enter_a" : "Enter a",
-            "or" : " or ",
-            "vimeo" : " Vimeo",
-            "video_url" : " video URL"
+            "enter_a_url": "Enter a video URL from Youtube or Vimeo."
         },
         "unstructured" : {
             "add_survey" : {

--- a/app/main/posts/modify/video.html
+++ b/app/main/posts/modify/video.html
@@ -2,13 +2,7 @@
 <form>
   <div class="form-field video_embed">
     <label>{{label}}</label>
-    <p>
-      <span translate="post.video.enter_a">Enter a</span>
-
-      <img src="/img/youtube.png" class="wordmark-replace">
-      <span translate="post.video.or"> or </span>
-      <img src="/img/vimeo.png" class="wordmark-replace">
-      <span translate="post.video.video_url"> video URL</span>
+    <p translate="post.video.enter_a_url">Enter a video URL from Youtube or Vimeo.
     </p>
     <input type="text" ng-model="videoUrl" ng-blur="constructIframe(videoUrl)" placeholder="https://youtu.be/123456">
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,10 @@ module.exports = {
       {
         test: /\.png/,
         use: {
-          loader: 'url-loader?limit=10000'
+          loader: 'url-loader?limit=10000',
+          options: {
+            esModule:false
+          }
         }
       },
       {


### PR DESCRIPTION
This pull request makes the following changes:
- Removing images for Youtube and Vimeo
-  Disabling esModules for url-loader (the underlying cause to why the images was not loaded)

Testing checklist:
- [ ] Add a post to a survey that accepts video-links
- [ ] The label should say "Enter a video URL from Youtube or Vimeo." and no logos should be seen.

- [ x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
