### PR TITLE
Revert "Removed share button from post creation page"

### DIFF
--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -35,6 +35,7 @@
               </button>
           </div>
           <div class="button-group" ng-show="!post.id">
+              <post-share button="true" ng-show="!post.id"></post-share>
               <button type="submit" class="button-alpha"  ng-if="!saving_post">{{submit}}</button>
               <button type="submit" class="button-alpha"  disabled ng-if="saving_post">{{submitting}}
                 <div class="loading">


### PR DESCRIPTION
Reverts ushahidi/platform-client#1474
@Obadha2 provided super valuable feedback here. There is a proper use case for this, essentially someone wanting to share the "create a post" link. 
While I don't love this approach, we can't remove it without a replacement IMO. 
Reverting. 