### PR TITLE
Mapbox cannot be used without an API Key provided by the deployer

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -97,7 +97,7 @@ angular.module('app',
         OAUTH_CLIENT_SECRET      : '35e7f0bca957836d05ca0492211b0ac707671261',
         CLAIMED_ANONYMOUS_SCOPES : claimedAnonymousScopes,
         CLAIMED_USER_SCOPES      : ['*'],
-        MAPBOX_API_KEY           : window.ushahidi.mapboxApiKey || 'pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw', // Default OSS mapbox api key
+        MAPBOX_API_KEY           : window.ushahidi.mapboxApiKey, // Default OSS mapbox api key
         USH_DISABLE_CHECKS       : ushDisableChecks,
         TOS_RELEASE_DATE         : new Date(window.ushahidi.tosReleaseDate).toJSON() ? new Date(window.ushahidi.tosReleaseDate) : false, // Date in UTC
         EXPORT_POLLING_INTERVAL  : window.ushahidi.export_polling_interval || 30000

--- a/app/common/services/maps.js
+++ b/app/common/services/maps.js
@@ -6,15 +6,18 @@ function Maps(ConfigEndpoint, L, _, CONST) {
         baselayers : {
             satellite: {
                 name: 'Satellite',
+                provider: 'mapbox',
                 url: 'https://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?access_token={apikey}',
                 layerOptions: {
                     apikey: CONST.MAPBOX_API_KEY,
+                    provider: 'mapbox',
                     mapid: 'mapbox.satellite',
                     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>, &copy; <a href="https://www.mapbox.com/about/maps/"">Mapbox</a> | <a href="https://www.mapbox.com/feedback/" target="_blank">Improve the underlying map</a>'
                 }
             },
             streets: {
                 name: 'Streets',
+                provider: 'mapbox',
                 url: 'https://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?access_token={apikey}',
                 layerOptions: {
                     apikey: CONST.MAPBOX_API_KEY,
@@ -24,6 +27,7 @@ function Maps(ConfigEndpoint, L, _, CONST) {
             },
             hOSM: {
                 name: 'Humanitarian',
+                provider: 'openstreetmap',
                 url: '//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
                 layerOptions: {
                     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>, &copy; <a href="http://hot.openstreetmap.org/">Humanitarian OpenStreetMap</a> | <a href="https://www.mapbox.com/feedback/" target="_blank">Improve the underlying map</a>'
@@ -84,8 +88,10 @@ function Maps(ConfigEndpoint, L, _, CONST) {
 
     function getLeafletConfig() {
         return getConfig().then(function (config) {
-            var defaultLayer = layers.baselayers[config.default_view.baselayer];
-
+            const layer = getSelectedBaseLayer(config.default_view.baselayer);
+            console.log(layer);
+            var defaultLayer = layers.baselayers[layer];
+            console.log(defaultLayer);
             return angular.extend(defaultConfig(),
             {
                 layers: [L.tileLayer(defaultLayer.url, defaultLayer.layerOptions)],
@@ -95,8 +101,16 @@ function Maps(ConfigEndpoint, L, _, CONST) {
             });
         });
     }
-
+    function getSelectedBaseLayer(layer) {
+        if (!CONST.MAPBOX_API_KEY && layers.baselayers[layer].provider === 'mapbox') {
+            return 'hOSM';
+        }
+        return layer;
+    }
     function getBaseLayers() {
+        if (!CONST.MAPBOX_API_KEY) {
+            return _.filter(layers.baselayers, (l => l.provider !== 'mapbox'));
+        }
         return layers.baselayers;
     }
     /* eslint-disable */


### PR DESCRIPTION
This pull request makes the following changes:
- Do not list Mapbox layers in the settings panel if the deployer did not setup the key for it
- If you had selected a mapbox layer but do not have a key, we switch to OSM


Testing checklist:
- [ ] Change your default map layer to be 'streets' or 'satellite'
- [ ] Remove your mapbox api key in the client
- [ ] Go to settings. Check that you can no longer use any other layers except `humanitarian`. Do not change anything.
- [ ] Go to the map. You should be seeing the humanitarian layer load.
- [ ] Edit your settings to use humanitarian
- [ ] Go to the map. You should be seeing the humanitarian layer load.

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
