### PR TITLE
fix(md-editor): Migrating to Toast-editor 2.0.1

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -153,7 +153,7 @@ angular.module('app',
         return require('sortablejs/Sortable');
     })
     .factory('Editor', function () {
-        return require('tui-editor');
+        return require('@toast-ui/editor');
     })
     // inject the router instance into a `run` block by name
     //.run(['$uiRouter', '$trace', '$location', function ($uiRouter, $trace, $location) {

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -40,7 +40,7 @@ function (
                     usageStatistics: false
                 });
 
-                $scope.editor.setValue($scope.editAttribute.instructions);
+                $scope.editor.setMarkdown($scope.editAttribute.instructions);
                 /** This is a hack to override the tui-editor's own inline-style
                  * that makes the scroll get stuck inside the editor-area */
                 let editor = document.querySelector('#editSection');
@@ -50,7 +50,7 @@ function (
             initiateEditor();
 
             $scope.save = function (editAttribute, activeTask) {
-                editAttribute.instructions = $scope.editor.getValue();
+                editAttribute.instructions = $scope.editor.getMarkdown();
                 if (!$scope.attributeLabel.$invalid) {
                     $scope.editAttribute.label = $scope.label;
                     $scope.addNewAttribute(editAttribute, activeTask);

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "dependencies": {
+    "@toast-ui/editor": "2.0.1",
     "@uirouter/angularjs": "^1.0.10",
     "URIjs": "^1.14.1",
     "angular": "^1.5.6",
@@ -127,7 +128,6 @@
     "raven-js": "^3.26.3",
     "socket.io-client": "2.0.3",
     "sortablejs": "1.10.0",
-    "tui-editor": "^1.4.7",
     "underscore": "^1.7.0",
     "ushahidi-platform-pattern-library": "^4.4.1"
   },

--- a/sass/overrides/_tui-markdown.scss
+++ b/sass/overrides/_tui-markdown.scss
@@ -25,8 +25,12 @@
 // Fixes position and appearance of link-popup
 .tui-popup-wrapper {
     width: 250px;
-    left: 20%;
+    margin-left: -150px;
     padding: 0px 10px 10px 10px !important;
+
+    &.te-heading-add {
+        margin-left: 10px;
+    }
 
     .tui-popup-header {
         padding: 10px 0px;


### PR DESCRIPTION
This pull request makes the following changes:
- Migrating to newest version of toast-editor
- Fixing css-overrides that needed to change in new version

Testing checklist:
- [ ] Go to settings -> surveys
- [ ] Create a new survey
- Click on one of the title or description-fields
- [ ] It should be possible to add text in the description-editor
- Add some text in the editor
-  Click Update
-  Add a new field (any kind)
- [ ] It should be possible to add text in the description-editor
- Add some text in the editor
-  Click Update
- Save the survey
- Go back to the survey
- [ ] The description for the fields where description was added should still be there

- Repeat for an existing survey

Possible other areas affected:
- Adding and editing posts (is the description visible)


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
