### PR TITLE
fix(md-editor): Importing correct css-files

### DIFF
--- a/sass/vendor.scss
+++ b/sass/vendor.scss
@@ -12,10 +12,8 @@
 @import "~leaflet.markercluster/dist/MarkerCluster.Default";
 @import "~leaflet.locatecontrol/src/L.Control.Locate";
 @import "~nvd3/build/nv.d3";
-@import '~tui-editor/dist/tui-editor.css'; // editor's ui
-@import '~tui-editor/dist/tui-editor-contents.css'; // editor's content
-@import '~codemirror/lib/codemirror.css'; // codemirror
-@import '~highlight.js/styles/github.css'; // code block highlight
+@import '~@toast-ui/editor/dist/toastui-editor-viewer.css'; // editor's ui
+@import '~@toast-ui/editor/dist/toastui-editor.css'; // editor's content
 
 
 // Custom overrides


### PR DESCRIPTION
This pull request makes the following changes:
- Updates paths to css for new Toast-editor version

Testing checklist:
- [ ] Run gulp build
- [ ] Build should not fail
- Plus checklist in https://github.com/ushahidi/platform-client/pull/1502

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
