### PR TITLE
ci(actions): ship docker image after test

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test & Ship
 
 on:
 - push
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -53,3 +53,38 @@ jobs:
 
         #
         # gulp send-stats-to-coveralls ;
+
+  ship:
+    needs: [ test ]
+    if: github.event_name == 'push'   # not on PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Get ECR password
+      id: get-ecr-password
+      run: echo "::set-output name=password::$(aws ecr get-login-password)"
+
+    - name: Build and push to Amazon ECR
+      uses: docker/build-push-action@v1
+      with:
+        registry: 513259414768.dkr.ecr.eu-west-1.amazonaws.com
+        repository: platform-client
+        username: AWS
+        password: ${{ steps.get-ecr-password.outputs.password }}
+        always_pull: true
+        tag_with_sha: true
+        tag_with_ref: true
+
+    - name: Logout from Amazon ECR
+      if: always()
+      run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
This pull request makes the following changes:
- Builds and pushes docker image to AWS ECR registry after successful test run

Testing checklist:
- [ ] Run workflow successfully

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
