### PR TITLE
FIX: Closing text-area tag #4024

### DIFF
--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -7,7 +7,7 @@
 
     <div class="form-field">
         <label class="input-label" translate>set.description</label>
-        <textarea ng-model="cpySavedSearch.description" />
+        <textarea ng-model="cpySavedSearch.description"></textarea>
     </div>
 
     <!-- Who can see? -->


### PR DESCRIPTION
This pull request makes the following changes:
- Closes a tag that made the html below it go missing in production

Testing checklist:
- Login
- Click on filter-dropdown in map or data-view
- Select a saved search
- Click on "Edit" or "Update"
- [ ] You should see the whole modal with role-selector, close and save-buttons.


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
