### PR TITLE
Removing auto-update of filters in map-view

### DIFF
--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -23,7 +23,7 @@ function FilterPostsController($scope, PostFilters, $state, $document, $element)
     $scope.showDropdown = showDropdown;
     $scope.removeQueryFilter = removeQueryFilter;
     $scope.applyFilters = applyFilters;
-    PostFilters.reactiveFilters = false;
+    PostFilters.reactToFilters = false;
     activate();
 
     function activate() {
@@ -44,7 +44,7 @@ function FilterPostsController($scope, PostFilters, $state, $document, $element)
     }
 
     function applyFilters() {
-        PostFilters.reactiveFilters = true;
+        PostFilters.reactToFilters = true;
         $scope.status.isopen = false;
     }
 

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -61,8 +61,5 @@ function FiltersDropdownController($scope, $state, PostFilters, ModalService, $r
         $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
         ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', modalHeaderText, 'star', $scope, false, false);
     };
-    $scope.disableApplyButton = function () {
-        return $state.$current.includes['posts.map'] ? true : false;
-    };
 }
 

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -26,5 +26,5 @@
 </div>
 <div class="form-field filter-actions">
     <button type="button" class="button-beta" ng-click="clearFilters()" translate>global_filter.restore_defaults</button>
-    <button type="submit" class="button-alpha" ng-disabled="disableApplyButton()" translate>app.apply_filters</button>
+    <button type="submit" class="button-alpha" translate>app.apply_filters</button>
 </div>

--- a/app/main/posts/views/post-filters.service.js
+++ b/app/main/posts/views/post-filters.service.js
@@ -33,7 +33,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         cleanUIFilters: cleanUIFilters,
         cleanRemovedValuesFromObject: cleanRemovedValuesFromObject,
         addIfCurrentObjectMatchesOriginal: addIfCurrentObjectMatchesOriginal,
-        reactiveFilters: true,
+        reactToFilters: true,
         /**
          * This flag is used to syncronize the "internalChange" state globally
          * (useful between filters bug icons and checkboxes).
@@ -163,7 +163,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         // Replace filterState with defaults
         angular.copy(getDefaults(), filterState);
         // Trigger reactive filters
-        this.reactiveFilters = true;
+        this.reactToFilters = true;
         return filterState;
     }
 
@@ -216,7 +216,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
                 if (key === 'saved_search') {
                     return true;
                 }
-                if (key === 'reactiveFilters') {
+                if (key === 'reactToFilters') {
                     return true;
                 }
                 // Is value empty?
@@ -302,7 +302,7 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
         return _.omit(
             filters,
             function (value, key, object) {
-                if (key === 'reactiveFilters') {
+                if (key === 'reactToFilters') {
                     return true;
                 }
                 // Ignore difference in saved_search

--- a/app/main/posts/views/post-view-data.directive.js
+++ b/app/main/posts/views/post-view-data.directive.js
@@ -153,12 +153,12 @@ function PostViewDataController(
         } else {
             getPosts(false, false);
         }
-        // whenever the reactiveFilters var changes, do a dummy update of $scope.filters.reactiveFilters
+        // whenever the reactToFilters varable is set to true, do a dummy update of $scope.filters.reactToFilters
         // to force the $scope.filters watcher to run
         $scope.$watch(function () {
-            return PostFilters.reactiveFilters;
+            return PostFilters.reactToFilters;
         }, function () {
-            if (PostFilters.reactiveFilters === true) {
+            if (PostFilters.reactToFilters === true) {
                 $scope.filters.reactToFilters = $scope.filters.reactToFilters ? !$scope.filters.reactToFilters : true;
             }
         }, true);
@@ -166,9 +166,9 @@ function PostViewDataController(
         $scope.$watch(function () {
             return $scope.filters;
         }, function (newValue, oldValue) {
-            if (PostFilters.reactiveFilters === true && (newValue !== oldValue)) {
+            if (PostFilters.reactToFilters === true && (newValue !== oldValue)) {
                 getPosts(false, false, true, goToFirstPostIfPostDoesNotMatchFilters);
-                PostFilters.reactiveFilters = false;
+                PostFilters.reactToFilters = false;
             }
         }, true);
         $scope.$watch('selectedPosts.length', function () {

--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -123,17 +123,24 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
         function watchFilters() {
             // whenever filters change, reload the posts on the map
             $scope.$watch(function () {
+                return PostFilters.reactToFilters;
+            }, function () {
+                if (PostFilters.reactToFilters === true) {
+                    $scope.filters.reactToFilters = $scope.filters.reactToFilters ? !$scope.filters.reactToFilters : true;
+                }
+            }, true);
+            $scope.$watch(function () {
                 return $scope.filters;
             }, function (newValue, oldValue) {
                 var diff = _.omit(newValue, function (value, key, obj) {
                     return _.isEqual(oldValue[key], value);
                 });
                 var diffLength = _.keys(diff).length;
-
-                if (diffLength > 0) {
+                if (PostFilters.reactToFilters === true && diffLength > 0) {
                     cancelCurrentRequests();
                     clearData();
                     reloadMapPosts();
+                    PostFilters.reactToFilters = false;
                 }
             }, true);
         }

--- a/test/unit/main/post/views/filters/filters-posts.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-posts.directive.spec.js
@@ -58,13 +58,13 @@ describe('filters-posts directive', function () {
     }));
 
     describe('test directive functions', function () {
-        it('reactiveFilters should be false', function () {
-            expect(PostFilters.reactiveFilters).toEqual(false); // revisit where we set the default for this?
+        it('reactToFilters should be false', function () {
+            expect(PostFilters.reactToFilters).toEqual(false); // revisit where we set the default for this?
         });
-        it('should enable reactiveFilters when I call applyFiltersLocked', function () {
-            expect(PostFilters.reactiveFilters).toEqual(false);
+        it('should enable reactToFilters when I call applyFiltersLocked', function () {
+            expect(PostFilters.reactToFilters).toEqual(false);
             isolateScope.applyFilters();
-            expect(PostFilters.reactiveFilters).toEqual(true);
+            expect(PostFilters.reactToFilters).toEqual(true);
         });
         it('should clear PostFilters when calling clearFilters', function () {
             isolateScope.removeQueryFilter();


### PR DESCRIPTION
This pull request makes the following changes:
- Makes it required to click "Apply" before the filters are applied in map-view (same behaviour as Data-view)

Testing checklist:
- Go to map-view
- Click on the filters-dropdown and select a number of filters
- Click on Apply
- [ ] The filters becomes applied
- Go back to the filters dropdown and change the selection of filters
- Click outside of the dropdown to close it
- [ ] The filters are not applied

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#3946 .

Ping @ushahidi/platform
