### PR TITLE
Enabling button in map-view

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -85,6 +85,7 @@
         "filter_by" :"Filter by...",
         "sort_filter": "Sort & filter",
         "apply_filters" : "Apply",
+        "close_and_view": "Close and view results",
         "show_more_less" : "Show more/less",
         "filters" : "Filters",
         "filter_by_survey" : "Filter by survey",

--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -44,7 +44,9 @@ function FilterPostsController($scope, PostFilters, $state, $document, $element)
     }
 
     function applyFilters() {
-        PostFilters.reactiveFilters = true;
+        if ($state.$current.includes['posts.data']) {
+            PostFilters.reactiveFilters = true;
+        }
         $scope.status.isopen = false;
     }
 

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -61,5 +61,12 @@ function FiltersDropdownController($scope, $state, PostFilters, ModalService, $r
         $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
         ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', modalHeaderText, 'star', $scope, false, false);
     };
+
+    $scope.getButtonText = function () {
+        if ($state.$current.includes['posts.map']) {
+            return 'app.close_and_view';
+        }
+        return 'app.apply_filters';
+    }
 }
 

--- a/app/main/posts/views/filters/filters-dropdown.directive.js
+++ b/app/main/posts/views/filters/filters-dropdown.directive.js
@@ -61,8 +61,5 @@ function FiltersDropdownController($scope, $state, PostFilters, ModalService, $r
         $scope.savedSearch.user_id = $rootScope.currentUser ? $rootScope.currentUser.userId : null;
         ModalService.openTemplate('<saved-search-editor saved-search="savedSearch"></saved-search-editor>', modalHeaderText, 'star', $scope, false, false);
     };
-    $scope.disableApplyButton = function () {
-        return $state.$current.includes['posts.map'] ? true : false;
-    };
 }
 

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -26,5 +26,4 @@
 </div>
 <div class="form-field filter-actions">
     <button type="button" class="button-beta" ng-click="clearFilters()" translate>global_filter.restore_defaults</button>
-    <button type="submit" class="button-alpha" translate>app.apply_filters</button>
-</div>
+    <button type="submit" class="button-alpha" translate>{{getButtonText()}}</button></div>

--- a/app/main/posts/views/filters/filters-dropdown.html
+++ b/app/main/posts/views/filters/filters-dropdown.html
@@ -26,5 +26,5 @@
 </div>
 <div class="form-field filter-actions">
     <button type="button" class="button-beta" ng-click="clearFilters()" translate>global_filter.restore_defaults</button>
-    <button type="submit" class="button-alpha" ng-disabled="disableApplyButton()" translate>app.apply_filters</button>
+    <button type="submit" class="button-alpha" translate>app.apply_filters</button>
 </div>

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -80,6 +80,19 @@ describe('post filters-dropdown directive', function () {
             isolateScope.saveSavedSearchModal();
             expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
         });
+        it('should return currect button text', function () {
+            mockState.$current.includes = {
+                'posts': true,
+                'posts.map': true
+            };
+            expect(isolateScope.getButtonText()).toEqual('app.close_and_view');
+            mockState.$current.includes = {
+                'posts': true,
+                'posts.data': true,
+                'posts.map': false
+            };
+            expect(isolateScope.getButtonText()).toEqual('app.apply_filters');
+        });
     });
     describe('test children', function () {
         it('should have a filter-post-order-asc-desc directive child', function () {

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -80,16 +80,6 @@ describe('post filters-dropdown directive', function () {
             isolateScope.saveSavedSearchModal();
             expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
         });
-        it('should return false when calling disableApplyButton if in data-view', function () {
-            expect(isolateScope.disableApplyButton()).toEqual(false);
-        });
-        it('should return true when calling disableApplyButton if in map-view', function () {
-            mockState.$current.includes = {
-                    'posts': true,
-                    'posts.map': true
-                };
-            expect(isolateScope.disableApplyButton()).toEqual(true);
-        });
     });
     describe('test children', function () {
         it('should have a filter-post-order-asc-desc directive child', function () {

--- a/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-dropdown.directive.spec.js
@@ -80,7 +80,7 @@ describe('post filters-dropdown directive', function () {
             isolateScope.saveSavedSearchModal();
             expect(ModalService.openTemplate).toHaveBeenCalledTimes(1);
         });
-        it('should return currect button text', function () {
+        it('should return correct button text', function () {
             mockState.$current.includes = {
                 'posts': true,
                 'posts.map': true

--- a/test/unit/main/post/views/filters/filters-posts.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-posts.directive.spec.js
@@ -5,17 +5,25 @@ describe('filters-posts directive', function () {
         PostFilters,
         element,
         isolateScope,
-        $compile;
+        $compile,
+        mockState = {
+            '$current': {
+                name: 'posts.data',
+                includes: {
+                    'posts': true,
+                    'posts.data': true
+                }
+            }
+        };
+;
     beforeEach(function () {
         fixture.setBase('mocked_backend/api/v3');
         var testApp = makeTestApp();
         testApp
         .directive('filterPosts', require('app/main/posts/views/filters/filter-posts.directive'))
         .service('PostFilters', require('app/main/posts/views/post-filters.service.js'))
-        .service('$state', () => {
-            return {
-                go : () => {}
-            };
+        .service('$state', function () {
+            return mockState;
         })
         ;
         angular.mock.module('testApp');


### PR DESCRIPTION
This pull request makes the following changes:
- Enables the apply button in filter-dropdown in map-view
- Changes the text on apply-button in map-view to "Close and see the results"
- Closes the filter-dropdown in map-view when clicking apply-button


Testing checklist:
- Go to map-view
- Click on filters
- Select a number of filters
- [ ] Filters still automatically applies
- Click on "Close and see the results"
- [ ] The filter bar closes
- [ ] You see the filtered results in map-view
- Go to data-view
- Click on filters
- [ ] The text on the button is still "Apply"
- Select a number of filters
- [ ] Filters does not apply
- Click the Apply-button
- [ ] Dropdown closes and the results are visible


- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4050 .

Ping @ushahidi/platform
