### PR TITLE
4051 close filter-dropdown

### DIFF
--- a/app/main/posts/views/filters/filter-posts.directive.js
+++ b/app/main/posts/views/filters/filter-posts.directive.js
@@ -21,6 +21,7 @@ function FilterPostsController($scope, PostFilters, $state, $document, $element)
     $scope.status = { isopen: false };
     $scope.hideDropdown = hideDropdown;
     $scope.showDropdown = showDropdown;
+    $scope.toggleDropdown = toggleDropdown;
     $scope.removeQueryFilter = removeQueryFilter;
     $scope.applyFilters = applyFilters;
     PostFilters.reactiveFilters = false;
@@ -72,5 +73,15 @@ function FilterPostsController($scope, PostFilters, $state, $document, $element)
 
         // Otherwise close the dropdown
         $scope.$apply(hideDropdown);
+    }
+    function toggleDropdown(event) {
+        switch (event.keyCode) {
+            case 27: $scope.hideDropdown();
+                break;
+            case 13: $scope.hideDropdown();
+                break;
+            default:
+                $scope.showDropdown();
+        }
     }
 }

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -15,9 +15,17 @@
         <div class="form-field">
             <label class="hidden" translate="toolbar.searchbar.search_entity">Search</label>
             <div class="input-with-icon">
-                <input name="q" type="search" autocomplete="off"
-                placeholder="{{ 'toolbar.searchbar.search_entity' | translate }}"
-                ng-model="filters.q" ng-model-options="{ debounce: 300 }" ng-click = "showDropdown()" ng-keyup="($event.keyCode === 27)  ? hideDropdown(): showDropdown()" ng-keypress="($event.keyCode === 27) ? hideDropdown(): showDropdown()">
+                <input 
+                    name="q"
+                    type="search"
+                    autocomplete="off"
+                    placeholder="{{ 'toolbar.searchbar.search_entity' | translate }}"
+                    ng-model="filters.q"
+                    ng-model-options="{debounce: 300}"
+                    ng-click = "toggleDropdown($event)"
+                    ng-keyup="toggleDropdown($event)"
+                    ng-keypress="toggleDropdown($event)"
+                >
                 <svg class="iconic" ng-show="!postFiltersFormOpen.q.$viewValue.length">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>

--- a/test/unit/main/post/views/filters/filters-posts.directive.spec.js
+++ b/test/unit/main/post/views/filters/filters-posts.directive.spec.js
@@ -78,5 +78,26 @@ describe('filters-posts directive', function () {
             isolateScope.removeQueryFilter();
             expect(isolateScope.filters.q).toEqual('');
         });
+        it('should close dropdown when pressing escape', function () {
+            spyOn(isolateScope, 'hideDropdown').and.callThrough();
+            let event = {keyCode: 13};
+            isolateScope.toggleDropdown(event);
+            expect(isolateScope.hideDropdown).toHaveBeenCalled();
+            expect(isolateScope.status.isopen).toEqual(false);
+        });
+        it('should close dropdown when pressing enter', function () {
+            spyOn(isolateScope, 'hideDropdown').and.callThrough();
+            let event = {keyCode: 27};
+            isolateScope.toggleDropdown(event);
+            expect(isolateScope.hideDropdown).toHaveBeenCalled();
+            expect(isolateScope.status.isopen).toEqual(false);
+        });
+        it('should open dropdown when pressing any key except enter and escape', function () {
+            spyOn(isolateScope, 'showDropdown').and.callThrough();
+            let event = {keyCode: 22};
+            isolateScope.toggleDropdown(event);
+            expect(isolateScope.showDropdown).toHaveBeenCalled();
+            expect(isolateScope.status.isopen).toEqual(true);
+        });
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:
- Closes the filter-dropdown and perform search when user clicks enter in keyword-search-bar

Testing checklist:

**In map-view**
- Write something in the filter-keyword-search
- [ ] The dropdown opens
- [ ] You see the keyword in the "active filters" area in the dropdown
- [ ] Search is happening as you write
- Click on "Close and view results"
- [ ] The filtered results are visible

**In data-view**
- Write something in the filter-keyword-search
- [ ] The dropdown opens
- [ ] You see the keyword in the "active filters" area in the dropdown
- [ ] Search is not happening as you write
- Click on "Apply"
- [ ] The filtered results are visible
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4051 .

Ping @ushahidi/platform
