### PR TITLE
FIX: Removing use of current location in embeds #4043

### DIFF
--- a/app/main/posts/modify/location.html
+++ b/app/main/posts/modify/location.html
@@ -14,7 +14,7 @@
                 />
             </div>
             <div id="searchbar-results" class="searchbar-results dropdown-menu init">
-                <div class="form-field">
+                <div class="form-field" embed-only=false>
                     <button class="button-beta button-plain" ng-click="chooseCurrentLocation()" ng-if="showCurrentPositionControl" >
                         <svg class="iconic">
                             <use


### PR DESCRIPTION
This pull request makes the following changes:
- Removing the "Use your current location" in the location-picker for posts when in embeds. The use of geolocation in embeds create the error: "Geolocation error: Geolocation has been disabled in this document by Feature Policy." and confuses both deployers and people adding the posts.

Testing checklist:
In "normal" mode (not embed)
- Create or edit a post for a survey with a location-field
- click on the text-search-bar in the location-picker
- [ ] The button "Use your current location" should be there

In "embed" mode
- Create or edit a post for a survey with a location-field
- click on the text-search-bar in the location-picker
- [ ] The button "Use your current location" should not be there

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
