### PR TITLE
Adds information to posts

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -266,6 +266,7 @@
         "radio_button": "Radio Button(s)",
         "checkbox": "Checkbox(es)",
         "related_post": "Related Post",
+        "related_post_info": "Please note, the posts to relate to needs to be published, posts that are \"Under review\" will not appear in the search-results",
         "upload_image": "Image",
         "embed_video": "Embed video",
         "markdown": "Markdown",

--- a/app/main/posts/modify/relation.html
+++ b/app/main/posts/modify/relation.html
@@ -1,4 +1,5 @@
 <form class="input-relation">
+	<p><em translate="survey.related_post_info">Please note, the posts to relate to needs to be published, posts that are "Under review" will not appear in the search-results</em></p>
 	<p ng-if="model">{{ selectedPost.title }} ({{ model }}) <button class="button-secondary icon-only alt trash" type="button" ng-click="clearPost()" translate></button></p>
     <div class="input-inline">
         <input class="form-control" type="text" placeholder="Search.." ng-model="searchTerm">


### PR DESCRIPTION
This pull request makes the following changes:
- Adds information above the search-box that posts need to be published in related post field.

Test-checklist
- Start adding a post to a survey that have a field for related posts
- [ ] Below the field label, there should be an info-text: "Please note, the posts to relate to needs to be published, posts that are "Under review" will not appear in the search-results"



Fixes ushahidi/platform#4078 .

Ping @ushahidi/platform
