### PR TITLE
Revert "Fix labels for Settings->Categories, Data export and Users"

### DIFF
--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -44,15 +44,13 @@
             <div class="form-sheet">
               <!-- Title -->
               <div class="form-field">
-                <label translate>category.editor.name
-                  <input type="text" placeholder="{{'category.editor.name' | translate}}" ng-minlength="2" ng-maxlength="255" ng-model="category.tag" required>
-                </label>
+                <label translate>category.editor.name</label>
+                <input type="text" placeholder="{{'category.editor.name' | translate}}" ng-minlength="2" ng-maxlength="255" ng-model="category.tag" required>
               </div>
               <!-- Description -->
               <div class="form-field">
-                <label translate>category.editor.description
-                  <textarea name="description" data-min-rows='1' rows='1' ng-maxlength="150" ng-model="category.description"></textarea>
-                </label>
+                <label translate>category.editor.description</label>
+                <textarea name="description" data-min-rows='1' rows='1' ng-maxlength="150" ng-model="category.description"></textarea>
               </div>
               <!-- Parent/child-relations -->
               <fieldset

--- a/app/settings/data-export/data-export.html
+++ b/app/settings/data-export/data-export.html
@@ -113,9 +113,7 @@
                     <p translate>data_export.select_fields_desc</p>
                 </div>
                 <div class="form-field" ng-repeat="form in forms">
-                    <label>
-                        <bdi>{{form.name}}</bdi>
-                    </label>
+                    <label><bdi>{{form.name}}</bdi></label>
                     <div class="form-field checkbox" ng-show="form.attributes">
                         <label>
                             <input

--- a/app/settings/users/users-edit.html
+++ b/app/settings/users/users-edit.html
@@ -41,9 +41,8 @@
             <form name="form">
                 <div class="form-sheet">
                     <div class="form-field init required" ng-class="{ 'error': form.full_name.$invalid && form.full_name.$dirty }">
-                        <label translate>user.full_name
-                            <input type="text" placeholder="{{'user_create.full_name' | translate}}" ng-maxlength="150" ng-model="user.realname" name="full_name" required>
-                        </label>
+                        <label translate>user.full_name</label>
+                        <input type="text" placeholder="{{'user_create.full_name' | translate}}" ng-maxlength="150" ng-model="user.realname" name="full_name" required>
                         <div ng-repeat="(error, value) in form.full_name.$error"
                             ng-show="form.full_name.$dirty"
                             class="alert error">
@@ -55,9 +54,8 @@
                     </div>
 
                     <div class="form-field init required" ng-class="{ 'error': form.email.$invalid && form.email.$dirty }">
-                        <label translate>user.email
-                            <input type="email" placeholder="{{'user_create.email' | translate}}" ng-maxlength="150" ng-model="user.email" name="email" required>
-                        </label>
+                        <label translate>user.email</label>
+                        <input type="email" placeholder="{{'user_create.email' | translate}}" ng-maxlength="150" ng-model="user.email" name="email" required>
                         <div ng-repeat="(error, value) in form.email.$error"
                             ng-show="form.email.$dirty"
                             class="alert error">
@@ -69,9 +67,11 @@
                     </div>
 
                     <div class="form-field init required" ng-class="{ 'error': form.password.$invalid && form.password.$dirty }">
-                        <label translate for="password">user.password</label>
+                        <label translate>user.password</label>
+
                         <a class="button button-flat" ng-show="!passwordShown" ng-click="showPassword()" translate>user.update_password</a>
-                        <input id="password" type="password" ng-show="passwordShown" placeholder="{{'user.password' | translate}}"  ng-minlength="7" ng-maxlength="72" ng-model="user.password" name="password" ng-required="!user.id">
+
+                        <input type="password" ng-show="passwordShown" placeholder="{{'user.password' | translate}}"  ng-minlength="7" ng-maxlength="72" ng-model="user.password" name="password" ng-required="!user.id">
                         <div ng-repeat="(error, value) in form.password.$error"
                             ng-show="form.password.$dirty"
                             class="alert error">


### PR DESCRIPTION
Reverts ushahidi/platform-client#1552
- User creation page has Display name and Email Address fields missing.
<img width="1032" alt="Screen Shot 2020-10-12 at 10 29 20 AM" src="https://user-images.githubusercontent.com/38259840/95717906-5bc14880-0c76-11eb-9214-340384dec6a6.png">

- Category creation page has Category Name and Description fields missing.
<img width="1119" alt="Screen Shot 2020-10-12 at 10 35 20 AM" src="https://user-images.githubusercontent.com/38259840/95718102-a773f200-0c76-11eb-877f-2c89838240f4.png">
