### PR TITLE
Adding role button on a tags #4133

### DIFF
--- a/app/main/posts/collections/mode-context.html
+++ b/app/main/posts/collections/mode-context.html
@@ -112,7 +112,7 @@
         <!--// END IF //-->
         <div class="form-field">
             <!-- mode context bar is only available in the map so it should take you back there -->
-            <a ng-click="clearFilters()" type="button" class="button-link">
+            <a role="button" tabindex="0" ng-click="clearFilters()" type="button" class="button-link">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#arrow-left"></use>
                 </svg>

--- a/app/main/posts/detail/post-messages.html
+++ b/app/main/posts/detail/post-messages.html
@@ -35,7 +35,7 @@
   <div class="listing-item">
     <div class="listing-item-primary">
       <h2 class="listing-item-title">
-        <a href="" class="button button-flat" ng-click="reply()">
+        <a role="button" tabindex="0" href="" class="button button-flat" ng-click="reply()">
           <svg class="iconic">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#plus"></use>
           </svg>

--- a/app/main/posts/savedsearches/mode-context.html
+++ b/app/main/posts/savedsearches/mode-context.html
@@ -112,7 +112,7 @@
         <!--// END IF //-->
         <div class="form-field">
             <!-- mode context is only available in the map so we are always sending you back to it in the return to all posts feature -->
-            <a ng-click="clearFilters()" type="button" class="button-link">
+            <a role="button" tabindex="0" ng-click="clearFilters()" type="button" class="button-link">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#arrow-left"></use>
                 </svg>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -39,7 +39,7 @@
 
     <!-- Toggle Filters show/hide -->
     <div uib-dropdown-toggle class="searchbar-options">
-        <a type="button" class="searchbar-options-filter button">
+        <a role="button" tabindex="0" type="button" class="searchbar-options-filter button">
             <sort-and-filter-counter></sort-and-filter-counter>
         </a>
     </div>

--- a/app/main/posts/views/filters/filter-saved-search.html
+++ b/app/main/posts/views/filters/filter-saved-search.html
@@ -11,7 +11,7 @@
             <option value="" translate="app.select_one">Select one</option>
         </select>
     </div>
-    <a class="button button-beta" ng-show="selectedSavedSearch" ng-click="$parent.editSavedSearchModal('edit')">Edit</a>
+    <a role="button" tabindex="0" class="button button-beta" ng-show="selectedSavedSearch" ng-click="$parent.editSavedSearchModal('edit')">Edit</a>
 </fieldset>
 <fieldset ng-show="loading">
     <label translate="app.saved_search"></label>

--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -50,7 +50,7 @@
         <strong>global_filter.unmapped_one</strong></a> <span translate="global_filter.unmapped_end"></span></p>
 </div>
 <div class="form-field" ng-show="hasManageSettingsPermission()">
-    <a ui-sref="settings.surveys.create" class="button button-link">
+    <a role="button" tabindex="0" ui-sref="settings.surveys.create" class="button button-link">
         <svg class="iconic">
             <use xlink:href="/img/iconic-sprite.svg#plus"></use>
         </svg>

--- a/app/main/posts/views/post-view-unavailable.html
+++ b/app/main/posts/views/post-view-unavailable.html
@@ -2,5 +2,5 @@
     <span translate translate-values="{value: '{{view}}'}">
         feature_limits.view_unavailable
     </span>
-    <p><a class="button" href="/settings/plan" translate>limit.upgrade</a></p>
+    <p><a role="button" tabindex="0" class="button" href="/settings/plan" translate>limit.upgrade</a></p>
 </div>

--- a/app/main/posts/views/share/post-share.html
+++ b/app/main/posts/views/share/post-share.html
@@ -1,4 +1,4 @@
-<a ng-class="{ 'button' : isButton(), 'button-flat': isAdd()}" ng-click="openShareMenu()">
+<a role="button" tabindex="0" ng-class="{ 'button' : isButton(), 'button-flat': isAdd()}" ng-click="openShareMenu()">
 		<div class="loading" ng-if="loading">
 			<div class="line"></div>
 			<div class="line"></div>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixed  https://github.com/ushahidi/platform/issues/4113

- The links that acted as a button in the post folder had no role button or tabindex=0
- Added the` role= button` and `tabindex = 0`  to links (`a tags`) that act like buttons in the app>main>post folder



Testing checklist:
- [x] Go to the post section of the app.

The following buttons were changed
- [x] The link in the post collections with the span text `Return to all posts` that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The `post messages send link` in the post messages that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The link in the saved searches with the span text `Return to all posts` that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The sort and filter link in the` Toggle Filters show/hide` that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The `edit link` in the `filtered saved search show/hide` that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The link with the span text `create a new survey` in the views section that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] The `share` link  in post share section > post-share.html that acted as a `button` now has a `button role` and a `tabindex=0`
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
