### PR TITLE
4044 - Remove default value for fields that don't use it in post created

### DIFF
--- a/app/common/directives/mode-bar/mode-bar.html
+++ b/app/common/directives/mode-bar/mode-bar.html
@@ -32,7 +32,7 @@
             </li>
 
             <li>
-                <a class="more-menu-trigger" ng-class="{ active : moreActive }" ng-click="showMore($event)">
+                <a href="" class="more-menu-trigger" ng-class="{ active : moreActive }" ng-click="showMore($event)">
                     <svg class="iconic">
                         <use xlink:href="/img/iconic-sprite.svg#ellipses"></use>
                     </svg>
@@ -56,39 +56,16 @@
         <!-- user account menu -->
 
             <li>
-                <a href="" ng-click="viewSupportLinks()">
-                    <ng-include src="'common/directives/mode-bar/ushahidi-logo.html'"></ng-include>
-                    <span class="label" translate>app.support</span>
-                </a>
-            </li>
-
-            <li ng-show="currentUser">
-                <a ng-click="logout()" data-modal="login">
+                <a href="" ng-click="viewCollectionListing()">
                     <svg class="iconic">
-                        <use xlink:href="/img/iconic-sprite.svg#account-logout"></use>
+                        <use xlink:href="/img/iconic-sprite.svg#grid-three-up"></use>
                     </svg>
-                    <span class="label" translate="nav.logout">Log out</span>
-                </a>
-            </li>
-
-            <li ng-show="currentUser">
-                <a ng-click="viewAccountSettings()">
-                    <img class="avatar" ng-src="https://www.gravatar.com/avatar/{{ currentUser.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ currentUser.realname }}"/>
-                    <span class="label">{{currentUser.realname || currentUser.email}}</span>
-                </a>
-            </li>
-
-            <li ng-show="!currentUser && canRegister">
-                <a ng-click="register()" data-modal="signup">
-                    <svg class="iconic">
-                        <use xlink:href="/img/iconic-sprite.svg#person"></use>
-                    </svg>
-                    <translate translate="nav.register">Sign up</translate>
+                    <span class="label" translate>nav.collections</span>
                 </a>
             </li>
 
             <li ng-hide="currentUser">
-                <a ng-click="login()" data-modal="login">
+                <a href="" ng-click="login()" data-modal="login">
                     <svg class="iconic">
                         <use xlink:href="/img/iconic-sprite.svg#account-login"></use>
                     </svg>
@@ -96,14 +73,38 @@
                 </a>
             </li>
 
-            <li>
-                <a ng-click="viewCollectionListing()">
+            <li ng-show="!currentUser && canRegister">
+                <a href="" ng-click="register()" data-modal="signup">
                     <svg class="iconic">
-                        <use xlink:href="/img/iconic-sprite.svg#grid-three-up"></use>
+                        <use xlink:href="/img/iconic-sprite.svg#person"></use>
                     </svg>
-                    <span class="label" translate>nav.collections</span>
+                    <translate translate="nav.register">Sign up</translate>
                 </a>
             </li>
+
+            <li ng-show="currentUser">
+                <a href="" ng-click="viewAccountSettings()">
+                    <img class="avatar" ng-src="https://www.gravatar.com/avatar/{{ currentUser.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="{{ currentUser.realname }}"/>
+                    <span class="label">{{currentUser.realname || currentUser.email}}</span>
+                </a>
+            </li>
+
+            <li ng-show="currentUser">
+                <a href="" ng-click="logout()" data-modal="login">
+                    <svg class="iconic">
+                        <use xlink:href="/img/iconic-sprite.svg#account-logout"></use>
+                    </svg>
+                    <span class="label" translate="nav.logout">Log out</span>
+                </a>
+            </li>
+
+            <li>
+                <a href="" ng-click="viewSupportLinks()">
+                    <ng-include src="'common/directives/mode-bar/ushahidi-logo.html'"></ng-include>
+                    <span class="label" translate>app.support</span>
+                </a>
+            </li>
+
         <!-- user account menu -->
         </ul>
 

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -76,6 +76,11 @@ function (
             $scope.canDisableCaption = function () {
                 return $scope.editAttribute.type === 'media' && $scope.editAttribute.input === 'upload';
             };
+
+            //Remove default value for location (variation of $scope.canDisplay)
+            $scope.canDisplayDefaultValue = function () {
+                return $scope.editAttribute.input !== 'upload' && $scope.editAttribute.type !== 'title' && $scope.editAttribute.type !== 'description' && $scope.editAttribute.input !== 'tags' && $scope.editAttribute.input !== 'location';
+            };
         }
     };
 }];

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -92,19 +92,18 @@
            <label class="tgl-btn" for="switchprivateresponse"></label>
         </div>
        </div>
-       <div class="form-field switch" ng-if="canDisplay()">
-            <label translate="app.default_value">Default value (optional):</label>
-            <div class="form-field">
-              <div ng-switch="editAttribute.input">
-                  <input ng-switch-when="location" type="text" placeholder="{{ 'form.default_location_placeholder'|translate }}" ng-model="editAttribute.default">
-                  <input ng-switch-when="date" type="text" date-time="editAttribute.default" ng-model="editAttribute.default">
-                  <input ng-switch-when="int" type="number" step="1" ng-model="editAttribute.default">
-                  <input ng-switch-when="decimal" type="number" ng-model="editAttribute.default">
-                  <input ng-switch-default type="text" placeholder="{{ 'form.default_default_placeholder'|translate }}" ng-model="editAttribute.default">
-              </div>
-            </div>
+       <div class="form-field switch" ng-if="canDisplayDefaultValue()">
+          <label ng-if="canDisplayDefaultValue()" translate="app.default_value">Default value (optional):</label>
+          <div class="form-field">
+             <div ng-switch="editAttribute.input">
+                <input ng-switch-when="location" type="text" placeholder="{{ 'form.default_location_placeholder'|translate }}" ng-model="editAttribute.default">
+                <input ng-switch-when="date" type="text" date-time="editAttribute.default" ng-model="editAttribute.default">
+                <input ng-switch-when="int" type="number" step="1" ng-model="editAttribute.default">
+                <input ng-switch-when="decimal" type="number" ng-model="editAttribute.default">
+                <input ng-switch-default type="text" placeholder="{{ 'form.default_default_placeholder'|translate }}" ng-model="editAttribute.default">
+             </div>
+          </div>
         </div>
-   </div>
    <div class="form-field">
       <button ng-show="!editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="save(editAttribute, activeTask)" translate="app.add_and_close">Add &amp; close</button>
       <button ng-show="editAttribute.id" type="button" class="button-alpha modal-trigger" ng-click="save(editAttribute, activeTask)" translate="app.update_and_close">Update &amp; close</button>


### PR DESCRIPTION
**This pull request makes the following changes:**
- Fixes ushahidi/platform#4044

**Observations:**
Fields that have the default value input found in settings > surveys > create a new survey > add field grouped below with observations stated.

**Default values that show on created post:**
- Short Text
- Long Text
- Select
- Radio Buttons
- Check Boxes
- Mark Down

**Default values that **only** work when the right values are entered (Ask mentors before removing):**
- Number (decimal) e.g. 1
- Number (Integer) e.g 1
- Date e.g 16 October, 2020
- Date & Time e.g 16 October, 2020 7:14 pm
- Embed video e.g https://www.youtube.com/watch?v=vpQDkEgO-kA

Haven't been able to assess this yet (Ask mentors):
- Related post

**Default values that don't work at all in post created:**
- Location

**Steps taken:**
- Changes made in attribute-editor.html and attribute-editor.directive.js. 
- Added new function  ($scope.canDisplayDefaultValue) and included location among the inputs to be omitted/removed in attribute-editor.directive.js. 
- Applied it on the elements to be hidden (location input & label) with ng-If directive.

**Testing checklist:**
- [x] Check for default values that don't work at all in post created
- [x] Remove default values that don't work at all in post created

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
