### PR TITLE
Associated the labels to their respective inputs  #4123

### DIFF
--- a/app/main/activity/activity.html
+++ b/app/main/activity/activity.html
@@ -69,7 +69,9 @@
                                             <svg class="iconic">
                                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
                                             </svg>
-                                            <input type="date" pick-a-date="createdAfter" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="createdAfter" />
+                                            <label>
+                                              <input type="date" pick-a-date="createdAfter" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="createdAfter" />
+                                            </label>  
                                         </div>
                                         <span class="date-joiner">to</span>
                                     </div>
@@ -80,7 +82,9 @@
                                             <svg class="iconic">
                                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
                                             </svg>
-                                            <input type="date" pick-a-date="createdBefore" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="createdBefore">
+                                            <label>
+                                               <input type="date" pick-a-date="createdBefore" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="createdBefore">
+                                            </label>   
                                         </div>
                                     </div>
                                 </div>

--- a/app/main/activity/activity.html
+++ b/app/main/activity/activity.html
@@ -64,27 +64,27 @@
                                 <!-- todo: reuse filter-date -->
                                 <div class="form-fieldgroup">
                                     <div class="form-field date" ng-show="editableInterval == 'custom'">
-                                        <label class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
+                                        <label class="hidden" translate="global_filter.filter_tabs.created_after" for="start-date">Start date</label>
                                         <div class="input-with-icon">
                                             <svg class="iconic">
                                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
                                             </svg>
-                                            <label>
-                                              <input type="date" pick-a-date="createdAfter" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="createdAfter" />
-                                            </label>  
+                                            
+                                              <input id="start-date" type="date" pick-a-date="createdAfter" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="createdAfter" />
+                                            
                                         </div>
                                         <span class="date-joiner">to</span>
                                     </div>
 
                                     <div class="form-field date" ng-show="editableInterval == 'custom'">
-                                        <label class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
+                                        <label class="hidden" translate="global_filter.filter_tabs.created_before" for="end-date">End date</label>
                                         <div class="input-with-icon">
                                             <svg class="iconic">
                                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
                                             </svg>
-                                            <label>
-                                               <input type="date" pick-a-date="createdBefore" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="createdBefore">
-                                            </label>   
+                                            
+                                               <input id="end-date" type="date" pick-a-date="createdBefore" pick-a-date-options="dateOptions" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="createdBefore">
+                                              
                                         </div>
                                     </div>
                                 </div>

--- a/app/main/posts/collections/listing.html
+++ b/app/main/posts/collections/listing.html
@@ -1,15 +1,13 @@
 <div>
     <div class="modal-body" style="max-height: 337.26px;">
         <div class="form-field search">
-            <label class="hidden" translate>set.find_a_collection</label>
+            <label for="find-a-collection" class="hidden" translate>set.find_a_collection</label>
             <div class="input-with-icon">
                 <svg class="iconic">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>
                 <form ng-submit="searchCollections(collectionQuery)">
-                    <label>
-                       <input name="collectionQuery" ng-model="collectionQuery" type="search" placeholder="{{ 'set.find_a_collection' | translate}}">
-                    </label>
+                       <input id="find-a-collection" name="collectionQuery" ng-model="collectionQuery" type="search" placeholder="{{ 'set.find_a_collection' | translate}}">
                 </form>
             </div>
         </div>

--- a/app/main/posts/collections/listing.html
+++ b/app/main/posts/collections/listing.html
@@ -7,7 +7,9 @@
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>
                 <form ng-submit="searchCollections(collectionQuery)">
-                    <input name="collectionQuery" ng-model="collectionQuery" type="search" placeholder="{{ 'set.find_a_collection' | translate}}">
+                    <label>
+                       <input name="collectionQuery" ng-model="collectionQuery" type="search" placeholder="{{ 'set.find_a_collection' | translate}}">
+                    </label>
                 </form>
             </div>
         </div>

--- a/app/main/posts/savedsearches/saved-search-modal.html
+++ b/app/main/posts/savedsearches/saved-search-modal.html
@@ -4,11 +4,13 @@
         <svg class="iconic">
             <use xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
         </svg>
-        <input
-            type="search"
-            ng-model="savedSearchQuery"
-            placeholder="{{ 'set.find_a_saved_search' | translate }}" ng-keydown="searchSearches(savedSearchQuery)"
-        >
+        <label>
+            <input
+                type="search"
+                ng-model="savedSearchQuery"
+                placeholder="{{ 'set.find_a_saved_search' | translate }}" ng-keydown="searchSearches(savedSearchQuery)"
+            >
+        </label>
     </div>
 </div>
 <div class="modal-body">

--- a/app/main/posts/savedsearches/saved-search-modal.html
+++ b/app/main/posts/savedsearches/saved-search-modal.html
@@ -1,16 +1,16 @@
 <div class="form-field">
-    <label class="hidden" translate="set.find_a_saved_search">Find a saved search</label>
+    <label for="saved-search" class="hidden" translate="set.find_a_saved_search">Find a saved search</label>
     <div class="input-with-icon">
         <svg class="iconic">
             <use xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
         </svg>
-        <label>
             <input
                 type="search"
                 ng-model="savedSearchQuery"
                 placeholder="{{ 'set.find_a_saved_search' | translate }}" ng-keydown="searchSearches(savedSearchQuery)"
+                id="saved-search"
             >
-        </label>
+        
     </div>
 </div>
 <div class="modal-body">

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -1,7 +1,7 @@
 <fieldset>
     <label translate>global_filter.date_range</label>
     <div class="form-field date">
-        <label for="filter-startDate" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
+        <label for="filter-start-date" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
             <div class="input-with-icon">
                 <svg class="iconic">
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -13,7 +13,7 @@
 
 
     <div class="form-field date">
-        <label for="filter-endDate" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
+        <label for="filter-end-Date" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
         <div class="input-with-icon">
             <svg class="iconic">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -2,12 +2,12 @@
     <label translate>global_filter.date_range</label>
     <div class="form-field date">
         <label for="filter-startDate" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
-        <div class="input-with-icon">
-            <svg class="iconic">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
-            </svg>
-            <input id="filter-startDate" type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" /> 
-        </div>
+            <div class="input-with-icon">
+                <svg class="iconic">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
+                </svg>
+                <input id="filter-start-date"  aria-labelledby="filter-startDate" type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" /> 
+            </div>
     </div>
             <span class="date-joiner">to</span>
 
@@ -16,11 +16,10 @@
         <label for="filter-endDate" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
         <div class="input-with-icon">
             <svg class="iconic">
-              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <input id="filter-endDate" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
-              
-    </div>
+            <input id="filter-end-date"  aria-labelledby="filter-endDate" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">  
+        </div>
 </div>
 
 

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -6,7 +6,7 @@
                 <svg class="iconic">
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
                 </svg>
-                <input id="filter-start-date"  aria-labelledby="filter-startDate" type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" /> 
+                <input id="filter-start-date"  type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" /> 
             </div>
     </div>
             <span class="date-joiner">to</span>
@@ -18,7 +18,7 @@
             <svg class="iconic">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <input id="filter-end-date"  aria-labelledby="filter-endDate" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">  
+            <input id="filter-end-date" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">  
         </div>
 </div>
 

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -1,28 +1,25 @@
 <fieldset>
     <label translate>global_filter.date_range</label>
     <div class="form-field date">
-        <label class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
+        <label for="filter-startDate" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
         <div class="input-with-icon">
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <label>
-                <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
-            </label>
+            <input id="filter-startDate" type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" /> 
         </div>
     </div>
             <span class="date-joiner">to</span>
 
 
     <div class="form-field date">
-        <label class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
+        <label for="filter-endDate" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
         <div class="input-with-icon">
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <label>
-               <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
-            </label>   
+            <input id="filter-endDate" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
+              
     </div>
 </div>
 

--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -6,7 +6,9 @@
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
+            <label>
+                <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
+            </label>
         </div>
     </div>
             <span class="date-joiner">to</span>
@@ -18,7 +20,9 @@
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-        <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
+            <label>
+               <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
+            </label>   
     </div>
 </div>
 

--- a/app/main/posts/views/filters/filter-location.html
+++ b/app/main/posts/views/filters/filter-location.html
@@ -3,7 +3,9 @@
 
     <div class="form-field">
         <div class="input-with-icon">
-            <input type="text" style="padding-left: 24px;" placeholder="{{ 'global_filter.location_placeholder' | translate }}" ng-model="locationSearchText">
+            <label>
+               <input type="text" style="padding-left: 24px;" placeholder="{{ 'global_filter.location_placeholder' | translate }}" ng-model="locationSearchText">
+            </label>
             <svg class="iconic" style="left: 8px;">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#location"></use>
             </svg>

--- a/app/main/posts/views/filters/filter-location.html
+++ b/app/main/posts/views/filters/filter-location.html
@@ -3,9 +3,8 @@
 
     <div class="form-field">
         <div class="input-with-icon">
-            <label>
-               <input type="text" style="padding-left: 24px;" placeholder="{{ 'global_filter.location_placeholder' | translate }}" ng-model="locationSearchText">
-            </label>
+            <label for ="enter-location">Enter city or address</label>
+               <input id="enter-location" type="text" style="padding-left: 24px;" placeholder="{{ 'global_filter.location_placeholder' | translate }}" ng-model="locationSearchText">
             <svg class="iconic" style="left: 8px;">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#location"></use>
             </svg>

--- a/app/main/posts/views/filters/filter-location.html
+++ b/app/main/posts/views/filters/filter-location.html
@@ -3,7 +3,7 @@
 
     <div class="form-field">
         <div class="input-with-icon">
-            <label for ="enter-location">Enter city or address</label>
+            <label for="enter-location">Enter your location</label>
                <input id="enter-location" type="text" style="padding-left: 24px;" placeholder="{{ 'global_filter.location_placeholder' | translate }}" ng-model="locationSearchText">
             <svg class="iconic" style="left: 8px;">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#location"></use>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -13,9 +13,9 @@
     <div class="searchbar-input">
         <!-- Search input -->
         <div class="form-field">
-            <label class="hidden" translate="toolbar.searchbar.search_entity">Search</label>
+            <label for="search" class="hidden" translate="toolbar.searchbar.search_entity">Search</label>
             <div class="input-with-icon">
-                <label>
+                
                     <input 
                         name="q"
                         type="search"
@@ -26,8 +26,8 @@
                         ng-click = "toggleDropdown($event)"
                         ng-keyup="toggleDropdown($event)"
                         ng-keypress="toggleDropdown($event)"
+                        id="search"
                     >
-                </label>
                 <svg class="iconic" ng-show="!postFiltersFormOpen.q.$viewValue.length">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>

--- a/app/main/posts/views/filters/filter-posts.html
+++ b/app/main/posts/views/filters/filter-posts.html
@@ -15,17 +15,19 @@
         <div class="form-field">
             <label class="hidden" translate="toolbar.searchbar.search_entity">Search</label>
             <div class="input-with-icon">
-                <input 
-                    name="q"
-                    type="search"
-                    autocomplete="off"
-                    placeholder="{{ 'toolbar.searchbar.search_entity' | translate }}"
-                    ng-model="filters.q"
-                    ng-model-options="{debounce: 300}"
-                    ng-click = "toggleDropdown($event)"
-                    ng-keyup="toggleDropdown($event)"
-                    ng-keypress="toggleDropdown($event)"
-                >
+                <label>
+                    <input 
+                        name="q"
+                        type="search"
+                        autocomplete="off"
+                        placeholder="{{ 'toolbar.searchbar.search_entity' | translate }}"
+                        ng-model="filters.q"
+                        ng-model-options="{debounce: 300}"
+                        ng-click = "toggleDropdown($event)"
+                        ng-keyup="toggleDropdown($event)"
+                        ng-keypress="toggleDropdown($event)"
+                    >
+                </label>
                 <svg class="iconic" ng-show="!postFiltersFormOpen.q.$viewValue.length">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>
                 </svg>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixed  https://github.com/ushahidi/platform/issues/4123

- Connected the input to their labels for accessibility
- The labels in the activity and the posts section were not connected to their inputs. Thus I added `for="" ` and `id="" `  attributes to solve the issue. 
Below is an example
- Before changing the code, the inputs had no labels associated with them.
<img src="https://i.ibb.co/wMTbdQZ/Screenshot-307.png" alt="Screenshot-307" border="0" height="450px"> 

-  After adding `for ="" ` and `id="" ` attribute there was no error about it anymore. 
<img src="https://i.ibb.co/SdQ7YNb/Screenshot-308.png" alt="Screenshot-308" border="0" height="450px"> 


Testing checklist:
- [x] Go to the activity section
- [x] Check the `the start date and end date input` they are now set correctly with labels.
- [x] In the drop-down select custom date range. The input start date and end date are now associated with their respective labels.

- [x] Go to the home page 
- [x] Check the search input and you will see the input is set correctly with a label.
- [x] Click the `search input` and a filter section will pop up. 
- [x] The `start and end inputs` are now associated correctly with their respective labels. Hence no label errors anymore.
- [x] The `location input` has a label with the text `Enter your location`

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .


Ping @ushahidi/platform
