### PR TITLE
fix(dev): add route for dev server to find locales

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -163,7 +163,14 @@ function devServer() {
     serve({
         port: process.env.PORT || 3000,
         open: false,
-        server: {baseDir: root},
+        server: {
+            baseDir: root,
+            routes: {
+                // add locales folder under the route
+                // that the app expects them in
+                '/locales': 'app/common/locales'
+            }
+        },
         middleware: [
             historyApiFallback(),
             webpackDevMiddleware(compiler, {


### PR DESCRIPTION
This pull request makes the following changes:
- adds a route for the dev server to follow, so that it can file the locales

Up until now, running the dev server, didn't result in any languages available in the translations drop-down in the app.

This change only affects development environment, no server deployments or production environments affected.

Testing checklist:
- In a local development environment run `gulp` as usual.
- Go to http://localhost:3000 and open the languages drop-down.
- [ ] There should be languages in the list.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4140

Ping @ushahidi/platform
