### PR TITLE
Updating the filter searchbar

### DIFF
--- a/app/common/directives/filter-system/filter-searchbar.html
+++ b/app/common/directives/filter-system/filter-searchbar.html
@@ -11,7 +11,7 @@
                 ng-model="model.q"
                 ng-focus="showSearchResults()"
                 ng-keyup="detectSubmit($event)"
-                ng-value="model.q=''"
+                ng-value="model.q"
             >
             <svg class="iconic" ng-show="!form.q.$viewValue.length">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#magnifying-glass"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- Rectifies the filter search bar
- The user searching function now works consistently

Testing checklist:
- [ ] Sign in as an admin, go to 'Settings', then click on 'Users'
- [ ] Search for a user.
- [ ] Hit enter, or click on the button.
- [ ] The users list is shown correctly
- [ ] Only one request is sent to the backend per search or reset.
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3936

_Every time the enter key would be hit, the value of `model.q` would be reset to an empty string, which was changing the value of filters and thus calling the watch function._