### PR TITLE
Fix: Removing warning in posts about duplicate options

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -647,7 +647,7 @@
         "posts_total_map": "Displaying {{posts}} of {{total_nb}} posts with location information on the map.",
         "search_results": "Results:",
         "by" : "by",
-        "duplicate_option" : "There's a problem with the checkbox configuration in the survey because of duplicates, please fix it.",
+        "duplicate_option" : "There's a problem with the configuration of this field because of duplicates, please go to the survey-settings and fix it.",
         "task_completed" : "Task completed",
         "everyone" : "Everyone",
         "just_you" : "Just you",

--- a/app/main/posts/modify/post-value-edit.directive.js
+++ b/app/main/posts/modify/post-value-edit.directive.js
@@ -49,7 +49,6 @@ function PostValueEditController(
     $scope.taskIsMarkedCompleted = taskIsMarkedCompleted;
 
     $scope.isAdmin = $rootScope.isAdmin;
-    $scope.duplicatePresent = duplicatePresent;
 
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
@@ -105,19 +104,5 @@ function PostValueEditController(
     // Remove a value
     function removeValue(attr, key) {
         $scope.post.values[attr.key].splice(key, 1);
-    }
-    // Is duplicate present in options attribute?
-    function duplicatePresent(attr) {
-        if (attr.options.length < 1) {
-            return false;
-        }
-        let tmp = [];
-        for (let x of attr.options) {
-            if (tmp.indexOf(x) !== -1) {
-                return true;
-            }
-            tmp.push(x);
-        }
-        return false;
     }
 }

--- a/app/main/posts/modify/post-value-edit.directive.js
+++ b/app/main/posts/modify/post-value-edit.directive.js
@@ -49,7 +49,7 @@ function PostValueEditController(
     $scope.taskIsMarkedCompleted = taskIsMarkedCompleted;
 
     $scope.isAdmin = $rootScope.isAdmin;
-
+    $scope.duplicatePresent = duplicatePresent;
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
 
@@ -104,5 +104,20 @@ function PostValueEditController(
     // Remove a value
     function removeValue(attr, key) {
         $scope.post.values[attr.key].splice(key, 1);
+    }
+
+    // Is duplicate present in options attribute?
+    function duplicatePresent(attr) {
+        if (attr.options && attr.options.length < 1) {
+            return false;
+        }
+        let tmp = [];
+        for (let x of attr.options) {
+            if (tmp.indexOf(x) !== -1) {
+                return true;
+            }
+            tmp.push(x);
+        }
+        return false;
     }
 }

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -221,9 +221,7 @@
             </div>
         </div>
         <!-- Container for fieldset structured elements -->
-        <div class="alert" role="alert" ng-show="duplicatePresent(attribute) && isAdmin()">
-            <p translate>post.duplicate_option</p>
-        </div>
+        
         <fieldset ng-if="isFieldSetStructure(attribute) && attribute.options.length > 0"> 
             <!-- Attribute Label -->
             <label ng-class="{

--- a/app/main/posts/modify/post-value-edit.html
+++ b/app/main/posts/modify/post-value-edit.html
@@ -112,15 +112,21 @@
                         ></post-datetime>
                     </div>
                     <!-- type: select -->
-                    <select
-                        ng-switch-when="select"
-                        id="values[{{attribute.key}}][{{key}}]"
-                        name="values_{{attribute.id}}"
-                        ng-model="post.values[attribute.key][key]"
-                        ng-required="attribute.required"
-                        >
-                        <option ng-repeat="opt in attribute.options" value="{{opt}}"><bdi>{{opt}}</bdi></option>
-                    </select>
+                    <div ng-switch-when="select">
+                        <div class="alert" role="alert" ng-show="duplicatePresent(attribute) && isAdmin()">
+                            <p translate>post.duplicate_option</p>
+                        </div>
+                        <div class="form-field select">
+                            <select
+                                id="values[{{attribute.key}}][{{key}}]"
+                                name="values_{{attribute.id}}"
+                                ng-model="post.values[attribute.key][key]"
+                                ng-required="attribute.required"
+                                >
+                                <option ng-repeat="opt in attribute.options" value="{{opt}}"><bdi>{{opt}}</bdi></option>
+                            </select>
+                        </div>
+                    </div>
                     <!-- type: number -->
                     <input
                         ng-switch-when="number"
@@ -242,6 +248,10 @@
             <div ng-switch="attribute.input">
                 <!-- type: radio -->
                 <div ng-switch-when="radio">
+                     <!-- Container for fieldset structured elements -->
+                     <div class="alert" role="alert" ng-show="duplicatePresent(attribute) && isAdmin()">
+                        <p translate>post.duplicate_option</p>
+                    </div>
                     <div ng-repeat="(key, value) in post.values[attribute.key] track by key">
                     <div class="form-field radio" ng-repeat="option in attribute.options">
                         <label>
@@ -259,6 +269,10 @@
                 </div>
                 <!-- type: checkbox -->
                 <div ng-switch-when="checkbox">
+                    <!-- Container for fieldset structured elements -->
+                    <div class="alert" role="alert" ng-show="duplicatePresent(attribute) && isAdmin()">
+                        <p translate>post.duplicate_option</p>
+                    </div>
                     <div class="form-field checkbox" ng-repeat="option in attribute.options | unique ">
                     <label>
                         <input


### PR DESCRIPTION
This pull request makes the following changes:
- Removes warning about duplicate options in post, but keeps the check when adding a new attribute (this makes the warning in the post redundant, it should not be possible to add duplicates in the first place)

Testing checklist:
- [ ] Go to surveys-> add new checkbox, radio-button or select
- [ ] Try adding duplicate options, it should not be possible
- [ ] In a survey with already present duplicate options (Anna will add one of those surveys to staging), try adding a post
- [ ] You will see an error-message warning about duplicate options at each field with problems
- [ ] Go back to settings and remove the duplicate options
- [ ] Go back to add a post, no warnings visible.




- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
