### PR TITLE
fix(surveys): makes the first input focusable on every page reload

### DIFF
--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -48,7 +48,7 @@ function (
             };
 
             initiateEditor();
-
+            document.getElementById('attribute_name').focus();
             $scope.save = function (editAttribute, activeTask) {
                 editAttribute.instructions = $scope.editor.getMarkdown();
                 if ($scope.valuesPermissible() && !$scope.attributeLabel.$invalid) {

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -120,7 +120,7 @@ function SurveyEditorController(
             $scope.targetedSurveysEnabled = Features.isFeatureEnabled('targeted-surveys');
             $scope.anonymiseReportersEnabled = Features.isFeatureEnabled('anonymise-reporters');
         });
-
+        document.getElementById('survey_name').focus();
         if ($scope.surveyId) {
             loadFormData();
         } else {

--- a/app/settings/surveys/task-create.directive.js
+++ b/app/settings/surveys/task-create.directive.js
@@ -22,6 +22,7 @@ function (
             $scope.closeModal = function () {
                 ModalService.close();
             };
+            document.getElementById('task_name').focus();
         }
     };
 }];

--- a/app/settings/user-settings/user-settings.controller.js
+++ b/app/settings/user-settings/user-settings.controller.js
@@ -32,7 +32,7 @@ function (
 
     $scope.tempApiKey = '';
     $scope.tempMaintainerId = '';
-
+    document.getElementById('hdx_maintainer_id').focus();
     $scope.hdxSettings = {
         'hdx_api_key': {
             id: null,


### PR DESCRIPTION
This pull request makes the following changes:
Makes the first input box in the following forms focusable after every page reload
- While creating/updating a new survey
- While adding/updating fields in a survey
- While adding tasks in the survey
- While updating user settings for hdx maintainer 

Testing checklist:
- [ ] While creating or updating new survey the survey title field gets focusable
- [ ] While adding or updating any new field the first input gets focusable
- [ ] While adding or updating any task  the first input gets focusable.
- [ ] While updating user settings for hdx maintainer the first input gets focusable.

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2073 .

Ping @ushahidi/platform
