### PR TITLE
fix(MapView stats): use the stats endpoint instead of counting the geojson entries since we can get the same info

### DIFF
--- a/app/main/posts/views/post-view-map.directive.js
+++ b/app/main/posts/views/post-view-map.directive.js
@@ -149,7 +149,7 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                     function (a,b) {
                         return a.total + b.total
                     }
-                );
+                ) - result.unmapped;
 
                 $scope.stats.unmapped = result.unmapped;
             });


### PR DESCRIPTION
fix(MapView stats): use the stats endpoint instead of counting the geojson entries since we can get the same info from the stats endpoint. 

This pull request makes the following changes:
- Changes a call to geojson for a call to stats which is less resource intensive.

Testing checklist:
- [ ] Load the map view with a deployment with many posts. 
- [ ] Verify that your filters dropdown displays the correct count for mapped vs unmapped posts (x of y. ) 
      - Note: the wording there is a bit odd because it implies its not showing the full dataset when in reality what is does is show the count of mapped vs totals, but that's a separate thing, didn't want to change it without more talking about it.


- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
