### PR TITLE
Fixing broken datepicker in filter-dropdown #4169

### DIFF
--- a/app/main/posts/views/filters/filter-date.html
+++ b/app/main/posts/views/filters/filter-date.html
@@ -1,24 +1,25 @@
 <fieldset>
     <label translate>global_filter.date_range</label>
     <div class="form-field date">
-        <label for="date" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
+        <label id="date-after" class="hidden" translate="global_filter.filter_tabs.created_after">Start date</label>
         <div class="input-with-icon">
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-            <input id="date" type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" />
+            <input type="date" pick-a-date="dateAfter" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_after' | translate }}" ng-model="dateAfterModel" aria-labelledby="date-after" />
         </div>
+        
     </div>
             <span class="date-joiner">to</span>
 
 
     <div class="form-field date">
-        <label for="date" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
+        <label id="date-before" class="hidden" translate="global_filter.filter_tabs.created_before">End date</label>
         <div class="input-with-icon">
             <svg class="iconic">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#calendar"></use>
             </svg>
-        <input id="date" type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel">
+        <input type="date" pick-a-date="dateBefore" pick-a-date-options="options" placeholder="{{ 'global_filter.filter_tabs.created_before' | translate }}" ng-model="dateBeforeModel" aria-labelledby="date-before">
     </div>
 </div>
 


### PR DESCRIPTION
This pull request makes the following changes:
- Exchanges associating label and input from for-id to aria-labelledby because the date-picker broke with for-id relationship (even after changing the ids to be unique)

Testing checklist:
- go to filter-dropdown
- select a date in "date-range"
- [ ] The datepicker should open
- [ ] The datepicker should close when selecting a date
- [ ] The date should remain in the input-box after selection

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#4169 .

Ping @ushahidi/platform
