### PR TITLE
hotfix(Webpack): configuration for css and js bundles 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,8 @@ module.exports = {
           {
             loader: 'file-loader',
             options: {
-              name: 'manifest.json'
+              name: 'manifest.json',
+              esModule: false
             }
           }
         ]
@@ -99,7 +100,11 @@ module.exports = {
       }
     },
   plugins: [
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin(
+        {
+          filename: '[name].[contenthash].css'
+        }
+    ),
      // Skip locales
      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
      new webpack.DefinePlugin({

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -7,7 +7,7 @@ var config  = require('./webpack.config');
 config.mode = 'production';
 
 config.output = {
-  filename: '[name].[chunkhash].js',
+  filename: '[name].[contenthash].js',
   chunkFilename: '[name].[chunkhash].js',
   publicPath: '',
   path: path.resolve(__dirname, 'server/www') // Overwritten by gulp


### PR DESCRIPTION
This pull request makes the following changes:
- Changed config to use contenthash for full CSS and JS files. Kept chunkhash for chunks
- Added contenthash name for the MinifyCss plugin otherwise it would generate the files without the correct name
- Fixed manifest which was getting transformed to esModule object like it happened for PNGs

Testing checklist:
Run `npm gulp build` to create a dist. Check server/www/index.html

- [ ] vendors~app.x.css files should be generated and linked in the index.html (where x=the hash generated)
- [ ] vendors~app.x.js files should be generated and linked in the index.html (where x=the hash generated)
- [ ] app.x.js files should be generated and linked in the index.html (where x=the hash generated)
- [ ] app.x.css files should be generated and linked in the index.html (where x=the hash generated)
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
