### PR TITLE
Moving required-asterix to after Name in attribute-editor

### DIFF
--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -4,9 +4,8 @@
       'error': fieldLabel.$invalid && fieldLabel.$dirty
   }">
     <form name="fieldLabel">
-      <label>{{'app.name'|translate}}
-        <input aria-label="app.name" type="text" ng-model="label" ng-required="true" placeholder="{{ 'form.field_name_placeholder' | translate}}" />
-      </label>
+      <label for="field-name">{{'app.name'|translate}}</label>
+      <input id="field-name" aria-label="app.name" type="text" ng-model="label" ng-required="true" placeholder="{{ 'form.field_name_placeholder' | translate}}" />
       <div
           class="alert error"
           ng-show="fieldLabel.$invalid && fieldLabel.$dirty"


### PR DESCRIPTION
This pull request makes the following changes:
- Moves the required asterix back to where it should be

Testing checklist:
- Go to edit survey and select a field
- [ ] The required-asterix ("x") should be after Name, not below the input-box

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
