### PR TITLE
Make navigational menu in /views/map accessible

### DIFF
--- a/app/main/posts/views/filter-by-datasource.html
+++ b/app/main/posts/views/filter-by-datasource.html
@@ -20,12 +20,12 @@
                     {{provider.label}}
                 </label>
             </div>
-            <span class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
+            <button class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
                 {{provider.total}}
                 <svg class="iconic" role="img">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
                 </svg>
-            </span>
+            </button>
             <div class="dropdown-menu init" dropdown-menu>
                 <span class="post-band" ng-style="{backgroundColor: '#00aced'}"></span>
                 <p>
@@ -38,6 +38,7 @@
                             translate="post.show_only_form" 
                             translate-values="{form: provider.label}"
                             ng-click="showOnly(provider.label)"
+                            href=""
                         ></a>
                     </li>
                     <li>
@@ -45,6 +46,7 @@
                             translate="post.hide_form"
                             translate-values="{form: provider.label}"
                             ng-click="hide(provider.label)"
+                            href=""
                         ></a>
                     </li>
                     <li ng-if="featureEnabled()">
@@ -52,7 +54,7 @@
                             translate="post.messages.show_only_incoming"
                             translate-values="{provider: provider.heading.toLowerCase()}"
                             ng-click="showOnlyIncoming(provider.label)"
-
+                            href=""
                         ></a>
                     </li>
                     <div class="divider"></div>

--- a/app/main/posts/views/mode-context-form-filter.html
+++ b/app/main/posts/views/mode-context-form-filter.html
@@ -9,13 +9,13 @@
                     <bdi ng-if="!form.translations[userLanguage].name">{{form.name}}</bdi>
                 </label>
             </div>
-             <span class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
+             <button class="survey-filter-total init" data-toggle="dropdown-menu" dropdown-toggle>
                 <!-- todo! show count -->
                 {{ form.post_count }}
                 <svg class="iconic" role="img">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#chevron-bottom"></use>
                 </svg>
-            </span>
+            </button>
             <ul class="dropdown-menu init" dropdown-menu>
                 <li ng-show="canAddToSurvey(form)">
                     <a ui-sref="postCreate({id: form.id })">
@@ -26,8 +26,8 @@
                     </a>
                 </li>
                 <div class="divider"></div>
-                <li><a translate="post.show_only_form" translate-values="{ form: form.name }" ng-click="showOnly(form.id)">Show only </a></li>
-                <li><a translate="post.hide_form" translate-values="{ form: form.name }" ng-click="hide(form.id)">Hide</a></li>
+                <li><a translate="post.show_only_form" translate-values="{ form: form.name }" ng-click="showOnly(form.id)" href="">Show only </a></li>
+                <li><a translate="post.hide_form" translate-values="{ form: form.name }" ng-click="hide(form.id)" href="">Hide</a></li>
                 <div class="divider"></div>
                 <li ng-show="hasManageSettingsPermission()">
                     <a ui-sref="settings.surveys.id({id: form.id, action: 'edit'})">


### PR DESCRIPTION
This pull request makes the following changes:
- It makes the dropdown buttons in the maps navigational menu accessible along with its content using only keyboard.

Testing checklist:
- [ ] Open /views/maps.
- [ ] Disconnect your mouse and navigate with keyboard only.
- [ ] The buttons present next to the posts and data sources filter would be accessible along with its content.

- [x] I certify that I ran my checklist

Recording:
![Maps navbar](https://user-images.githubusercontent.com/70752431/103913090-2bcaf980-512e-11eb-9890-82c7c3b53bd6.gif)

Fixes ushahidi/platform#4187 .

Ping @ushahidi/platform
