### PR TITLE
Adding focus to modals

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -165,6 +165,9 @@ angular.module('app',
     .factory('UshahidiSdk', function () {
         return UshahidiSdk;
     })
+    .factory('FocusTrap', function () {
+        return require('focus-trap');
+    })
     .run(['$rootScope', 'LoadingProgress', '$transitions', '$uiRouter', function ($rootScope, LoadingProgress, $transitions, $uiRouter) {
         // this handles the loading-state app-wide
         LoadingProgress.watchTransitions();

--- a/app/common/directives/modal-container.directive.js
+++ b/app/common/directives/modal-container.directive.js
@@ -66,8 +66,8 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
             modalContent.html(template);
             $compile(modalContent)(templateScope);
 
-            // we need timeout here to make sure the content is ready
-            $timeout(function () {
+            // we need to check that the content is ready before activating the focus-trap
+            angular.element(modalContent).ready(function () {
                 trap.activate();
             });
             $scope.title = title;

--- a/app/common/directives/modal-container.directive.js
+++ b/app/common/directives/modal-container.directive.js
@@ -24,6 +24,9 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
         $scope.showCloseButton = true;
         // Callbacks
         $scope.closeButtonClicked = closeButtonClicked;
+        $rootScope.$on('activate:modal-slider', () => {
+            $scope.sliderOpen = true;
+        });
 
         var templateScope;
         var iconPath = require('ushahidi-platform-pattern-library/assets/img/iconic-sprite.svg');
@@ -51,8 +54,7 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
             return scope.$new();
         }
 
-        function openModal(ev, template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent) {
-            $scope.sliderPresent = sliderPresent;
+        function openModal(ev, template, title, icon, scope, closeOnOverlayClick, showCloseButton) {
             // Clean up any previous modal content
             cleanUpModal();
             // Create new scope and keep it to destroy when done with the modal

--- a/app/common/directives/modal-container.directive.js
+++ b/app/common/directives/modal-container.directive.js
@@ -51,7 +51,8 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
             return scope.$new();
         }
 
-        function openModal(ev, template, title, icon, scope, closeOnOverlayClick, showCloseButton) {
+        function openModal(ev, template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent) {
+            $scope.sliderPresent = sliderPresent;
             // Clean up any previous modal content
             cleanUpModal();
             // Create new scope and keep it to destroy when done with the modal

--- a/app/common/directives/modal-container.directive.js
+++ b/app/common/directives/modal-container.directive.js
@@ -4,8 +4,8 @@
  */
 module.exports = ModalContainer;
 
-ModalContainer.$inject = ['$timeout', '$rootScope', '$compile', 'ModalService', 'SliderService'];
-function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderService) {
+ModalContainer.$inject = ['$timeout', '$rootScope', '$compile', 'ModalService', 'SliderService', 'FocusTrap'];
+function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderService, FocusTrap) {
     return {
         restrict: 'E',
         template: require('./modal-container.html'),
@@ -29,6 +29,7 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
         var iconPath = require('ushahidi-platform-pattern-library/assets/img/iconic-sprite.svg');
         // Modal content element
         var modalContent = $element.find('modal-content');
+        let trap = FocusTrap.createFocusTrap('.modal-window');
 
         // Bind to modal service open/close events
         ModalService.onOpen(openModal, $scope);
@@ -62,6 +63,10 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
             modalContent.html(template);
             $compile(modalContent)(templateScope);
 
+            // we need timeout here to make sure the content is ready
+            $timeout(function () {
+                trap.activate();
+            });
             $scope.title = title;
             $scope.icon = icon ? iconPath + '#' + icon : icon;
 
@@ -96,6 +101,7 @@ function ModalContainer($timeout, $rootScope, $compile, ModalService, SliderServ
             $scope.classVisible = false;
             $rootScope.toggleModalVisible(false);
             ModalService.setState(false);
+            trap.deactivate();
             cleanUpModal();
 
             // if (classChangePromise) {

--- a/app/common/directives/modal-container.html
+++ b/app/common/directives/modal-container.html
@@ -16,7 +16,7 @@
             </span>
         </h3>
         <modal-content></modal-content>
-        <ush-slider inside-modal="true"></ush-slider>
+        <ush-slider ng-if="sliderPresent" inside-modal="true"></ush-slider>
     </div>
     <div class="modal-overlay" ng-click="closeButtonClicked('overlay')"></div>
 </div>

--- a/app/common/directives/modal-container.html
+++ b/app/common/directives/modal-container.html
@@ -16,7 +16,7 @@
             </span>
         </h3>
         <modal-content></modal-content>
-        <ush-slider ng-if="sliderPresent" inside-modal="true"></ush-slider>
+        <ush-slider ng-show="sliderOpen" inside-modal="true"></ush-slider>
     </div>
     <div class="modal-overlay" ng-click="closeButtonClicked('overlay')"></div>
 </div>

--- a/app/common/notifications/notify.service.js
+++ b/app/common/notifications/notify.service.js
@@ -141,6 +141,7 @@ function Notify(_, $q, $rootScope, $translate, SliderService, ModalService, Demo
     }
 
     function confirm(confirmText, translateValues) {
+        $rootScope.$broadcast('activate:modal-slider');
         var deferred = $q.defer();
 
         var scope = getScope();

--- a/app/common/notifications/slider.html
+++ b/app/common/notifications/slider.html
@@ -2,6 +2,7 @@
 <div
     class="message"
     ng-class="{'active': classVisible}"
+    tabindex="-1"
 >
 
     <div class='progress-bar' ng-if="loading"><span>Loading...</span></div><br>

--- a/app/common/services/modal.service.js
+++ b/app/common/services/modal.service.js
@@ -17,9 +17,9 @@ function ModalService($rootScope, $q, $templateRequest) {
         setState: setState
     };
 
-    function openTemplate(template, title, icon, scope, closeOnOverlayClick, showCloseButton) {
+    function openTemplate(template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent) {
         deferredOpen.promise.then(function () {
-            $rootScope.$emit('modal:open', template, title, icon, scope, closeOnOverlayClick, showCloseButton);
+            $rootScope.$emit('modal:open', template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent);
         });
     }
 

--- a/app/common/services/modal.service.js
+++ b/app/common/services/modal.service.js
@@ -17,9 +17,9 @@ function ModalService($rootScope, $q, $templateRequest) {
         setState: setState
     };
 
-    function openTemplate(template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent) {
+    function openTemplate(template, title, icon, scope, closeOnOverlayClick, showCloseButton) {
         deferredOpen.promise.then(function () {
-            $rootScope.$emit('modal:open', template, title, icon, scope, closeOnOverlayClick, showCloseButton, sliderPresent);
+            $rootScope.$emit('modal:open', template, title, icon, scope, closeOnOverlayClick, showCloseButton);
         });
     }
 

--- a/app/main/posts/views/share/post-share.directive.js
+++ b/app/main/posts/views/share/post-share.directive.js
@@ -48,6 +48,6 @@ function PostShareController(
 
     function openShareMenu() {
         var template = '<share-menu-modal filters="filters" post-id="' + $scope.postId + '"></share-menu-modal>';
-        ModalService.openTemplate(template, 'app.share', 'share', $scope, true, true);
+        ModalService.openTemplate(template, 'app.share', 'share', $scope, true, true, true);
     }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "checklist-model": "~0.11.0",
     "cross-fetch": "^3.0.4",
     "d3": "^3.5.17",
+    "focus-trap": "^6.3.0",
     "leaflet": "^1.6.0",
     "leaflet-easybutton": "^2.4.0",
     "leaflet.locatecontrol": "^0.71.1",


### PR DESCRIPTION
This pull request makes the following changes:
- Focus modals on open
- Creating a focus-trap inside a modal so focus is not moved outside
- Deactivating the focus-trap when closing the modal
- Only rendering the slider if its actually used in the specific modal

Testing checklist:
- [ ] Navigate with keyboard
- [ ] Open for example the login-modal
- [ ] Focus should be inside of the modal
- [ ] Try logging in, it should work and close the modal
- [ ] Try cancelling, it should close the modal

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
