### PR TITLE
Made share button and menu accessible with keyboard

### DIFF
--- a/app/main/posts/views/share/post-export.html
+++ b/app/main/posts/views/share/post-export.html
@@ -1,1 +1,1 @@
-<a ng-click="exportPostsConfirmation()" translate="app.export_to_csv">Export filtered data</a>
+<button ng-click="exportPostsConfirmation()" translate="app.export_to_csv" class="button-export">Export filtered data</button>

--- a/app/main/posts/views/share/post-share.html
+++ b/app/main/posts/views/share/post-share.html
@@ -1,4 +1,4 @@
-<a ng-class="{ 'button' : isButton(), 'button-flat': isAdd()}" ng-click="openShareMenu()">
+<button ng-class="{ 'button' : isButton(), 'button-flat': isAdd()}" ng-click="openShareMenu()">
 		<div class="loading" ng-if="loading">
 			<div class="line"></div>
 			<div class="line"></div>
@@ -10,4 +10,4 @@
 	<span ng-class="{'button-label': isButton(), 'label': !isButton()}" translate="app.share">
 			Share {{isButton()}}
 	</span>
-</a>
+</button>

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "socket.io-client": "2.0.3",
     "sortablejs": "1.10.0",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "4.4.4-pre.6",
+    "ushahidi-platform-pattern-library": "4.4.5",
     "ushahidi-platform-sdk": "^0.4.0"
   },
   "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- It makes the share button accessible 
- It makes the export filtered data option present in share menu accessible 

Testing checklist:
- [ ] Open /views/maps.
- [ ] Disconnect your mouse and navigate with keyboard only.
- [ ] Go to the share menu and press enter
- [ ] The export filtered data shall be accessible with keyboard

- [x] I certify that I ran my checklist

Recording:

![Export filtered data](https://user-images.githubusercontent.com/70752431/105353139-deae5380-5c14-11eb-8935-9243970b9346.gif)

Fixes ushahidi/platform#4189