### PR TITLE
Role selector fix

### DIFF
--- a/app/common/directives/role-selector.directive.js
+++ b/app/common/directives/role-selector.directive.js
@@ -13,10 +13,11 @@ function RoleSelectorDirective() {
         template: require('./role-selector.html')
     };
 }
-RoleSelectorController.$inject = ['$scope', 'RoleEndpoint', '$translate'];
+RoleSelectorController.$inject = ['$scope', 'RoleEndpoint', '$translate', '_'];
 
-function RoleSelectorController($scope, RoleEndpoint, $translate) {
+function RoleSelectorController($scope, RoleEndpoint, $translate, _) {
     $scope.setEveryone = setEveryone;
+    $scope.setAdmin = setAdmin;
 
     activate();
 
@@ -27,8 +28,19 @@ function RoleSelectorController($scope, RoleEndpoint, $translate) {
         });
     }
 
+    function setAdmin() {
+        // adding admin to roles_allowed if not already there
+        let admin = _.findWhere($scope.roles, {name: 'admin'});
+        if ($scope.model.role === null) {
+            $scope.model.role = [];
+        }
+        if (_.indexOf($scope.model.role, admin.name) === -1) {
+            $scope.model.role.push(admin.name);
+        }
+    }
+
     // adding all available roles to model if user clicks 'Everyone'
     function setEveryone() {
-        $scope.model.role = [];
+        $scope.model.role = null;
     }
 }

--- a/app/common/directives/role-selector.html
+++ b/app/common/directives/role-selector.html
@@ -1,5 +1,5 @@
     <!--// Who can add //-->
-    <fieldset>
+    <fieldset ng-show="roles.length">
         <legend translate="{{title}}"></legend>
         <div
             class="form-field radio icon-input"
@@ -38,6 +38,7 @@
                     ng-modaldata-fieldgroup-toggle="add_roles"
                     type="radio"
                     ng-model="everyone"
+                    ng-click="setAdmin()"
                 >
                 <span translate="app.specific_roles">Specific roles...</span>
             </label>
@@ -54,6 +55,8 @@
                         type="checkbox"
                         checklist-model="model.role"
                         checklist-value="role.name"
+                        ng-disabled="role.name === 'admin'"
+                        ng-checked="role.name === 'admin'"
                     >
                     {{role.display_name | translate}}
                     </label>

--- a/app/main/posts/collections/mode-context.directive.js
+++ b/app/main/posts/collections/mode-context.directive.js
@@ -61,6 +61,10 @@ function CollectionModeContextController(
                 $scope.notification = notifications[0];
             }
         }, angular.noop);
+
+        $rootScope.$on('collection:update', function (ev, data) {
+            $scope.collection = data;
+        });
     }
 
     function canEdit(collection) {


### PR DESCRIPTION
This pull request makes the following changes:
- Set role=null if "Everyone" is selected
- Always add "admin" if specific roles is clicked
- Always check and disable the "admin"-checkbox in the specific-role list
- Adjustments to mode-context bar for collections. If the active collection is saved, its now updated in the mode-context-bar as well, it was not previously which made changes not visible until you reload the whole page.

Testing checklist:
- Go to categories
- Scroll to "Who can see this category?"
- Click on "specific roles"
- [ ] Admin should be selected and disabled
- Select a number of roles
- Save
- Go back to the category
- Look at "Who can see this category?"
- Click on "Specific roles"
- [ ] Same roles as was clicked in previous step should be marked
- Click on "Everyone"
- Save
- Go back to the category
- Look at "Who can see this category?"
- [ ] "Everyone" should still be checked

- [ ] Repeat above in different steps and variants
- [ ] Repeat above for collections and saved searches

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
