### PR TITLE
using role.name instead of role when selecting options in role-selector

### DIFF
--- a/app/common/directives/role-selector.html
+++ b/app/common/directives/role-selector.html
@@ -56,7 +56,7 @@
                         checklist-model="model.role"
                         checklist-value="role.name"
                         ng-disabled="role.name === 'admin'"
-                        ng-selected="role.name === 'admin' || model.role.indexOf(role) > -1"
+                        ng-selected="role.name === 'admin' || model.role.indexOf(role.name) > -1"
                     >
                     {{role.display_name | translate}}
                     </label>


### PR DESCRIPTION
This pull request makes the following changes:
- Using ng-selected to select all roles available in the model

Testing checklist:
- Go to categories
- Scroll to "Who can see this category?"
- Click on "specific roles"
- [ ] Admin should be selected and disabled
- Select a number of roles
- Save
- Go back to the category
- Look at "Who can see this category?"
- Click on "Specific roles"
- [ ] Same roles as was clicked in previous step should be marked
- Click on "Everyone"
- Save
- Go back to the category
- Look at "Who can see this category?"
- [ ] "Everyone" should still be checked

- [ ] Repeat above in different steps and variants
- [ ] Repeat above for collections and saved searches

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
