### PR TITLE
Role fixes from qa

### DIFF
--- a/app/common/directives/role-selector.directive.js
+++ b/app/common/directives/role-selector.directive.js
@@ -31,7 +31,7 @@ function RoleSelectorController($scope, RoleEndpoint, $translate, _) {
     function setAdmin() {
         // adding admin to roles_allowed if not already there
         let admin = _.findWhere($scope.roles, {name: 'admin'});
-        if ($scope.model.role === null) {
+        if (!$scope.model.role) {
             $scope.model.role = [];
         }
         if (_.indexOf($scope.model.role, admin.name) === -1) {

--- a/app/main/posts/savedsearches/savedsearch-editor.html
+++ b/app/main/posts/savedsearches/savedsearch-editor.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Who can see? -->
-    <role-selector model="savedSearch" title="'app.who_can_see_this'"></role-selector>
+    <role-selector model="cpySavedSearch" title="'app.who_can_see_this'"></role-selector>
     <div class="modal-actions">
         <div class="form-field">
             <button type="button" class="button-beta  modal-trigger" ng-click="cancel()" translate>app.cancel</button>


### PR DESCRIPTION
This pull request makes the following changes:
- Save changes in role for saved searches
- Always mark admin in the "Specific role" list when creating a new category 

Testing checklist:
- Go to categories
- Create a new category
- Click on "Specific role"
- [ ] The admin-option should be checked
- Go to map or data-view
- Click on filter, select a saved search and click edit
- Change the roles
- [ ] The new roles should save

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
