### PR TITLE
Make the add post survey list accessible

### DIFF
--- a/app/common/directives/mainsheet-container.directive.js
+++ b/app/common/directives/mainsheet-container.directive.js
@@ -1,8 +1,8 @@
 module.exports = MainsheetContainer;
 
-MainsheetContainer.$inject = ['$rootScope', '$compile', 'MainsheetService'];
+MainsheetContainer.$inject = ['$timeout', '$rootScope', '$compile', 'MainsheetService', 'FocusTrap'];
 
-function MainsheetContainer($rootScope, $compile, MainsheetService) {
+function MainsheetContainer($timeout, $rootScope, $compile, MainsheetService, FocusTrap) {
     return {
         restrict: 'E',
         scope: true,
@@ -20,6 +20,7 @@ function MainsheetContainer($rootScope, $compile, MainsheetService) {
 
         // Mainsheet content element
         var mainsheetContent = $element.find('mainsheet-content');
+        let trap = FocusTrap.createFocusTrap('.mainsheet-window');
 
         // Bind to mainsheet service open/close events
         MainsheetService.onOpen(openMainsheet, $scope);
@@ -38,7 +39,7 @@ function MainsheetContainer($rootScope, $compile, MainsheetService) {
             return scope.$new();
         }
 
-        function openMainsheet(event, template, title, scope) {
+        function openMainsheet(event, template, title, scope, showCloseButton) {
 
             // Clean up any previous mainsheet content
             cleanUpMainsheet();
@@ -52,7 +53,17 @@ function MainsheetContainer($rootScope, $compile, MainsheetService) {
             mainsheetContent.html(template);
             $compile(mainsheetContent)(templateScope);
 
+            $timeout(function () {
+                trap.activate();
+            });
             $scope.title = title;
+
+            // If showCloseButton isn't passed, default to true
+            if (typeof showCloseButton === 'undefined') {
+                $scope.showCloseButton = true;
+            } else {
+                $scope.showCloseButton = showCloseButton;
+            }
 
             $scope.showMainsheet = true;
             MainsheetService.setState(true);
@@ -61,6 +72,7 @@ function MainsheetContainer($rootScope, $compile, MainsheetService) {
         function closeMainsheet() {
             $scope.showMainsheet = false;
             MainsheetService.setState(false);
+            trap.deactivate();
             cleanUpMainsheet();
         }
 

--- a/app/common/directives/mainsheet-container.directive.js
+++ b/app/common/directives/mainsheet-container.directive.js
@@ -1,8 +1,8 @@
 module.exports = MainsheetContainer;
 
-MainsheetContainer.$inject = ['$timeout', '$rootScope', '$compile', 'MainsheetService', 'FocusTrap'];
+MainsheetContainer.$inject = ['$rootScope', '$compile', 'MainsheetService', 'FocusTrap'];
 
-function MainsheetContainer($timeout, $rootScope, $compile, MainsheetService, FocusTrap) {
+function MainsheetContainer($rootScope, $compile, MainsheetService, FocusTrap) {
     return {
         restrict: 'E',
         scope: true,
@@ -53,7 +53,7 @@ function MainsheetContainer($timeout, $rootScope, $compile, MainsheetService, Fo
             mainsheetContent.html(template);
             $compile(mainsheetContent)(templateScope);
 
-            $timeout(function () {
+            angular.element(mainsheetContent).ready(function () {
                 trap.activate();
             });
             $scope.title = title;

--- a/app/common/directives/mainsheet-container.html
+++ b/app/common/directives/mainsheet-container.html
@@ -1,5 +1,12 @@
 <div class="mainsheet init active" ng-show="showMainsheet" style="display: block; opacity: 1;">
     <div class="mainsheet-window">
+        <button class="button-beta button-flat mainsheet-trigger-close" ng-show="showCloseButton" ng-click="closeMainsheet()">
+            <svg class="iconic" role="img">
+                <!-- TODO: fix icon to be settable -->
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#x"></use>
+            </svg>
+            <span class="hidden" translate>modal.button.close</span>
+        </button>
         <h3 class="mainsheet-heading" ng-if="title">
             {{ title | translate }}
         </h3>

--- a/app/common/services/mainsheet.service.js
+++ b/app/common/services/mainsheet.service.js
@@ -18,9 +18,9 @@ function MainsheetService($rootScope, $q) {
         setState: setState
     };
 
-    function openTemplate(template, title, scope) {
+    function openTemplate(template, title, scope, showCloseButton) {
         deferredOpen.promise.then(function () {
-            $rootScope.$emit('mainsheet:open', template, title, scope);
+            $rootScope.$emit('mainsheet:open', template, title, scope, showCloseButton);
         });
     }
 

--- a/app/main/posts/views/add-post-survey-list.html
+++ b/app/main/posts/views/add-post-survey-list.html
@@ -1,9 +1,9 @@
 <ul>
     <li ng-repeat="form in forms" ng-show="!form.targeted_survey">
-        <a ng-click="handleClick(form)">
+        <button ng-click="handleClick(form)" class="button-export">
             <span class="post-band" ng-style="{backgroundColor: form.color}"></span>
             <bdi ng-if="form.translations[userLanguage].name ">{{form.translations[userLanguage].name}}</bdi>
             <bdi ng-if="!form.translations[userLanguage].name">{{form.name}}</bdi>
-        </a>
+        </button>
     </li>
 </ul>

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "socket.io-client": "2.0.3",
     "sortablejs": "1.10.0",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "4.4.4-pre.6",
+    "ushahidi-platform-pattern-library": "4.4.6",
     "ushahidi-platform-sdk": "^0.4.0"
   },
   "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- It makes the add post mainsheet window accessible with keyboard.

Testing checklist:
- [ ] Go to /views/map.
- [ ] Click on the add post button.
- [ ] The mainsheet container is accessible via keyboard.

- [x] I certify that I ran my checklist

Recording:
![add_post_menu](https://user-images.githubusercontent.com/70752431/105681465-297ee280-5f17-11eb-9bd0-6bf4ecc0f530.gif)


Fixes ushahidi/platform#4188 .

Ping @ushahidi/platform
