### PR TITLE
Prefill title desc

### DIFF
--- a/app/main/posts/modify/post-value-edit.directive.js
+++ b/app/main/posts/modify/post-value-edit.directive.js
@@ -51,8 +51,21 @@ function PostValueEditController(
     $scope.duplicatePresent = duplicatePresent;
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
+    $scope.$watch('activeSurveyLanguage', () =>{
+        if ($scope.form.title && !$scope.form.title.$dirty) {
+            addDefaultValue();
+        }
+        });
 
     function activate() {
+        addDefaultValue();
+    }
+
+    function addDefaultValue() {
+        if (($scope.attribute.type === 'title' || scope.attribute.type === 'description')  && $scope.attribute.default) {
+            let fieldType = $scope.attribute.type === 'description' ? 'content' : $scope.attribute.type;
+            $scope.post[fieldType] = $scope.attribute.translations[$scope.activeSurveyLanguage] && $scope.attribute.translations[$scope.activeSurveyLanguage].default ? $scope.attribute.translations[$scope.activeSurveyLanguage].default : $scope.attribute.default;
+        }
     }
 
     function taskIsMarkedCompleted() {

--- a/app/main/posts/modify/post-value-edit.directive.js
+++ b/app/main/posts/modify/post-value-edit.directive.js
@@ -62,7 +62,7 @@ function PostValueEditController(
     }
 
     function addDefaultValue() {
-        if (($scope.attribute.type === 'title' || scope.attribute.type === 'description')  && $scope.attribute.default) {
+        if (($scope.attribute.type === 'title' || $scope.attribute.type === 'description')  && $scope.attribute.default) {
             let fieldType = $scope.attribute.type === 'description' ? 'content' : $scope.attribute.type;
             $scope.post[fieldType] = $scope.attribute.translations[$scope.activeSurveyLanguage] && $scope.attribute.translations[$scope.activeSurveyLanguage].default ? $scope.attribute.translations[$scope.activeSurveyLanguage].default : $scope.attribute.default;
         }

--- a/app/main/posts/modify/post-value-edit.directive.js
+++ b/app/main/posts/modify/post-value-edit.directive.js
@@ -62,7 +62,8 @@ function PostValueEditController(
     }
 
     function addDefaultValue() {
-        if (($scope.attribute.type === 'title' || $scope.attribute.type === 'description')  && $scope.attribute.default) {
+        const isTitleOrDesc =  $scope.attribute.type === 'title' || $scope.attribute.type === 'description';
+        if (isTitleOrDesc && $scope.attribute.default && !$scope.post.id) {
             let fieldType = $scope.attribute.type === 'description' ? 'content' : $scope.attribute.type;
             $scope.post[fieldType] = $scope.attribute.translations[$scope.activeSurveyLanguage] && $scope.attribute.translations[$scope.activeSurveyLanguage].default ? $scope.attribute.translations[$scope.activeSurveyLanguage].default : $scope.attribute.default;
         }

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -75,7 +75,7 @@ function (
             };
 
             $scope.canDisplay = function () {
-                return $scope.editField.input !== 'upload' && $scope.editField.type !== 'title' && $scope.editField.type !== 'description' && $scope.editField.input !== 'tags';
+                return $scope.editField.input !== 'upload' && $scope.editField.input !== 'tags';
             };
 
             $scope.canMakePrivate = function () {


### PR DESCRIPTION
This pull request makes the following changes:
- Makes it possible to add default-values to title and description-field

Testing checklist:
- Go to a survey
- Edit title and/or description-field
- Add a default value
- Go to translations, add default-value there as well
- Save and add to the post
- [ ] The post title and/or description should be prefilled with the default value
- Change language
- [ ] The post title and/or description should change to the translated default
- Change the title and/or description
- Change the language
- [ ] The post title and/or description should NOT change to the default
- Try saving on all above steps
- [ ] It should save the value that is in the input-box

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
