### PR TITLE
V5 main hydration options

### DIFF
--- a/app/common/common-module.js
+++ b/app/common/common-module.js
@@ -112,6 +112,7 @@ angular.module('ushahidi.common', [
 .directive('addCategory', require('./directives/add-category.directive.js'))
 .directive('categorySelector', require('./directives/category-selector.directive.js'))
 .directive('languageSwitch', require('./directives/language-switch.directive.js'))
+.directive('loadingDotsButton', require('./directives/loading-dots-button.directive.js'))
 .directive('loadingDots', require('./directives/loading-dots.directive.js'))
 .directive('addLanguage', require('./directives/add-language.directive.js'))
 .directive('translationsSwitch', require('./directives/translation-switch.directive.js'))

--- a/app/common/directives/category-selector.directive.js
+++ b/app/common/directives/category-selector.directive.js
@@ -40,22 +40,22 @@ function CategorySelectorController($scope, _) {
         $scope.categories = $scope.available;
         if ($scope.displayWarning) {
             $scope.categoryTranslationUnavailable = _.filter($scope.categories, (category) => {
-            let available = [category.enabled_languages.default, ...category.enabled_languages.available];
-            if (available.indexOf($scope.activeLanguage.language) === -1) {
-                return category;
+                let available = [category.enabled_languages.default, ...category.enabled_languages.available];
+                if (available.indexOf($scope.activeLanguage.language) === -1) {
+                    return category;
+                }
+            });
+
+        }
+        // with v5, the selected categories are delivered as objects
+        $scope.selected = _.map($scope.selected, category => {
+            if (typeof category === 'object') {
+                return category.id
+            } else {
+                return category
             }
         });
-
-    }
-    // with v4, the selected categories are delivered as objects
-    $scope.selected = _.map($scope.selected, category => {
-        if (typeof category === 'object') {
-            return category.id
-        } else {
-            return category
-        }
-    });
-    // making sure no children are selected without their parents
+        // making sure no children are selected without their parents
         $scope.changeCategories();
     }
 

--- a/app/common/directives/category-selector.html
+++ b/app/common/directives/category-selector.html
@@ -1,5 +1,6 @@
 <div class="form-fieldgroup checkbox">
-    <div class="form-field checkbox">
+
+    <div class="form-field checkbox" ng-show="categories">
         <label>
             <input
                   type="checkbox"

--- a/app/common/directives/loading-dots-button.directive.js
+++ b/app/common/directives/loading-dots-button.directive.js
@@ -1,0 +1,20 @@
+module.exports = LoadingDotsButtonDirective;
+
+LoadingDotsButtonDirective.$inject = [];
+
+function LoadingDotsButtonDirective() {
+    return {
+        restrict: 'E',
+        scope: {
+            buttonClass: '@',
+            label: '=',
+            disabled: '='
+        },
+        controller: LoadingDotsButtonController,
+        template: require('./loading-dots-button.html')
+    };
+}
+LoadingDotsButtonController.$inject = ['$scope'];
+
+function LoadingDotsButtonController($scope) {
+}

--- a/app/common/directives/loading-dots-button.html
+++ b/app/common/directives/loading-dots-button.html
@@ -1,0 +1,8 @@
+ <button type="button" ng-disabled="disabled" ng-class="{{buttonClass}}">
+        <div class="loading">
+            <div class="line"></div>
+            <div class="line"></div>
+            <div class="line"></div>
+        </div>
+        <span class="button-label" translate>{{label}}</span>
+</button>

--- a/app/common/directives/loading-dots.html
+++ b/app/common/directives/loading-dots.html
@@ -1,8 +1,5 @@
- <button type="button" ng-disabled="disabled" ng-class="{{buttonClass}}">
-        <div class="loading">
-            <div class="line"></div>
-            <div class="line"></div>
-            <div class="line"></div>
-        </div>
-        <span class="button-label" translate>{{label}}</span>
-</button>
+<div class="loading" aria-label="{{label}}" translate>
+    <div class="line"></div>
+    <div class="line"></div>
+    <div class="line"></div>
+</div>

--- a/app/common/services/data-export.service.js
+++ b/app/common/services/data-export.service.js
@@ -25,7 +25,7 @@ function DataExport($rootScope, ExportJobEndpoint,  Notify, $window, $timeout, $
         var queries = [];
         ExportJobEndpoint.queryFresh({user: 'me'}).$promise.then(function (response) {
             _.each(response, function (job) {
-                if (job.status !== 'SUCCESS' && job.status !== 'FAILED') {
+                if (job.status !== 'SUCCESS' && job.status !== 'FAILED' && job.status !== null) {
                     queries.push(ExportJobEndpoint.getFresh({id: job.id}));
                 }
             });

--- a/app/common/services/endpoints/sdk/PostsSdk.js
+++ b/app/common/services/endpoints/sdk/PostsSdk.js
@@ -55,5 +55,31 @@ function (
         return ushahidi()
                 .bulkDelete(ids.map(i => { return {id: i} }));
     }
-    return { findPost, getPosts, savePost, bulkDelete, deletePost, bulkPatch, patchPost };
+
+    const getPostsTo = function(reason) {
+        switch (reason) {
+            case 'count':
+                return ushahidi()
+                    .getPosts(
+                        [
+                            'id'
+                        ],
+                        []
+                    );
+        }
+    }
+
+    const findPostTo = function(id, reason) {
+        switch (reason) {
+            case 'list':
+                return ushahidi()
+                    .findPost(
+                        id,
+                        ['id', 'title'], ['translations', 'enabled_languages']
+                    );
+                break;
+
+        }
+    }
+    return { findPostTo, getPostsTo, findPost, getPosts, savePost, bulkDelete, deletePost, bulkPatch, patchPost };
 }];

--- a/app/common/services/endpoints/sdk/SurveysSdk.js
+++ b/app/common/services/endpoints/sdk/SurveysSdk.js
@@ -55,8 +55,53 @@ function (
             case 'filters':
                 return ushahidi()
                     .getSurveys(
-                        ['name', 'description', 'targeted_survey', 'everyone_can_create', 'can_create', 'id'], ''
+                        [
+                            'name', 'description', 'targeted_survey', 'everyone_can_create', 'can_create', 'id'
+                        ],
+                        [
+                            'translations', 'enabled_languages'
+                        ]
                     );
+            case 'count':
+                return ushahidi()
+                    .getSurveys(
+                        [
+                            'id'
+                        ],
+                        []
+                    );
+        }
+    }
+
+    const findSurveyTo = function(id, reason) {
+        switch (reason) {
+            case 'edit':
+                return ushahidi()
+                    .findSurvey(
+                        id
+                    );
+                break;
+            case 'delete':
+                return ushahidi()
+                    .findSurvey(
+                        id,
+                        [
+                            'targeted_survey', 'everyone_can_create', 'can_create', 'id'
+                        ]
+                    );
+                break;
+            case 'get_minimal_form':
+                return ushahidi()
+                    .findSurvey(
+                        id,
+                        [
+                            'name', 'color', 'description', 'targeted_survey', 'everyone_can_create', 'can_create', 'id'
+                        ],
+                        [
+                            'translations', 'enabled_languages'
+                        ]
+                    );
+                break;
         }
     }
     const deleteSurvey = function(id) {
@@ -64,5 +109,5 @@ function (
                 .deleteSurvey(id);
     }
 
-    return { getSurveysTo, findSurvey, getSurveys, saveSurvey, deleteSurvey };
+    return { findSurveyTo, getSurveysTo, findSurvey, getSurveys, saveSurvey, deleteSurvey };
 }];

--- a/app/common/services/endpoints/sdk/SurveysSdk.js
+++ b/app/common/services/endpoints/sdk/SurveysSdk.js
@@ -18,20 +18,50 @@ function (
             Session.getSessionDataEntry('accessTokenExpires')
         );
     }
-    const getSurveys = function(id) {
+    /**
+     *
+     * @param id of the survey [optional]
+     * @param includeOnly a list in the form "id,name", the API will include everything if not set,
+     * but it will avoid hydration if the parameter is set & empty
+     * @param hydrateOnly a list in the form "tasks, categories", the API will include everything if not set,
+     * but it will avoid hydration if the parameter is set & empty
+     * @returns {{then: then}}
+     */
+    const getSurveys = function(includeOnly, hydrateOnly) {
         return ushahidi()
-                    .getSurveys(id);
+                    .getSurveys(includeOnly, hydrateOnly);
+    }
+    /**
+     *
+     * @param id of the survey [optional]
+     * @param includeOnly a list in the form "id,name", the API will include everything if not set,
+     * but it will avoid hydration if the parameter is set & empty
+     * @param hydrateOnly a list in the form "tasks, categories", the API will include everything if not set,
+     * but it will avoid hydration if the parameter is set & empty
+     * @returns {{then: then}}
+     */
+    const findSurvey = function(id, includeOnly, hydrateOnly) {
+        return ushahidi()
+            .findSurvey(id, includeOnly, hydrateOnly);
     }
 
     const saveSurvey = function(survey) {
         return ushahidi()
             .saveSurvey(survey);
     }
-
+    const getSurveysTo = function(reason) {
+        switch (reason) {
+            case 'list_and_permissions':
+                return ushahidi()
+                    .getSurveys(
+                        ['name', 'description', 'targeted_survey', 'everyone_can_create', 'can_create', 'id'], ''
+                    );
+        }
+    }
     const deleteSurvey = function(id) {
         return ushahidi()
                 .deleteSurvey(id);
     }
 
-    return { getSurveys, saveSurvey, deleteSurvey };
+    return { getSurveysTo, findSurvey, getSurveys, saveSurvey, deleteSurvey };
 }];

--- a/app/common/services/endpoints/sdk/SurveysSdk.js
+++ b/app/common/services/endpoints/sdk/SurveysSdk.js
@@ -52,6 +52,7 @@ function (
     const getSurveysTo = function(reason) {
         switch (reason) {
             case 'list_and_permissions':
+            case 'filters':
                 return ushahidi()
                     .getSurveys(
                         ['name', 'description', 'targeted_survey', 'everyone_can_create', 'can_create', 'id'], ''

--- a/app/main/activity/crowdsourced-survey-table.html
+++ b/app/main/activity/crowdsourced-survey-table.html
@@ -1,5 +1,5 @@
 <div>
-    <loading-dots button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="!noSurveys && crowdsourcedSurveyStatsByForm.length === 0"></loading-dots>
+    <loading-dots-button button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="!noSurveys && crowdsourcedSurveyStatsByForm.length === 0"></loading-dots-button>
     <fieldset ng-if="crowdsourcedSurveyStatsByForm.length >= 1">
         <table>
             <thead>
@@ -10,7 +10,7 @@
                     <th translate="activity.email">Email</th>
                     <th translate="activity.sms">SMS</th>
                     <th translate="activity.twitter">Twitter</th>
-                    
+
                 </tr>
             </thead>
 

--- a/app/main/activity/targeted-survey-table.html
+++ b/app/main/activity/targeted-survey-table.html
@@ -1,5 +1,5 @@
 <div>
-    <loading-dots button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="!noSurveys && targetedSurveyStatsByForm.length === 0"></loading-dots>
+    <loading-dots-button button-class="'button-gamma button-flat'" label="'app.loading'" ng-if="!noSurveys && targetedSurveyStatsByForm.length === 0"></loading-dots-button>
     <fieldset ng-if="targetedSurveyStatsByForm.length >= 1">
         <table>
             <thead>
@@ -9,7 +9,7 @@
                     <th translate="activity.outbound">Outbound Surveying Messages</th>
                     <th translate="activity.recipients">Unique Recipients of Targeted Survey</th>
                     <th translate="activity.responders">Unique Responders to Targeted Survey</th>
-                    
+
                 </tr>
             </thead>
 

--- a/app/main/posts/common/post-survey.service.js
+++ b/app/main/posts/common/post-survey.service.js
@@ -52,7 +52,7 @@ function PostSurveyService(
     function allowedSurveys() {
         var allowed_forms = $q.defer();
 
-        SurveysSdk.getSurveys().then(forms => {
+        SurveysSdk.getSurveysTo('list_and_permissions').then(forms => {
             if ($rootScope.hasPermission('Manage Posts')) {
                 allowed_forms.resolve(forms);
             } else {

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -58,7 +58,7 @@ function PostDetailDataController(
         // Load the post form
         if ($scope.post && $scope.post.form_id && !$scope.post.form) {
                 // Set page title to '{form.name} Details' if a post title isn't provided.
-                SurveysSdk.findSurvey($scope.post.form_id, ['name', 'id']).then(form => {
+                SurveysSdk.findSurveyTo($scope.post.form_id, 'get_minimal_form').then(form => {
                     $scope.post.form = form;
                 // Make the first task visible
                 if (!_.isEmpty($scope.post.post_content) && $scope.post.post_content.length > 1) {

--- a/app/main/posts/detail/post-detail-data.directive.js
+++ b/app/main/posts/detail/post-detail-data.directive.js
@@ -38,8 +38,10 @@ function PostDetailDataController(
     SurveysSdk,
     TranslationService
 ) {
-    $scope.$watch('post', function (post) {
-        activate();
+    $scope.$watch('post', function (post, oldVal) {
+        if (post !== oldVal) {
+            activate();
+        }
     });
 
     $scope.post = $scope.post.data.result;
@@ -53,24 +55,15 @@ function PostDetailDataController(
     activate();
 
     function activate() {
-
         // Load the post form
-        if ($scope.post && $scope.post.form_id) {
+        if ($scope.post && $scope.post.form_id && !$scope.post.form) {
                 // Set page title to '{form.name} Details' if a post title isn't provided.
-                SurveysSdk.getSurveys($scope.post.form_id).then(form => {
+                SurveysSdk.findSurvey($scope.post.form_id, ['name', 'id']).then(form => {
                     $scope.post.form = form;
-                    // We might want to remove this since the form-name is already in the title now
-                if (!$scope.post.title) {
-                    $translate('post.type_details', {type: $scope.post.form.name}).then(function (title) {
-                        $scope.$emit('setPageTitle', title);
-                    });
-                }
-
                 // Make the first task visible
                 if (!_.isEmpty($scope.post.post_content) && $scope.post.post_content.length > 1) {
                     $scope.visibleTask = $scope.post.post_content[1].id;
                 }
-
                 _.each($scope.post.post_content, function (task) {
                     // Mark completed tasks
                         if (_.indexOf($scope.post.completed_stages, task.id) !== -1) {
@@ -78,8 +71,8 @@ function PostDetailDataController(
                         }
                     });
                 });
-            };
-        }
+        };
+    }
 
     $scope.publishedFor = function () {
         if ($scope.post.status === 'draft') {

--- a/app/main/posts/detail/post-value.directive.js
+++ b/app/main/posts/detail/post-value.directive.js
@@ -23,7 +23,7 @@ module.exports = ['PostEndpoint', 'moment', '_','PostsSdk', function (PostEndpoi
                 return false;
             }
             if ($scope.attribute.type === 'relation') {
-                PostsSdk.findPost($scope.attribute.value.value).then(post=>{
+                PostsSdk.findPostTo($scope.attribute.value.value, 'list').then(post=>{
                     $scope.attribute.value.value = post.data.result;
                     $scope.$apply();
                 });

--- a/app/main/posts/detail/post-value.html
+++ b/app/main/posts/detail/post-value.html
@@ -13,7 +13,8 @@
 
       </div>
       <div ng-if="attribute.type === 'relation'" >
-          <a ui-sref="posts.data.detail({postId: attribute.value.value.id})">{{attribute.value.value.title}}</a>
+
+          <a ui-sref="posts.data.detail({postId: attribute.value.value.id})">{{attribute.value.value.translations[activeLanguage].title || attribute.value.value.title}}</a>
           <!-- fwd porting notes start -->
           <!-- @review: take a look at post related rendering in case it broke during fwd porting-->
           <!-- <a ui-sref="posts.data.detail({postId: entry.id})"><bdi>{{entry.title}}</bdi></a>&ndash;&gt; -->
@@ -33,7 +34,7 @@
           <p><bdi>{{attribute.value.value}}</bdi></p>
       </div>
       <div ng-if="!isText() && attribute.input !=='checkbox' && attribute.input !=='relation' && attribute.input !== 'tags' &&  attribute.value.translations[activeLanguage].value">
-        <p><bdi>{{attribute.value.translations[activeLanguage].value}}</bdi></p>        
+        <p><bdi>{{attribute.value.translations[activeLanguage].value}}</bdi></p>
       </div>
       <div ng-if="attribute.input ==='checkbox' && !attribute.value.translations[activeLanguage].value " ng-repeat="entry in attribute.value.value track by $index">
         <p><bdi>{{entry}}</bdi></p>

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -70,9 +70,11 @@ function PostDataEditorController(
     $scope.submit = $translate.instant('app.submit');
     $scope.submitting = $translate.instant('app.submitting');
     $scope.hasPermission = $rootScope.hasPermission('Manage Posts');
-    $scope.loadData = loadData;
+    $scope.adjustPost = adjustPost;
     $scope.isSaving = LoadingProgress.getSavingState;
     $scope.removeLanguage = removeLanguage;
+    $scope.loadSurvey = loadSurvey;
+
     var ignoreCancelEvent = false;
     // Need state management
     $scope.$on('event:edit:post:reactivate', function () {
@@ -166,27 +168,27 @@ function PostDataEditorController(
 
     function activate() {
         if ($scope.post.form_id) {
-            SurveysSdk.findSurvey($scope.post.form_id).then(result => {
-                $scope.post.form = result;
-                $scope.$apply();
-                $scope.loadData();
-            });
+            loadSurvey($scope.post.form_id);
         } else {
-            console.error('There is no post.form_id for post' + $scope.post.id);
+            SurveysSdk.getSurveysTo('list_and_permissions').then(forms => {
+                $scope.forms = forms;
+                $scope.$apply();
+            });
         }
-        // @QUESTION: when would this happen? and why?
-        // else {
-        //     SurveysSdk.getSurveys().then(forms => {
-        //         $scope.forms = forms;
-        //         $scope.$apply();
-        //     });
-        // }
         $scope.medias = {};
         $scope.savingText = $translate.instant('app.saving');
         $scope.submittingText = $translate.instant('app.submitting');
     }
 
-    function loadData() {
+    function loadSurvey(id) {
+        SurveysSdk.findSurvey(id).then(result => {
+            $scope.post.form = result;
+            $scope.$apply();
+            $scope.adjustPost();
+        });
+    }
+
+    function adjustPost() {
         $scope.post.form_id = $scope.post.form.id;
         $scope.getLock();
         $scope.post.translations = Object.assign({}, $scope.post.translations);

--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -166,16 +166,19 @@ function PostDataEditorController(
 
     function activate() {
         if ($scope.post.form_id) {
-            SurveysSdk.getSurveys($scope.post.form_id).then(result => {
+            SurveysSdk.findSurvey($scope.post.form_id).then(result => {
                 $scope.loadData(result);
             });
-
         } else {
-            SurveysSdk.getSurveys().then(forms => {
-                $scope.forms = forms;
-                $scope.$apply();
-            });
+            console.error('There is no post.form_id for post' + $scope.post.id);
         }
+        // @QUESTION: when would this happen? and why?
+        // else {
+        //     SurveysSdk.getSurveys().then(forms => {
+        //         $scope.forms = forms;
+        //         $scope.$apply();
+        //     });
+        // }
         $scope.medias = {};
         $scope.savingText = $translate.instant('app.saving');
         $scope.submittingText = $translate.instant('app.submitting');

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -39,7 +39,7 @@
               ng-change="loadData(form)"
               ng-model="post.form"
             >
-              <option selected disabled translate>post.unstructured.add_survey.choose</option>              
+              <option selected disabled translate>post.unstructured.add_survey.choose</option>
               <option ng-repeat="form in forms" ng-value="form">
                 {{form.translations[languages.default].name || form.name}}
               </option>
@@ -85,7 +85,7 @@
 
           <button class="button-flat" ng-click="cancel()" translate>app.cancel</button>
           <button class="button button-alpha" ng-click="savePost()" ng-if="!isSaving()" translate="">app.save</button>
-          <loading-dots button-class="'button-alpha'" ng-if="isSaving()" disabled=true label="'app.saving'"></loading-dots>
+          <loading-dots-button button-class="'button-alpha'" ng-if="isSaving()" disabled=true label="'app.saving'"></loading-dots-button>
         </div>
       </div>
   </form>

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -41,7 +41,7 @@
             <select
               ng-if="forms"
               class="custom-select"
-              ng-change="loadData()"
+              ng-change="loadSurvey(post.form.id)"
               ng-model="post.form"
             >
               <option selected disabled translate>post.unstructured.add_survey.choose</option>

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -88,14 +88,11 @@ function PostEditorController(
     }
 
     function loadData() {
-        let requests = [SurveysSdk.getSurveys($scope.formId), CategoriesSdk.getCategories()];
+        let requests = [SurveysSdk.findSurvey($scope.formId)];
         return $q.all(requests).then(function (results) {
             $scope.post.form = results[0];
             $scope.post.post_content = results[0].tasks;
             $scope.languages = {default: results[0].enabled_languages.default, active: results[0].enabled_languages.default,  available: [results[0].enabled_languages.default, ...results[0].enabled_languages.available]}
-
-            var categories = results[1];
-
             // Initialize values on new post
             $scope.post.post_content.map(task => {
                 task.fields.map (attr => {

--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -88,7 +88,7 @@ function PostEditorController(
     }
 
     function loadData() {
-        let requests = [SurveysSdk.findSurvey($scope.formId)];
+        let requests = [SurveysSdk.findSurveyTo($scope.formId, 'get_minimal_form')];
         return $q.all(requests).then(function (results) {
             $scope.post.form = results[0];
             $scope.post.post_content = results[0].tasks;

--- a/app/main/posts/views/filters/filter-form.directive.js
+++ b/app/main/posts/views/filters/filter-form.directive.js
@@ -36,7 +36,7 @@ function FormSelectDirective($rootScope, SurveysSdk, TranslationService) {
         }
         function activate() {
             // Load forms
-            SurveysSdk.getSurveys().then(surveys => {
+            SurveysSdk.getSurveys(['id', 'name', 'translations']).then(surveys => {
                 scope.forms = surveys;
                 scope.$apply();
             });

--- a/app/main/posts/views/filters/filter-form.directive.js
+++ b/app/main/posts/views/filters/filter-form.directive.js
@@ -34,6 +34,7 @@ function FormSelectDirective($rootScope, SurveysSdk, TranslationService) {
                 Array.prototype.splice.apply(scope.selectedForms, [0, scope.selectedForms.length]);
             }
         }
+
         function activate() {
             // Load forms
             SurveysSdk.getSurveysTo('filters').then(surveys => {

--- a/app/main/posts/views/filters/filter-form.directive.js
+++ b/app/main/posts/views/filters/filter-form.directive.js
@@ -36,7 +36,7 @@ function FormSelectDirective($rootScope, SurveysSdk, TranslationService) {
         }
         function activate() {
             // Load forms
-            SurveysSdk.getSurveys(['id', 'name', 'translations']).then(surveys => {
+            SurveysSdk.getSurveysTo('filters').then(surveys => {
                 scope.forms = surveys;
                 scope.$apply();
             });

--- a/app/main/posts/views/mode-context-form-filter.directive.js
+++ b/app/main/posts/views/mode-context-form-filter.directive.js
@@ -44,12 +44,12 @@ function ModeContextFormFilter($scope, PostEndpoint, $q, _, $rootScope, PostSurv
 
     function activate() {
         // Load forms
-        SurveysSdk.getSurveys().then(forms => {
+        SurveysSdk.getSurveysTo('filters').then(forms => {
             $scope.forms = forms;
             $scope.$apply();
         });
         getUserLanguage();
-        var postCountRequest = getPostStats($scope.filters);
+        let postCountRequest = getPostStats($scope.filters);
         $q.all([$scope.forms.$promise, postCountRequest.$promise]).then(function (responses) {
             if (!responses[1] || !responses[1].totals || !responses[1].totals[0]) {
                 return;

--- a/app/main/posts/views/post-toolbar.html
+++ b/app/main/posts/views/post-toolbar.html
@@ -15,7 +15,7 @@
         <div ng-if="editMode()">
             <button ng-if="hasPermission" class="button" ng-click="cancel()" translate>app.cancel</button>
             <button ng-if="hasPermission && !isSaving()" ng-click="savePost()" class=" button button-alpha" translate>app.save</button>
-            <loading-dots button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots>
+            <loading-dots-button button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots-button>
         </div>
     </div>
 
@@ -34,7 +34,7 @@
                 </div>
             </div>
         </div>
-        <loading-dots button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots>
+        <loading-dots-button button-class="'button-alpha'" disabled=true label="'app.saving'" ng-if="isSaving()"></loading-dots-button>
     </div>
 
     <!-- toolbar -->

--- a/app/main/posts/views/post-view-data.html
+++ b/app/main/posts/views/post-view-data.html
@@ -91,7 +91,7 @@
                 <div class="listing-item-primary">
                     <button ng-disabled="isLoading()" ng-hide="( isLoading() || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
                     </button>
-                     <loading-dots button-class="'button-gamma button-flat'" label="'app.loading'" ng-show="isLoading()"></loading-dots>
+                     <loading-dots-button button-class="'button-gamma button-flat'" label="'app.loading'" ng-show="isLoading()"></loading-dots-button>
                 </div>
             </div>
         </div>

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -5,13 +5,17 @@ module.exports = [
     'Editor',
     'Notify',
     'UshahidiSdk',
+    'CategoriesSdk',
+    'SurveysSdk',
 function (
     $rootScope,
     ModalService,
     _,
     Editor,
     Notify,
-    UshahidiSdk
+    UshahidiSdk,
+    CategoriesSdk,
+    SurveysSdk
     ) {
     return {
         restrict: 'E',
@@ -49,6 +53,7 @@ function (
                  * that makes the scroll get stuck inside the editor-area */
                 let editor = document.querySelector('#editSection');
                 editor.style.height = `${editorHeight + 60}px`;
+
             };
 
             initiateEditor();

--- a/app/settings/surveys/attribute-editor.directive.js
+++ b/app/settings/surveys/attribute-editor.directive.js
@@ -5,17 +5,13 @@ module.exports = [
     'Editor',
     'Notify',
     'UshahidiSdk',
-    'CategoriesSdk',
-    'SurveysSdk',
 function (
     $rootScope,
     ModalService,
     _,
     Editor,
     Notify,
-    UshahidiSdk,
-    CategoriesSdk,
-    SurveysSdk
+    UshahidiSdk
     ) {
     return {
         restrict: 'E',

--- a/app/settings/surveys/attribute-editor.html
+++ b/app/settings/surveys/attribute-editor.html
@@ -44,7 +44,9 @@
   <!-- editing/adding categories -->
   <div class="form-field" ng-if="editField.input ==='tags'">
     <label translate="category.which_categories">Which categories should be available</label>
+    <loading-dots button-class="'button-alpha'" not-button="true" disabled=true label="'app.loading'" ng-if="!availableCategories"></loading-dots>
     <category-selector
+        ng-if="availableCategories"
         available="availableCategories"
         selected="editField.options"
         enable-parents="true"
@@ -55,6 +57,7 @@
   <!-- End of editing/adding categories -->
   <div class="form-field" ng-if="editField.input === 'relation'">
     <label translate>survey.field_allowed_relation_survey</label>
+    <loading-dots button-class="'button-alpha'" not-button="true" disabled=true label="'app.loading'" ng-if="!availableSurveys"></loading-dots>
     <div name="visible-to">
       <div class="form-field checkbox" ng-repeat="relationForm in availableSurveys | filter : filterNotCurrentForm">
         <label>

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -263,6 +263,7 @@ function SurveyEditorController(
                 })
                 .filter()
                 .value();
+            $scope.$apply();
         });
     }
 

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -196,7 +196,7 @@ function SurveyEditorController(
 
         if (!$scope.surveyId) {
 
-            $q.all([Features.loadFeatures(), SurveysSdk.getSurveys()]).then(function (data) {
+            $q.all([Features.loadFeatures(), SurveysSdk.getSurveysTo('count')]).then(function (data) {
                 var forms_limit = Features.getLimit('forms');
                 // When limit is TRUE , it means no limit
                 // @todo run check before render
@@ -229,7 +229,7 @@ function SurveyEditorController(
     }
 
     function getInterimId() {
-        var id = 'interim_id_' + $scope.currentInterimId;
+        const id = 'interim_id_' + $scope.currentInterimId;
         $scope.currentInterimId++;
         return id;
     }
@@ -242,7 +242,7 @@ function SurveyEditorController(
 
     function loadAvailableForms() {
         // Get available forms for relation field
-        SurveysSdk.getSurveys().then(function (forms) {
+        SurveysSdk.getSurveysTo('list_and_permissions').then(function (forms) {
             $scope.availableSurveys = forms;
         });
     }

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -189,11 +189,6 @@ function SurveyEditorController(
             $scope.survey.tasks[0].id = $scope.getInterimId();
         }
 
-        // @QUESTION-jan-26: WHY? This is the editor, we know what we need
-            // loadAvailableForms();
-
-        loadAvailableCategories();
-
         if (!$scope.surveyId) {
 
             $q.all([Features.loadFeatures(), SurveysSdk.getSurveysTo('count')]).then(function (data) {
@@ -244,6 +239,7 @@ function SurveyEditorController(
         // Get available forms for relation field
         SurveysSdk.getSurveysTo('list_and_permissions').then(function (forms) {
             $scope.availableSurveys = forms;
+            $scope.$apply();
         });
     }
 
@@ -500,6 +496,15 @@ function SurveyEditorController(
         let fieldType = getFieldType(field) ? getFieldType(field) : field.label;
         let title = field.id ? $translate.instant('survey.edit_field', {fieldType: fieldType}) : $translate.instant('survey.add_field', {fieldType: fieldType});
         title = title.replace('&amp;', '&');
+        switch (field.type) {
+            case 'relation':
+                loadAvailableForms();
+                break;
+            case 'tags':
+                loadAvailableCategories();
+                break;
+        }
+
         ModalService.openTemplate('<survey-attribute-editor></survey-attribute-editor>', title, '', $scope, true, true);
     }
 

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -189,7 +189,9 @@ function SurveyEditorController(
             $scope.survey.tasks[0].id = $scope.getInterimId();
         }
 
-        loadAvailableForms();
+        // @QUESTION-jan-26: WHY? This is the editor, we know what we need
+            // loadAvailableForms();
+
         loadAvailableCategories();
 
         if (!$scope.surveyId) {
@@ -271,7 +273,7 @@ function SurveyEditorController(
     function loadFormData() {
         // If we're editing an existing survey,
         // load the survey info and all the fields.
-        SurveysSdk.getSurveys($scope.surveyId).then(res => {
+        SurveysSdk.findSurvey($scope.surveyId).then(res => {
             //Getting roles for the survey
             $scope.survey = res;
 

--- a/app/settings/surveys/surveys.controller.js
+++ b/app/settings/surveys/surveys.controller.js
@@ -25,7 +25,6 @@ function (
     if ($rootScope.hasManageSettingsPermission() === false) {
         return $location.path('/');
     }
-
     $translate('nav.posts_and_entities').then(function (title) {
         $scope.title = title;
         $scope.$emit('setPageTitle', title);
@@ -39,11 +38,14 @@ function (
     });
 
     // Get all the forms for display
+    //@QUESTION-jan26: WHY?
     $scope.refreshForms = function () {
-        SurveysSdk.getSurveys().then(function (forms) {
-            $scope.forms = forms;
-            $scope.$apply();
-        });
+        if ($location.path('/settings/surveys')) {
+            return SurveysSdk.getSurveys(['id', 'name', 'translations']).then(function (forms) {
+                $scope.forms = forms;
+                $scope.$apply();
+            });
+        }
     };
 
     $scope.deleteSurvey = function (survey) {

--- a/app/settings/surveys/surveys.controller.js
+++ b/app/settings/surveys/surveys.controller.js
@@ -41,7 +41,7 @@ function (
     //@QUESTION-jan26: WHY?
     $scope.refreshForms = function () {
         if ($location.path('/settings/surveys')) {
-            return SurveysSdk.getSurveys(['id', 'name', 'translations']).then(function (forms) {
+            return SurveysSdk.getSurveysTo('list_and_permissions').then(function (forms) {
                 $scope.forms = forms;
                 $scope.$apply();
             });

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "sortablejs": "1.10.0",
     "underscore": "^1.7.0",
     "ushahidi-platform-pattern-library": "4.4.4-pre.6",
-    "ushahidi-platform-sdk": "^0.4.0"
+    "ushahidi-platform-sdk": "^0.5.0"
   },
   "engines": {
     "node": ">=10.0"


### PR DESCRIPTION
This pull request makes the following changes:
- Limits API usage in the platform client to only get the things it needs at each point
- Removed "broken" exports so they aren't being checked every few seconds for eternity, slowing everything down
Testing checklist:
- [x] Survey creation
     - [x] Related posts
     - [x] Categories
     - [x] Translations
- [x] Data view
     - [x] Post view detail
     - [x] Filters
     - [x] Delete, bulk delete, bulk status update, status update
     - [x] translations for posts and their entities
- [ ] General smoke testing required
- [x] Exports (CSV) notifications - verify that when you create an export, and leave the page, you get notified of its completion
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
