### PR TITLE
Make account settings accessible

### DIFF
--- a/app/common/user-profile/account_settings.html
+++ b/app/common/user-profile/account_settings.html
@@ -6,12 +6,12 @@
   <nav class="tabs-menu init">
     <ul>
       <li ng-class="{'active': general}">
-        <a ng-click="showGeneral()" translate>
+        <button ng-click="showGeneral()" class="tab-button" translate ng-disabled="general">
           user_profile.nav.general
         </a>
       </li>
       <li ng-class="{'active': notifications}">
-        <a ng-click="showNotifications()" translate>
+        <button ng-click="showNotifications()" class="tab-button" translate ng-disabled="notifications">
           user_profile.nav.notifications
         </a>
       </li>

--- a/app/common/user-profile/notifications.directive.js
+++ b/app/common/user-profile/notifications.directive.js
@@ -132,12 +132,6 @@ module.exports = [
                     contact.active = !contact.active;
                 };
 
-                $scope.handleToggle = function () {
-                    var toggleButton = document.getElementsByClassName('tgl');
-                    console.log(toggleButton);
-                    toggleButton.checked = !toggleButton.checked;
-                };
-
                 // Only enable Save if active contacts are valid
                 $scope.canUpdate = function () {
                     // Get contacts that are currently being edited

--- a/app/common/user-profile/notifications.directive.js
+++ b/app/common/user-profile/notifications.directive.js
@@ -132,6 +132,12 @@ module.exports = [
                     contact.active = !contact.active;
                 };
 
+                $scope.handleToggle = function () {
+                    var toggleButton = document.getElementsByClassName('tgl');
+                    console.log(toggleButton);
+                    toggleButton.checked = !toggleButton.checked;
+                };
+
                 // Only enable Save if active contacts are valid
                 $scope.canUpdate = function () {
                     // Get contacts that are currently being edited

--- a/app/common/user-profile/notifications.html
+++ b/app/common/user-profile/notifications.html
@@ -32,7 +32,7 @@
                    id="{{contact.id || false}}"
                    type="checkbox"
                    ng-model="contact.can_notify">
-            <label class="tgl-btn" for="{{contact.id || false}}" ng-click=handleToggle()></label>
+            <label class="tgl-btn" for="{{contact.id || false}}"></label>
           </div>
         </div>
 

--- a/app/common/user-profile/notifications.html
+++ b/app/common/user-profile/notifications.html
@@ -32,7 +32,7 @@
                    id="{{contact.id || false}}"
                    type="checkbox"
                    ng-model="contact.can_notify">
-            <label class="tgl-btn" for="{{contact.id || false}}"></label>
+            <label class="tgl-btn" for="{{contact.id || false}}" ng-click=handleToggle()></label>
           </div>
         </div>
 
@@ -91,7 +91,7 @@
          >
       <div class="listing-item-primary">
         <h2 class="listing-item-title">
-          <a class="button button-flat"
+          <button class="button button-flat"
              role="button"
              ng-click="toggleActive(contact)"
              translate>
@@ -99,7 +99,7 @@
               <use xlink:href="/img/iconic-sprite.svg#plus"></use>
             </svg>
             contact.button.add
-          </a>
+          </button>
         </h2>
       </div>
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "socket.io-client": "2.0.3",
     "sortablejs": "1.10.0",
     "underscore": "^1.7.0",
-    "ushahidi-platform-pattern-library": "4.4.4-pre.6",
+    "ushahidi-platform-pattern-library": "4.4.9",
     "ushahidi-platform-sdk": "^0.4.0"
   },
   "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- Makes account settings accessible

Testing checklist:
- [ ] Log in to your account.
- [ ] Open account settings by clicking on your profile picture.
- [ ] The modal that opens would be accessible.

- [x] I certify that I ran my checklist

Recording:
![account_settings](https://user-images.githubusercontent.com/70752431/106242160-41af7400-622d-11eb-9b80-a5e92e05292a.gif)


Fixes ushahidi/platform#4194 .

Ping @ushahidi/platform
