### PR TITLE
assigning unstructured posts to a form

### DIFF
--- a/app/main/posts/modify/post-data-editor.directive.js
+++ b/app/main/posts/modify/post-data-editor.directive.js
@@ -167,7 +167,9 @@ function PostDataEditorController(
     function activate() {
         if ($scope.post.form_id) {
             SurveysSdk.getSurveys($scope.post.form_id).then(result => {
-                $scope.loadData(result);
+                $scope.post.form = result;
+                $scope.$apply();
+                $scope.loadData();
             });
 
         } else {
@@ -181,8 +183,8 @@ function PostDataEditorController(
         $scope.submittingText = $translate.instant('app.submitting');
     }
 
-    function loadData(form) {
-        $scope.post.form = form;
+    function loadData() {
+        $scope.post.form_id = $scope.post.form.id;
         $scope.getLock();
         $scope.post.translations = Object.assign({}, $scope.post.translations);
         if (!$scope.post.enabled_languages) {
@@ -190,7 +192,7 @@ function PostDataEditorController(
         }
         $scope.languages = {default: $scope.post.enabled_languages.default, available: $scope.post.enabled_languages.available, active: $scope.post.enabled_languages.default, surveyLanguages:[$scope.post.form.enabled_languages.default, ...$scope.post.form.enabled_languages.available]};
 
-        if (!$scope.post.post_content) {
+        if (!$scope.post.post_content || $scope.post.post_content.length === 0) {
             $scope.post.post_content = $scope.post.form.tasks;
         }
             // Initialize values on empty post-fields

--- a/app/main/posts/modify/post-data-editor.html
+++ b/app/main/posts/modify/post-data-editor.html
@@ -31,12 +31,17 @@
             class="form-field init required"
             ng-class="{'error': editForm.form.$invalid && editForm.form.$dirty, 'success': !editForm.form.$invalid && editForm.form.$dirty}"
           >
-
           <p translate="post.unstructured.add_survey.info" translate-values="{source:post.source}"></p>
           <label translate>post.unstructured.add_survey.title</label>
-              <select
+          <div class="loading" aria-label="Loading forms" ng-if="!forms" translate>
+              <div class="line"></div>
+              <div class="line"></div>
+              <div class="line"></div>
+          </div>
+            <select
+              ng-if="forms"
               class="custom-select"
-              ng-change="loadData(form)"
+              ng-change="loadData()"
               ng-model="post.form"
             >
               <option selected disabled translate>post.unstructured.add_survey.choose</option>              


### PR DESCRIPTION
This pull request makes the following changes:
- Refactor to assign selected form to an unstructured post

Testing checklist:
- Go to an unstructred posts
- Click edit
- [ ] You should see a dropdown with form-names
- Select a form
- [ ] The edit-view should appear
- Change the title and description to something new
- Add some more fields 
- Save
- [ ] The changed fields should save
- Go to a structured post
- Click edit
- [ ] The fields to edit should appear as normal
- Make some changes
- Save
- [ ] The changes should be saved

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
