### PR TITLE
Make collections list accessible

### DIFF
--- a/app/main/posts/collections/listing.html
+++ b/app/main/posts/collections/listing.html
@@ -22,9 +22,9 @@
                 </div>
                 <div class="listing-item-primary">
                     <h2 class="listing-item-title">
-                        <a ng-click="collectionClickHandler(collection)">
+                        <button class="button-export" ng-click="collectionClickHandler(collection)">
                             {{collection.name}}
-                        </a>
+                        </button>
                     </h2>
                     <p class="listing-item-secondary" ng-if="collection.user_id">
                         <span translate>


### PR DESCRIPTION
This pull request makes the following changes:
- makes the collections in collections menu accessible.

Testing checklist:
- [ ] Open the collections modal
- [ ] You can now access all the collections in the menu via keyboard
- [ ] Press enter when focus is on any of the collections and the collection would open.

- [x] I certify that I ran my checklist

Recording:
![collections_access](https://user-images.githubusercontent.com/70752431/106555433-91e74880-6543-11eb-82e1-08ef689fd5b6.gif)

Fixes ushahidi/platform#4192 .

Ping @ushahidi/platform
