### PR TITLE
Prefilling translation-editor with translated values

### DIFF
--- a/app/main/posts/modify/post-translation-editor.directive.js
+++ b/app/main/posts/modify/post-translation-editor.directive.js
@@ -1,3 +1,5 @@
+const { forEach } = require('angular');
+
 module.exports = PostTranslationEditor;
 
 PostTranslationEditor.$inject = [];
@@ -20,9 +22,35 @@ PostTranslationEditorController.$inject = ['$scope', '_'];
 function PostTranslationEditorController($scope, _) {
 
     $scope.canTranslate = canTranslate;
+    $scope.$watch('activeLanguage', () =>{
+        if ($scope.activeLanguage && $scope.activeLanguage !== $scope.defaultLanguage) {
+            addPrefillValue();
+        }
+        });
 
     function activate() {}
     activate();
+
+    function addPrefillValue() {
+        _.each($scope.post.post_content, task => {
+            _.each(task.fields, field => {
+                if (field.type === 'title' || field.type === 'description') {
+                    let fieldType = field.type === 'description' ? 'content' : 'title';
+                    if (!$scope.post.translations[$scope.activeLanguage]) {
+                        $scope.post.translations[$scope.activeLanguage] = {};
+                    }
+                    // Checking if there already is a translated value
+                    let value = $scope.post.translations[$scope.activeLanguage][fieldType] ? $scope.post.translations[$scope.activeLanguage][fieldType] : null;
+                    // Checking if there is a default value
+                    let defaultValue = field.translations[$scope.activeLanguage] && field.translations[$scope.activeLanguage].default ? field.translations[$scope.activeLanguage].default : null;
+                    // Assigning default-value if no other value is present
+                    if (!value && defaultValue) {
+                        $scope.post.translations[$scope.activeLanguage][fieldType] = defaultValue;
+                    }
+                }
+            });
+        });
+    }
 
     function canTranslate(field) {
         return field.type === 'text' || field.type === 'markdown' ||


### PR DESCRIPTION
This pull request makes the following changes:
- Prefills title and description-fields in the post-translation-editor if there is default values.

Testing checklist:
- Make sure you work with a post added to a survey that has translated default values for title and description
- Edit a post without translations
- Add a translation to the post
- [ ] The translated default values should be prefilled in the title and description edit-fields
- Save
- [ ] The translated default values should be saved and displayed when you switch languages
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
