### PR TITLE
fix(post-detail,categories): restores behavior of parent categories b…

### DIFF
--- a/app/main/posts/detail/post-category-value.directive.js
+++ b/app/main/posts/detail/post-category-value.directive.js
@@ -16,9 +16,16 @@ function PostCategoryValue() {
 PostCategoryValueController.$inject = ['$scope', '_', 'CategoriesSdk'];
 
 function PostCategoryValueController($scope, _, CategoriesSdk) {
+    // Make a list of parent category ids referenced by categories in the list
+    let parent_ids = _.uniq(_.without(_.pluck($scope.categories, 'parent_id'), null));
     $scope.display = $scope.categories.filter(f => {
+        // Hide categories that have been marked as inaccessible by the API
         if (_.isUndefined(f._ush_hidden)) {
-            return f;
+            // Hide categories that have been referenced as their parent categories by some
+            // other category in the list
+            if (!parent_ids.includes(f.id)) {
+                return f;
+            }
         }
     });
     function activate() {}


### PR DESCRIPTION
…eing hidden in post detail view

The v5 API now returns parent categories , this has the side-effect in the client of showing those parent categories along their children. Because our display currently is just a comma separated list, this can be confusing.

It's also detrimental to some of our deployers, who had intentionally created specific survey fields for specific family groups of the defined categories.

Since there is little information to be gained from listing the parent categories along their children categories in a comma separated list (there's no display of their hierarchical relationship), we should restore the original behavior.

This pull request makes the following changes:
- This PR restores the original behavior of not listing parent categories

Testing checklist:
- [x] View a post with a category field , where some of the selected categories have parent categories
- [x] Ensure none of the categories displayed are parent categories

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
