### PR TITLE
Fix order of fields

### DIFF
--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -88,7 +88,7 @@
                <div id="survey-build-post" class="survey-details tabs-target" >
                     <div class="listing init" style="margin-left: 4px;">
                         <h3 class="listing-heading hidden" translate="survey.post_fields">Fields</h3>
-                        <div class="listing-item" ng-repeat="field in survey.tasks[0].fields track by $index">
+                        <div class="listing-item" ng-repeat="field in survey.tasks[0].fields | orderBy: 'priority'">
                             <div class="listing-item-select">
                                 <div class="buttons-updown">
                                     <button type="button" class="button-beta" ng-disabled="isFirstField(survey.tasks[0], field)" ng-click="moveFieldUp(survey.tasks[0], field)">
@@ -317,7 +317,7 @@
                 </nav>
                 <div ng-attr-id="{{ 'section-build-' + task.id }}" class="section-1-details tabs-target active">
                     <div class="listing init">
-                        <div class="listing-item" ng-repeat="field in task.fields track by $index">
+                        <div class="listing-item" ng-repeat="field in task.fields | orderBy: 'priority'">
                             <div class="listing-item-select">
                                 <div class="buttons-updown">
                                     <button type="button" class="button-beta" ng-disabled="isFirstField(task, field)" ng-click="moveFieldUp(task, field)">


### PR DESCRIPTION
This pull request makes the following changes:
- Sorts the fields in the survey-editor in the order the user has sorted them when saving

Testing checklist:
- Go to settings -> surveys
- Select an existing survey or create a new one
- Create a number of fields and then rearrange them (and remember the new arrangement 😄 )
- Save
- Go back to the survey
- [ ] The fields should be still be sorted as they were when you saved the survey
- Add a new post
- [ ] The fields should be still be sorted as they were when you saved the survey
- Submit the post
- [ ] The replies in the fields should be still be sorted as they were when you saved the survey
- Edit the post
- [ ] The replies in the fields should be still be sorted as they were when you saved the survey

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#4195.

Ping @ushahidi/platform
