### PR TITLE
fix(post-editor): Copying post-object before preparing it for save)

### DIFF
--- a/app/main/posts/modify/post-editor.directive.js
+++ b/app/main/posts/modify/post-editor.directive.js
@@ -157,11 +157,12 @@ function PostEditorController(
         // Create/update any associated media objects
         // Media creation must be completed before we can progress with saving
         resolveMedia().then(function () {
-            $scope.post.base_language = $scope.languages.active;
-            $scope.post.type = 'report';
-            $scope.post.form_id = $scope.post.form.id;
-            delete $scope.post.form;
-            let post = PostEditService.cleanTagValues(angular.copy($scope.post));
+            let post = angular.copy($scope.post);
+            post.base_language = $scope.languages.active;
+            post.type = 'report';
+            post.form_id = $scope.post.form.id;
+            delete post.form;
+            post = PostEditService.cleanTagValues(post);
             PostsSdk.savePost(post).then(function (response) {
                 post = response.data.result;
                 var success_message = (post.status && post.status === 'published') ? 'notify.post.save_success' : 'notify.post.save_success_review';


### PR DESCRIPTION
This pull request makes the following changes:
- uses a copy of the post-object to do pre-saving formatting
- this makes it possible to continue edit and save a post again after validation-errors from the backend

Testing checklist:
- Add a post to a survey with required fields
- Leave one of the required fields empty
- Save the post
- [ ] You should see an error-message
- Add a response in the required field
- Save again
- [ ] The post should save

- [ ] Repeat above for when editing a post

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
