### PR TITLE
fix language not showing in side bar

### DIFF
--- a/app/common/directives/language-switch.directive.js
+++ b/app/common/directives/language-switch.directive.js
@@ -17,11 +17,17 @@ function LanguageSwitchController($scope, Languages, TranslationService, $locati
     $scope.changeLanguage = changeLanguage;
     $scope.$on('event:authentication:login:succeeded', TranslationService.setStartLanguage);
     $scope.$on('event:authentication:logout:succeeded', TranslationService.setStartLanguage);
+    $scope.site = {};
     activate();
 
     function activate() {
         Languages.then(function (languages) {
             $scope.languages = languages;
+            TranslationService.getLanguage().then(lang =>{
+                let deflangs = languages.filter(language => (language.code).toString().split('-')[0] === lang.split('-')[0]);
+                $scope.site.language = deflangs.length === 1 ? deflangs[0].code : lang;
+            })
+
         });
     }
 

--- a/app/settings/categories/categories-edit.html
+++ b/app/settings/categories/categories-edit.html
@@ -123,9 +123,7 @@
                     <select
                           ng-model="selectedLanguage"
                           ng-options="lang.code as lang.name for lang in languagesToSelect"
-                          ng-value="lang.code"
                           ng-change="selectLanguage(selectedLanguage)"
-                          ng-selected="lang.code === selectedLanguage"
                       >
                       </select>
                 </div>

--- a/app/settings/surveys/survey-editor.directive.js
+++ b/app/settings/surveys/survey-editor.directive.js
@@ -183,6 +183,7 @@ function SurveyEditorController(
                         surveyLanguages: [$scope.survey.enabled_languages.default, ...$scope.survey.enabled_languages.available]
                     }
                     }
+                    $scope.selectedLanguage = language;
                 });
             $scope.survey.tasks[0].id = $scope.getInterimId();
         }

--- a/app/settings/surveys/survey-editor.html
+++ b/app/settings/surveys/survey-editor.html
@@ -233,7 +233,6 @@
                             <select
                                 ng-model="selectedLanguage"
                                 ng-options="lang.code as lang.name for lang in languagesToSelect"
-                                ng-value="lang.code"
                                 ng-change="selectLanguage(selectedLanguage)"
                             >
                             </select>


### PR DESCRIPTION
This pull request makes the following changes:
-

Testing checklist:
- [ x] Log in and navigate to  /settings/categories/create, the drop-down now has the default language selected.
-  [ x] Log in and navigate to  /settings/surveys/create, the drop-down now has the default language selected.
-  [ x] Language select on the sidebar now has the default language.
- [ x] I certify that I ran my checklist

Fixes ushahidi/platform#4227.

Ping @ushahidi/platform

