### PR TITLE
Update file-upload.directive.js

### DIFF
--- a/app/common/directives/file-upload.directive.js
+++ b/app/common/directives/file-upload.directive.js
@@ -17,9 +17,9 @@ function FileUpload() {
             ) {
                 $scope.required = typeof $attrs.required !== 'undefined';
 
-                $scope.$on('event:FileUpload', function (event) {
-                    angular.element(document.querySelector('#file')).val('');
-                });
+//                 $scope.$on('event:FileUpload', function (event) {
+//                     angular.element(document.querySelector('#file')).val('');
+//                 });
 
                 $scope.uploadFile = function ($event) {
                     if (validateFile($event.target.files[0])) {

--- a/app/common/directives/file-upload.directive.js
+++ b/app/common/directives/file-upload.directive.js
@@ -17,9 +17,9 @@ function FileUpload() {
             ) {
                 $scope.required = typeof $attrs.required !== 'undefined';
 
-//                 $scope.$on('event:FileUpload', function (event) {
-//                     angular.element(document.querySelector('#file')).val('');
-//                 });
+                $scope.$on('event:FileUpload', function (event) {
+                    angular.element(document.querySelector('#file')).val('');
+                });
 
                 $scope.uploadFile = function ($event) {
                     if (validateFile($event.target.files[0])) {

--- a/app/common/directives/file-upload.html
+++ b/app/common/directives/file-upload.html
@@ -1,1 +1,1 @@
-<input id="file" name="file" type="file" custom-on-change='uploadFile' ng-required="{{ required }}" />
+<input name="file" type="file" custom-on-change='uploadFile' ng-required="{{ required }}" />

--- a/app/settings/donation/donation.html
+++ b/app/settings/donation/donation.html
@@ -103,7 +103,7 @@
 
                                     <div class="form-field">
                                         <label for="photo">Attach an image</label>
-                                        <file-upload container="image">
+                                        <file-upload id="file" container="image">
                                         </file-upload>
                                     </div>
                                 </div>


### PR DESCRIPTION
The commented line of code was supposed to be for a UX improvement when uploading multiple photos on the donation settings page, but it seems to be causing issues where the file upload directive is required.

This pull request makes the following changes:
- make it possible to upload an image again.

Fixes ushahidi/platform#4244 .

Ping @ushahidi/platform
