### PR TITLE
 Adding a button instead of a checkbox when disabling monetization

### DIFF
--- a/app/common/locales/en.json
+++ b/app/common/locales/en.json
@@ -24,6 +24,10 @@
         },
         "donate": "Donate",
         "donation": "Donation",
+        "disable_monetization": "Disable Monetization",
+        "enable_monetization": "Enable Monetization",
+        "enable_monetization_error": "Fill in required fields above before enabling monetization.",
+        "enable_monetization_info": "Monetization is currently disabled.",
         "intercom": {
             "intercom" : "Intercom",
             "description" : "Contact Ushahidi staff for chat support"

--- a/app/settings/donation/donation.directive.js
+++ b/app/settings/donation/donation.directive.js
@@ -65,6 +65,11 @@ module.exports = [
                     });
                 }
 
+                $scope.toggleMonetization = function () {
+                    $scope.site.donation.enabled = !$scope.site.donation.enabled;
+                    $scope.updateConfig();
+                }
+
                 function uploadImage() {
                     var dfd = $q.defer();
                     if ($scope.image.file) {

--- a/app/settings/donation/donation.directive.js
+++ b/app/settings/donation/donation.directive.js
@@ -66,8 +66,14 @@ module.exports = [
                 }
 
                 $scope.toggleMonetization = function () {
-                    $scope.site.donation.enabled = !$scope.site.donation.enabled;
-                    $scope.updateConfig();
+                    // we don't need to have a valid form if disabling monetization
+                    if ($scope.form.$valid || $scope.site.donation.enabled) {
+                        $scope.site.donation.enabled = !$scope.site.donation.enabled;
+                        $scope.showMessage = false;
+                        $scope.updateConfig();
+                    } else {
+                        $scope.showMessage = true;
+                    }
                 }
 
                 function uploadImage() {

--- a/app/settings/donation/donation.html
+++ b/app/settings/donation/donation.html
@@ -57,6 +57,7 @@
                             <div>
                                 <div class="form-field">
                                     <label for="donation-title"
+                                        class="required"
                                         ng-class="{'success': !form.title.$invalid && form.title.$dirty, 'error' : form.title.$invalid && form.title.$dirty }"
                                         translate>
                                         settings.donation.title.label
@@ -125,7 +126,7 @@
 
                             <div>
                                 <div class="form-field">
-                                    <label for="donation-wallet">Wallet address </label>
+                                    <label for="donation-wallet" class="required">Wallet address </label>
                                     <input name="wallet" id="donation-wallet" type="text" ng-model="site.donation.wallet"
                                         ng-required="true" placeholder="Enter a wallet address e.g $ilp.uphold.com/example" />
                                     <div class="alert error" ng-repeat="(error, value) in form.wallet.$error"

--- a/app/settings/donation/donation.html
+++ b/app/settings/donation/donation.html
@@ -147,21 +147,18 @@
                         </div>
 
                         <div class="form-field">
-                            <label>
-                                Disable Monetization
-                                <input id="donations-disable" type="checkbox"
-                                    class="ng-pristine ng-untouched ng-valid ng-empty" ng-model="site.donation.enabled"
-                                    ng-true-value="false" ng-false-value="true">
-                            </label>
+                            <div ng-if="site.donation.enabled">
+                                <button class="button-destructive"  ng-click="toggleMonetization()">Disable Monetization</button>
+                            </div>
+                            <div ng-if="!site.donation.enabled" >
+                                <div class="alert">
+                                    <p>Monetization is currently disabled.</p>
+                                </div>
+                                <div>
+                                    <button class="button-alpha"  ng-click="toggleMonetization()">Enable Monetization</button>
+                                </div>
+                            </div>
                         </div>
-
-                        <!-- <div class="form-field switch">
-                            <label translate>Enable Monetization</label>
-                            <div class="toggle-switch">
-                                <input class="tgl" id="donation_enable" type="checkbox">
-                                <label class="tgl-btn" for="donation_enable"></label>
-                           </div>
-                        </div> -->
                     </div>
                 </div>
             </div>

--- a/app/settings/donation/donation.html
+++ b/app/settings/donation/donation.html
@@ -150,12 +150,13 @@
                             <div ng-if="site.donation.enabled">
                                 <button class="button-destructive"  ng-click="toggleMonetization()">Disable Monetization</button>
                             </div>
+                            <div class="alert error" ng-if="showMessage && form.$invalid">Fill in required fields above before enabling monetization.</div>
                             <div ng-if="!site.donation.enabled" >
                                 <div class="alert">
                                     <p>Monetization is currently disabled.</p>
                                 </div>
                                 <div>
-                                    <button class="button-alpha"  ng-click="toggleMonetization()">Enable Monetization</button>
+                                    <button class="button-alpha" ng-click="toggleMonetization()">Enable Monetization</button>
                                 </div>
                             </div>
                         </div>

--- a/app/settings/donation/donation.html
+++ b/app/settings/donation/donation.html
@@ -149,15 +149,15 @@
 
                         <div class="form-field">
                             <div ng-if="site.donation.enabled">
-                                <button class="button-destructive"  ng-click="toggleMonetization()">Disable Monetization</button>
+                                <button class="button-destructive"  translate="app.disable_monetization" ng-click="toggleMonetization()">Disable Monetization</button>
                             </div>
-                            <div class="alert error" ng-if="showMessage && form.$invalid">Fill in required fields above before enabling monetization.</div>
+                            <div class="alert error" ng-if="showMessage && form.$invalid" translate="app.enable_monetization_error">Fill in required fields above before enabling monetization.</div>
                             <div ng-if="!site.donation.enabled" >
                                 <div class="alert">
-                                    <p>Monetization is currently disabled.</p>
+                                    <p translate="app.enable_monetization_info">Monetization is currently disabled.</p>
                                 </div>
                                 <div>
-                                    <button class="button-alpha" ng-click="toggleMonetization()">Enable Monetization</button>
+                                    <button class="button-alpha" translate="app.enable_monetization" ng-click="toggleMonetization()">Enable Monetization</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Removes the checkbox for disabling monetization
- Adds a button for disabling/enabling monetization
- Saves the settings when clicking the button

Testing checklist:
-  Go to donations-settings

**If monetization is previously enabled:**
- [ ]  There should be a button saying "Disable monetization" at the bottom of the page
- Click the button. It should switch to "enable monetization."

**If monetization is previously disabled:**
- [ ] The button says "enable monetization" together with a message "Monetization is currently disabled."
- Click the button
- [ ] If all required fields are filled in, the button should switch to  or "disable monetization."
- [ ] If all required fields are not filled in, the button should not switch, but a message saying "Fill in required fields above before enabling monetization." should appear.


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#4278 .

Ping @ushahidi/platform
