### PR TITLE
Performance(analysis): Adding webpack-bundle-analyzer

### DIFF
--- a/legacy/gulpfile.babel.js
+++ b/legacy/gulpfile.babel.js
@@ -12,7 +12,7 @@ import gzip from 'gulp-gzip';
 import WebpackDevServer from 'webpack-dev-server';
 import colorsSupported from 'supports-color';
 import historyApiFallback from 'connect-history-api-fallback';
-
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import karma from 'karma';
 import eslint from 'gulp-eslint';
 import gulpIf from 'gulp-if';
@@ -166,6 +166,27 @@ function devServer() {
 }
 
 task('default', devServer);
+
+// Starting the dev-server and running analyzis
+function analyzeBundle() {
+    const config = require('./webpack.dev.config');
+    const port = process.env.PORT || 3000;
+    config.entry = paths.entry;
+    config.plugins.push(
+        new BundleAnalyzerPlugin()
+    );
+    var compiler = webpack(config);
+    new WebpackDevServer(compiler, config.devServer).listen(port, 'localhost',
+        (err) => {
+            if (err) {
+                throw new gutil.PluginError('webpack-dev-server', err);
+            }
+            console.log('[webpack-dev-server]', `http://localhost:${port}/webpack-dev-server/index.html`);
+        }
+    );
+}
+
+task('analyze', analyzeBundle);
 
 //Serving the dist build (for heroku)
 function serveStatic() {

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -81,6 +81,7 @@
         "transifex": "^1.6.6",
         "url-loader": "^3.0.0",
         "webpack": "^4.41.4",
+        "webpack-bundle-analyzer": "^4.4.2",
         "webpack-dev-server": "^3.11.2"
     },
     "dependencies": {


### PR DESCRIPTION
This pull request makes the following changes:
- Adds webpack-bundle-analyzer to legacy-app

Testing checklist:
- run `gulp analyze` in legacy-folder
- open localhost:8888
- [ ] you should see the analysis result

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
