### PR TITLE
Fix(auth): Using refresh-token to renew session

### DIFF
--- a/app/common/auth/authentication.service.js
+++ b/app/common/auth/authentication.service.js
@@ -66,6 +66,49 @@ function (
         loginStatus = false;
     }
 
+    function handleRequestSuccess(authResponse) {
+        var accessToken = authResponse.data.access_token;
+        Session.setSessionDataEntry('accessToken', accessToken);
+        if (authResponse.data.expires_in) {
+            Session.setSessionDataEntry('accessTokenExpires', Math.floor(Date.now() / 1000) + authResponse.data.expires_in);
+        } else if (authResponse.data.expires) {
+            Session.setSessionDataEntry('accessTokenExpires', authResponse.data.expires);
+        }
+        // Setting a timer to refresh the session if a refresh-token is available
+        if (authResponse.data.refresh_token) {
+            scheduleRefreshAuth(authResponse.data.refresh_token);
+        }
+        Session.setSessionDataEntry('grantType', 'password');
+    }
+
+    function handleRequestError () {
+        setToLogoutState();
+        $rootScope.$broadcast('event:authentication:login:failed');
+    };
+
+    function scheduleRefreshAuth (refreshToken) {
+        if (Session.getSessionDataEntry('accessTokenExpires')) {
+            /* Getting a random number between 5 minutes and 11 minutes before the expiry time.
+            (to avoid simultanous requests if the user has 2 or more tabs open)*/
+            const minutesBefore = (Math.floor(Math.random() * 11) + 5) * 60;
+            const timeToExpire = Session.getSessionDataEntry('accessTokenExpires') - Date.now() / 1000;
+            const timeToRefresh = timeToExpire - minutesBefore;
+            // Setting the timer to refresh token
+            setTimeout(function () {
+                let payload = {
+                    refresh_token: refreshToken,
+                    grant_type: 'refresh_token',
+                    client_id: CONST.OAUTH_CLIENT_ID,
+                    client_secret: CONST.OAUTH_CLIENT_SECRET,
+                    scope: CONST.CLAIMED_USER_SCOPES.join(' ')
+                };
+                //TODO: If we want to show the login-box if the refresh-token is invalid, use error-handler
+                $http.post(Util.url('/oauth/token'), payload).then(handleRequestSuccess, handleRequestError);
+
+            }, timeToRefresh);
+        }
+    }
+
     return {
 
         login: function (username, password) {
@@ -78,24 +121,13 @@ function (
                 scope: CONST.CLAIMED_USER_SCOPES.join(' ')
             },
 
-            deferred = $q.defer(),
+            deferred = $q.defer();
 
-            handleRequestError = function () {
-                deferred.reject();
-                setToLogoutState();
-                $rootScope.$broadcast('event:authentication:login:failed');
-            },
-
-            handleRequestSuccess = function (authResponse) {
-                var accessToken = authResponse.data.access_token;
-                Session.setSessionDataEntry('accessToken', accessToken);
-                if (authResponse.data.expires_in) {
-                    Session.setSessionDataEntry('accessTokenExpires', Math.floor(Date.now() / 1000) + authResponse.data.expires_in);
-                } else if (authResponse.data.expires) {
-                    Session.setSessionDataEntry('accessTokenExpires', authResponse.data.expires);
-                }
-                Session.setSessionDataEntry('grantType', 'password');
-
+            //Requesting tokens
+            $http.post(Util.url('/oauth/token'), payload).then(authResponse => {
+                //Setting required Sessions
+                handleRequestSuccess(authResponse);
+                // Fetching user-info
                 $http.get(Util.apiUrl('/users/me')).then(
                     function (userDataResponse) {
                         RoleEndpoint.query({name: userDataResponse.data.role}).$promise
@@ -108,14 +140,21 @@ function (
                             return userDataResponse;
                         })
                         .finally(function () {
+                            /* Adjusting the UI to logged-in state
+                            and runs the doLogin-function in Authentication-events */
                             setToLoginState(userDataResponse.data);
                             $rootScope.$broadcast('event:authentication:login:succeeded');
                             deferred.resolve();
                         });
-                    }, handleRequestError);
-            };
-
-            $http.post(Util.url('/oauth/token'), payload).then(handleRequestSuccess, handleRequestError);
+                        // Handling 2 potential errors below, both the token-request and the user-info-request
+                    }, () => {
+                        deferred.reject();
+                        handleRequestError();
+                    });
+                }, () => {
+                    deferred.reject();
+                    handleRequestError();
+                });
 
             return deferred.promise;
         },


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a timer if there is an expiry-date and refresh-token available
- Renews the auth-token before session ends (in the background, user should not notice)

Testing checklist:
- Login
- Take note of the expiry-time in the Session
- Start adding a post or a survey
- Leave tab and post/survey open over the expiry-time
- Save post/survey after the first expiry-time
- [ ] Post/survey should save
- [ ] If a post, your logged in user should be the author of the post
- [ ] You should not lose your data

- Logout
- Login again
- Close the browser
- Open the browser and open the page
- Check that you are still logged in
- Take note of the expiry-time in the Session
- Start adding a post or a survey
- Leave tab and post/survey open over the expiry-time
- Save post/survey after the first expiry-time
- [ ] Post/survey should save
- [ ] If a post, your logged in user should be the author of the post
- [ ] You should not lose your data
  
- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
