### PR TITLE
Importmap: Changing the order of scripts in build-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Ushahidi Platform Official Web Client",
   "scripts": {
-    "build": "npm run build:api && npm run build:utilities && npm run build:legacy && npm run build:root && npm run generate:import-map && npm run copy",
+    "build": "npm run build:api && npm run build:utilities && npm run build:legacy && npm run build:root && npm run copy && npm run generate:import-map",
     "build:api": "cd api && npm run build",
     "build:root": "cd root && npm run build",
     "build:legacy": "cd legacy && npm run build",


### PR DESCRIPTION
This pull request makes the following changes:
- Changing the order of build-scripts so the importmap is present when running the mapping-script

Testing checklist:
- Run `npm run build`
- [ ] Build should complete without errors

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
