### PR TITLE
fix: Saving data from date-fields in the format YYYY-MM-DD

### DIFF
--- a/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
@@ -10,13 +10,6 @@ module.exports = [
             require: 'ngModel',
             template: require('./post-datetime-value.html'),
             link: function ($scope, element, attrs, ngModel) {
-                // Split date time in time and date fields
-                $scope.timeOptions = {
-                    format: 'HH:i',
-                    interval: 15,
-                    onClose: save
-                };
-                $scope.dateOptions = { format: 'yyyy-mm-dd', onClose: save };
                 $scope.model = null;
 
                 // If no ngModel, skip the rest
@@ -26,13 +19,12 @@ module.exports = [
 
                 // Update models on render
                 ngModel.$render = render;
+
+                $scope.$watch('model', save);
+
                 Flatpickr('#flatpickr', {
                     enableTime: true,
-                    dateFormat: 'Y-m-d H:i',
-                    onChange: function (selectedDates, dateStr, instance) {
-                        $scope.model = dateStr;
-                        save();
-                    }
+                    dateFormat: 'Y-m-d H:i'
                 });
 
                 // Render ngModel viewValue into scope

--- a/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
@@ -6,7 +6,7 @@ module.exports = [
         return {
             restrict: 'E',
             replace: true,
-            scope: {},
+            scope: {addMeta: '='},
             require: 'ngModel',
             template: require('./post-datetime-value.html'),
             link: function ($scope, element, attrs, ngModel) {
@@ -25,13 +25,18 @@ module.exports = [
                 Flatpickr('#flatpickr', {
                     enableTime: true,
                     altInput: true,
-                    altFormat: 'Y-m-d h:i K'
+                    altFormat: 'Y-m-d h:i'
                 });
 
                 // Render ngModel viewValue into scope
                 function render() {
-                    if (ngModel.$viewValue.value !== null) {
+                    // If we are dealing with a field-value
+                    if ($scope.addMeta && ngModel.$viewValue.value !== null) {
                         $scope.model = dayjs(ngModel.$viewValue.value).toDate();
+                    }
+                    // if we are dealing with another date
+                    if (!$scope.addMeta && ngModel.$viewValue !== null) {
+                        $scope.model = dayjs(ngModel.$viewValue).toDate();
                     }
                 }
 
@@ -39,14 +44,14 @@ module.exports = [
                 // Only runs when modal closes, this avoids overwriting the time
                 // and rounding it to 15mins, even when the user never changed it
                 function save() {
-                    let valueObject = {
-                        value: dayjs($scope.model).toDate(),
-                        value_meta: {
-                            from_tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                            offset: dayjs($scope.model).toDate().getTimezoneOffset()
-                        }
-                    }
-                    ngModel.$setViewValue(valueObject);
+                    let values = $scope.addMeta ? {
+                            value: dayjs($scope.model).toDate(),
+                            value_meta: {
+                                from_tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+                                offset: dayjs($scope.model).toDate().getTimezoneOffset()
+                            }
+                        } : dayjs($scope.model).toDate();
+                    ngModel.$setViewValue(values);
                 }
             }
         };

--- a/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
@@ -20,11 +20,17 @@ module.exports = [
                 // Update models on render
                 ngModel.$render = render;
 
-                $scope.$watch('model', save);
+                $scope.$watch('model', function() {
+                    console.log($scope.model)
+                    save()
+                });
 
                 Flatpickr('#flatpickr', {
                     enableTime: true,
-                    dateFormat: 'Y-m-d H:i'
+                    dateFormat: 'Z',
+                    altInput: true,
+                    altFormat: 'Y-m-d h:i K'
+
                 });
 
                 // Render ngModel viewValue into scope

--- a/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-datetime-value.directive.js
@@ -20,23 +20,18 @@ module.exports = [
                 // Update models on render
                 ngModel.$render = render;
 
-                $scope.$watch('model', function() {
-                    console.log($scope.model)
-                    save()
-                });
+                $scope.$watch('model', save);
 
                 Flatpickr('#flatpickr', {
                     enableTime: true,
-                    dateFormat: 'Z',
                     altInput: true,
                     altFormat: 'Y-m-d h:i K'
-
                 });
 
                 // Render ngModel viewValue into scope
                 function render() {
-                    if (ngModel.$viewValue !== null) {
-                        $scope.model = dayjs(ngModel.$viewValue).toDate();
+                    if (ngModel.$viewValue.value !== null) {
+                        $scope.model = dayjs(ngModel.$viewValue.value).toDate();
                     }
                 }
 
@@ -44,7 +39,14 @@ module.exports = [
                 // Only runs when modal closes, this avoids overwriting the time
                 // and rounding it to 15mins, even when the user never changed it
                 function save() {
-                    ngModel.$setViewValue($scope.model);
+                    let valueObject = {
+                        value: dayjs($scope.model).toDate(),
+                        value_meta: {
+                            from_tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+                            offset: dayjs($scope.model).toDate().getTimezoneOffset()
+                        }
+                    }
+                    ngModel.$setViewValue(valueObject);
                 }
             }
         };

--- a/legacy/app/data/common/post-edit-create/post-datetime-value.html
+++ b/legacy/app/data/common/post-edit-create/post-datetime-value.html
@@ -7,7 +7,7 @@
                     xlink:href="/img/iconic-sprite.svg#calendar"
                 ></use>
             </svg>
-            <input type="text" id="flatpickr" />
+            <input ng-model="model" type="text" id="flatpickr" />
         </div>
     </div>
 </div>

--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -42,12 +42,7 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
     angular.element(document).ready(function () {
-        Flatpickr('#date', {
-            onChange: function() {
-                $scope.attribute.value.value_meta = {
-                    from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
-                };
-            }});
+        Flatpickr('#date', {});
     });
     $scope.$watch('activeSurveyLanguage', () => {
         if ($scope.form.title && !$scope.form.title.$dirty) {
@@ -57,6 +52,13 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
 
     function activate() {
         addDefaultValue();
+        if (isDate($scope.attribute)) {
+            $scope.$watch('attribute.value.value', () => {
+                $scope.attribute.value.value_meta = {
+                    from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
+                };
+            });
+        }
     }
 
     function addDefaultValue() {

--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -42,7 +42,10 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
     angular.element(document).ready(function () {
-        Flatpickr('#date', {});
+        Flatpickr('#date', {
+            onChange: function() {
+                $scope.attribute.value.value_meta = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            }});
     });
     $scope.$watch('activeSurveyLanguage', () => {
         if ($scope.form.title && !$scope.form.title.$dirty) {

--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -44,7 +44,9 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     angular.element(document).ready(function () {
         Flatpickr('#date', {
             onChange: function() {
-                $scope.attribute.value.value_meta = Intl.DateTimeFormat().resolvedOptions().timeZone;
+                $scope.attribute.value.value_meta = {
+                    from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
+                };
             }});
     });
     $scope.$watch('activeSurveyLanguage', () => {

--- a/legacy/app/data/common/post-edit-create/post-value-edit.html
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.html
@@ -160,7 +160,7 @@
                     <post-datetime
                         id="values{{attribute.id}}"
                         name="values_{{attribute.id}}"
-                        ng-model="attribute.value.value"
+                        ng-model="attribute.value"
                         ng-required="attribute.required"
                     ></post-datetime>
                 </div>

--- a/legacy/app/data/common/post-edit-create/post-value-edit.html
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.html
@@ -148,7 +148,6 @@
                             ></use>
                         </svg>
                         <input
-                            type="date"
                             id="date"
                             name="values_{{attribute.id}}"
                             ng-model="attribute.value.value"

--- a/legacy/app/data/common/post-edit-create/post-value-edit.html
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.html
@@ -162,6 +162,7 @@
                         name="values_{{attribute.id}}"
                         ng-model="attribute.value"
                         ng-required="attribute.required"
+                        add-meta=true
                     ></post-datetime>
                 </div>
                 <!-- type: select -->

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -135,7 +135,8 @@ function PostEditorController(
                                 attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
                             } catch (err) {
                                 // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
-                            }                        } else {
+                            }
+                        } else {
                             attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
@@ -155,7 +156,6 @@ function PostEditorController(
     }
 
     function savePost() {
-        console.log($scope.post)
         $scope.saving_post = true;
         if (!$scope.canSavePost()) {
             if ($scope.postForm.$error.required) {

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -115,7 +115,7 @@ function PostEditorController(
                             attr.value.value = parseInt(attr.default);
                         }
                     }
-                    if (attr.input === 'date' || attr.input === 'datetime') {
+                    if (attr.input === 'datetime') {
                         // Date picker requires date object
                         // ensure that dates are preserved in UTC
                         if (attr.value.value) {
@@ -124,6 +124,19 @@ function PostEditorController(
                             attr.value.value = new Date(attr.default);
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).toDate() : null;
+                        }
+                    }
+                    if (attr.input === 'date') {
+                        // We are only interested in year-month-day for date-fields
+                        if (attr.value.value) {
+                            attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
+                        } else if (attr.default) {
+                            try {
+                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                            } catch (err) {
+                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                            }                        } else {
+                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
                 });
@@ -142,6 +155,7 @@ function PostEditorController(
     }
 
     function savePost() {
+        console.log($scope.post)
         $scope.saving_post = true;
         if (!$scope.canSavePost()) {
             if ($scope.postForm.$error.required) {

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -318,10 +318,10 @@ function PostDataEditorController(
                 ignoreCancelEvent = true;
                 $state.go('posts.data.detail', {view: 'data', postId: response.data.result.id});
 
-                Notify.notify(success_message, { name: $scope.post.title });
+                Notify.notify(success_message, { name: post.title });
 
                 // adding post to broadcast to make sure it gets filtered out from post-list if it does not match the filters.
-                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response});
+                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response.data.result});
             }, function (errorResponse) { // errors
                 Notify.sdkErrors(errorResponse);
                 $rootScope.$broadcast('event:edit:post:data:mode:saveError');

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -229,7 +229,7 @@ function PostDataEditorController(
                         }
                     }
 
-                    if (attr.input === 'date' || attr.input === 'datetime') {
+                    if (attr.input === 'datetime') {
                         // Date picker requires date object
                         // ensure that dates are preserved in UTC
                         if (attr.value.value) {
@@ -238,6 +238,20 @@ function PostDataEditorController(
                             attr.value.value = new Date(attr.default);
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).toDate() : null;
+                        }
+                    }
+                    if (attr.input === 'date') {
+                        // We are only interested in year-month-day for date-fields
+                        if (attr.value.value) {
+                            attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
+                        } else if (attr.default) {
+                            try {
+                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                            } catch (err) {
+                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                            }
+                        } else {
+                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
                 }


### PR DESCRIPTION
This pull request makes the following changes:
- Initialises and stores data from date-fields in the format YYYY-MM-DD
- Removes the type="date" from date-fields since the validator does not like the new format

Testing checklist:
- Add a new post to a survey with date-fields
- Select a date
[ ] Look at the data sent to the API, it should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the time-zone
- Edit the same post
- Make some changes to the dates
- Save
- Look at the data sent to the API
[ ] The "value" should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the time-zone

- Add a new post to a survey with a date-time-field
- Select a date and time
- Look at the data sent to the API,
[ ] The value should be the same date and time added converted to UTC.
[ ] The "value_meta" should contain the time-zone and the offset in minutes
- Edit the same post
[ ]  The pre-filled values should be the same as the value added to the post in the first place <-- this one fails!
- Make some changes to the date and time
- Save
- Look at the data sent to the API,
[ ] The value should be the same date and time added converted to UTC.
[ ] The "value_meta" should contain the time-zone and the offset in minutes
 



- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
