### PR TITLE
fix: Saving data from date-fields in the format YYYY-MM-DD

### DIFF
--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -49,7 +49,7 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
         addDefaultValue();
         if (isDate($scope.attribute)) {
             $scope.$watch('attribute.value.value', (newValue, oldValue) => {
-                if (newValue !== oldValue) {
+                if (newValue && newValue !== oldValue) {
                     $scope.attribute.value.value_meta = {
                         from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
                     };

--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -44,14 +44,18 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     angular.element(document).ready(function () {
         Flatpickr('#date', {});
     });
-    $scope.$watch('activeSurveyLanguage', () => {
-        if ($scope.form.title && !$scope.form.title.$dirty) {
-            addDefaultValue();
-        }
-    });
 
     function activate() {
         addDefaultValue();
+        if (isDate($scope.attribute)) {
+            $scope.$watch('attribute.value.value', (newValue, oldValue) => {
+                if (newValue !== oldValue) {
+                    $scope.attribute.value.value_meta = {
+                        from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
+                    };
+                }
+            });
+        }
     }
 
     function addDefaultValue() {

--- a/legacy/app/data/common/post-edit-create/post-value-edit.html
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.html
@@ -148,7 +148,6 @@
                             ></use>
                         </svg>
                         <input
-                            type="date"
                             id="date"
                             name="values_{{attribute.id}}"
                             ng-model="attribute.value.value"

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -132,12 +132,12 @@ function PostEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                                attr.value.value = dayjs(new Date(attr.default).format('YYYY-MM-DD'));
                             } catch (err) {
                                 // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
                             }
                         } else {
-                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
+                            attr.value.value = attr.required ? dayjs(new Date()).format('YYYY-MM-DD') : null;
                         }
                     }
                 });

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -135,7 +135,8 @@ function PostEditorController(
                                 attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
                             } catch (err) {
                                 // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
-                            }                        } else {
+                            }
+                        } else {
                             attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
@@ -155,7 +156,6 @@ function PostEditorController(
     }
 
     function savePost() {
-        console.log($scope.post)
         $scope.saving_post = true;
         if (!$scope.canSavePost()) {
             if ($scope.postForm.$error.required) {

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -115,7 +115,7 @@ function PostEditorController(
                             attr.value.value = parseInt(attr.default);
                         }
                     }
-                    if (attr.input === 'date' || attr.input === 'datetime') {
+                    if (attr.input === 'datetime') {
                         // Date picker requires date object
                         // ensure that dates are preserved in UTC
                         if (attr.value.value) {
@@ -124,6 +124,19 @@ function PostEditorController(
                             attr.value.value = new Date(attr.default);
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).toDate() : null;
+                        }
+                    }
+                    if (attr.input === 'date') {
+                        // We are only interested in year-month-day for date-fields
+                        if (attr.value.value) {
+                            attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
+                        } else if (attr.default) {
+                            try {
+                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                            } catch (err) {
+                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                            }                        } else {
+                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
                 });
@@ -142,6 +155,7 @@ function PostEditorController(
     }
 
     function savePost() {
+        console.log($scope.post)
         $scope.saving_post = true;
         if (!$scope.canSavePost()) {
             if ($scope.postForm.$error.required) {

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -318,10 +318,10 @@ function PostDataEditorController(
                 ignoreCancelEvent = true;
                 $state.go('posts.data.detail', {view: 'data', postId: response.data.result.id});
 
-                Notify.notify(success_message, { name: $scope.post.title });
+                Notify.notify(success_message, { name: post.title });
 
                 // adding post to broadcast to make sure it gets filtered out from post-list if it does not match the filters.
-                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response});
+                $rootScope.$broadcast('event:edit:post:data:mode:saveSuccess', {post: response.data.result});
             }, function (errorResponse) { // errors
                 Notify.sdkErrors(errorResponse);
                 $rootScope.$broadcast('event:edit:post:data:mode:saveError');

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -246,12 +246,12 @@ function PostDataEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                                attr.value.value = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
                             } catch (err) {
                                 // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
                             }
                         } else {
-                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
+                            attr.value.value = attr.required ? dayjs(new Date()).format('YYYY-MM-DD') : null;
                         }
                     }
                 }

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -229,7 +229,7 @@ function PostDataEditorController(
                         }
                     }
 
-                    if (attr.input === 'date' || attr.input === 'datetime') {
+                    if (attr.input === 'datetime') {
                         // Date picker requires date object
                         // ensure that dates are preserved in UTC
                         if (attr.value.value) {
@@ -238,6 +238,20 @@ function PostDataEditorController(
                             attr.value.value = new Date(attr.default);
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).toDate() : null;
+                        }
+                    }
+                    if (attr.input === 'date') {
+                        // We are only interested in year-month-day for date-fields
+                        if (attr.value.value) {
+                            attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
+                        } else if (attr.default) {
+                            try {
+                                attr.value.value = new Date(attr.default).format('YYYY-MM-DD');
+                            } catch (err) {
+                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                            }
+                        } else {
+                            attr.value.value = attr.required ? new Date().format('YYYY-MM-DD') : null;
                         }
                     }
                 }


### PR DESCRIPTION
This pull request makes the following changes:

Initialises and stores data from date-fields in the format YYYY-MM-DD
Removes the type="date" from date-fields since the validator does not like the new format
Testing checklist:

Add a new post to a survey with date-fields

Select a date
[ ] Look at the data sent to the API, it should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the time-zone

Edit the same post
Change the date
Save

Look at the data sent to the API
[ ] The "value" should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the time-zone

- Change time-zone on your computer
- Edit the same post again but do not touch the date-field
[ ] The "value" should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the time-zone that the post was originally saved in (it should not update the timezone to your new setting)


Edit the same post again and make a change to the date
Save

Look at the data sent to the API
[ ] The "value" should be in the format YYYY-MM-DD without any time-stamp
[ ] The "value_meta" should contain the new time-zone

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
