### PR TITLE
Fix: Not using default date if invalid

### DIFF
--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -132,8 +132,11 @@ function PostEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                attr.value.value = dayjs(new Date(attr.default).format('YYYY-MM-DD'));
-                            } catch (err) {
+                                let defaultValue = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
+                                // Safeguarding against invalid default dates below. We should add validation in the survey setup instead
+                                if (defaultValue !== 'Invalid Date') {
+                                    attr.value.value = defaultValue;
+                                }                            } catch (err) {
                                 // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
                             }
                         } else {

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -132,14 +132,16 @@ function PostEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                let defaultValue = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
+                                let defaultValue = dayjs(new Date(attr.default))
                                 // Safeguarding against invalid default dates below. We should add validation in the survey setup instead
-                                if (defaultValue !== 'Invalid Date') {
-                                    attr.value.value = defaultValue;
-                                }                            } catch (err) {
-                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                                if (defaultValue.isValid()) {
+                                    attr.value.value = defaultValue.format('YYYY-MM-DD');
+                                }
+                            } catch (err) {
+                                // What do do if the default-value is in the wrong format?
                             }
-                        } else {
+                        }
+                        else {
                             attr.value.value = attr.required ? dayjs(new Date()).format('YYYY-MM-DD') : null;
                         }
                     }

--- a/legacy/app/data/post-create/post-editor.directive.js
+++ b/legacy/app/data/post-create/post-editor.directive.js
@@ -132,7 +132,7 @@ function PostEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                let defaultValue = dayjs(new Date(attr.default))
+                                let defaultValue = dayjs(new Date(attr.default));
                                 // Safeguarding against invalid default dates below. We should add validation in the survey setup instead
                                 if (defaultValue.isValid()) {
                                     attr.value.value = defaultValue.format('YYYY-MM-DD');

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -246,13 +246,14 @@ function PostDataEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                let defaultValue = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
-                                // Safeguarding against invalid default dates below. We should add validation in the survey setup instead
-                                if (defaultValue !== 'Invalid Date') {
-                                    attr.value.value = defaultValue;
+                                let defaultValue = dayjs(new Date(attr.default))
+                                //Safeguarding against invalid default dates below. We should add validation in the survey setup instead
+                                if (defaultValue.isValid()) {
+                                    attr.value.value = defaultValue.format('YYYY-MM-DD');
                                 }
                             } catch (err) {
-                                return;
+                            // What do do if the default-value is in the wrong format?
+
                             }
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).format('YYYY-MM-DD') : null;

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -246,7 +246,7 @@ function PostDataEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                let defaultValue = dayjs(new Date(attr.default))
+                                let defaultValue = dayjs(new Date(attr.default));
                                 //Safeguarding against invalid default dates below. We should add validation in the survey setup instead
                                 if (defaultValue.isValid()) {
                                     attr.value.value = defaultValue.format('YYYY-MM-DD');

--- a/legacy/app/data/post-edit/post-data-editor.directive.js
+++ b/legacy/app/data/post-edit/post-data-editor.directive.js
@@ -246,9 +246,13 @@ function PostDataEditorController(
                             attr.value.value = dayjs(attr.value.value).format('YYYY-MM-DD');
                         } else if (attr.default) {
                             try {
-                                attr.value.value = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
+                                let defaultValue = dayjs(new Date(attr.default)).format('YYYY-MM-DD');
+                                // Safeguarding against invalid default dates below. We should add validation in the survey setup instead
+                                if (defaultValue !== 'Invalid Date') {
+                                    attr.value.value = defaultValue;
+                                }
                             } catch (err) {
-                                // What do do if the default-value is in the wrong format? Probably validate that field in the first place?
+                                return;
                             }
                         } else {
                             attr.value.value = attr.required ? dayjs(new Date()).format('YYYY-MM-DD') : null;


### PR DESCRIPTION
This pull request makes the following changes:
- Ignores default date if its an Invalid Date on editing and creating a post

Testing checklist:
- Add a new post to a survey with a date-field with a default-value that is not a date (for example a text-string)
- Look at the date-field
- [ ] It should be empty and not say "Invalid Date"
- Edit a post to a survey with a date-field with a default-value that is not a date (for example a text-string). The post should not have any data for the date-field
- Look at the date-field
- [ ] It should be empty and not say "Invalid Date"


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
