### PR TITLE
Date time field

### DIFF
--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -42,12 +42,20 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     $scope.isFieldSetStructure = isFieldSetStructure;
     activate();
     angular.element(document).ready(function () {
-        Flatpickr('#date', {});
+        if (isDate($scope.attribute) || isDateTime($scope.attribute)) {
+            let config = isDate($scope.attribute) ? {} : {
+                altFormat: 'Y-m-d H:i',
+                altInput: true,
+                dateFormat: 'Z',
+                enableTime: true
+            };
+            Flatpickr(`#values_${$scope.attribute.id}`, config);
+        }
     });
 
     function activate() {
         addDefaultValue();
-        if (isDate($scope.attribute)) {
+        if (isDate($scope.attribute) || isDateTime($scope.attribute)) {
             $scope.$watch('attribute.value.value', (newValue, oldValue) => {
                 if (newValue && newValue !== oldValue) {
                     $scope.attribute.value.value_meta = {

--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -36,7 +36,7 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     $scope.isCheckbox = isCheckbox;
 
     $scope.taskIsMarkedCompleted = taskIsMarkedCompleted;
-
+    let flatpickr;
     $scope.isAdmin = $rootScope.isAdmin;
     $scope.duplicatePresent = duplicatePresent;
     $scope.isFieldSetStructure = isFieldSetStructure;
@@ -49,7 +49,7 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
                 dateFormat: 'Z',
                 enableTime: true
             };
-            Flatpickr(`#values_${$scope.attribute.id}`, config);
+            flatpickr = Flatpickr(`#values_${$scope.attribute.id}`, config);
         }
     });
 
@@ -61,6 +61,9 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
                     $scope.attribute.value.value_meta = {
                         from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
                     };
+                } else if (oldValue && newValue === '') {
+                    // Removing timezone if the value is deleted
+                    $scope.attribute.value.value_meta = null;
                 }
             });
         }

--- a/legacy/app/data/common/post-edit-create/post-value-edit.html
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.html
@@ -148,7 +148,7 @@
                             ></use>
                         </svg>
                         <input
-                            id="date"
+                            id="values_{{attribute.id}}"
                             name="values_{{attribute.id}}"
                             ng-model="attribute.value.value"
                             ng-required="attribute.required"
@@ -157,12 +157,21 @@
                 </div>
                 <!-- type: datetime -->
                 <div ng-switch-when="datetime" class="input-with-icon">
-                    <post-datetime
-                        id="values{{attribute.id}}"
-                        name="values_{{attribute.id}}"
-                        ng-model="attribute.value.value"
-                        ng-required="attribute.required"
-                    ></post-datetime>
+                    <!-- Date icon -->
+                    <div class="input-with-icon">
+                        <svg class="iconic" role="img">
+                            <use
+                                xmlns:xlink="http://www.w3.org/1999/xlink"
+                                xlink:href="/img/iconic-sprite.svg#calendar"
+                            ></use>
+                        </svg>
+                        <input
+                            id="values_{{attribute.id}}"
+                            name="values_{{attribute.id}}"
+                            ng-model="attribute.value.value"
+                            ng-required="attribute.required"
+                        />
+                    </div>
                 </div>
                 <!-- type: select -->
                 <div ng-switch-when="select">


### PR DESCRIPTION
This pull request makes the following changes:
- Uses the post-value-edit directive for date-field and date-time fields
- Converts and sends the time to the API in UTC 
- Adds timezone information to meta-data

Testing checklist:
- Add a new post to a survey with a date-time field
- [x] Check the post, it should show exactly the same time as you added
- [x] Click on edit, the date visible should still be the same as you added
- Change the value of the field
- [x] Check the post, it should show exactly the same time as you changed to

**Known bug (needs changes in the API): When deleting the value in edit-mode, the date is reset to 1 january 1970.**

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
