### PR TITLE
Fix: Adding timezone to correct changes in date/date-time-fields

### DIFF
--- a/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
+++ b/legacy/app/data/common/post-edit-create/post-value-edit.directive.js
@@ -56,13 +56,33 @@ function PostValueEditController($rootScope, $scope, _, Flatpickr, SurveysSdk) {
     function activate() {
         addDefaultValue();
         if (isDate($scope.attribute) || isDateTime($scope.attribute)) {
+
             $scope.$watch('attribute.value.value', (newValue, oldValue) => {
-                if (newValue && newValue !== oldValue) {
+                let addTimezone = false;
+                // if the post is being created and is requred.
+                if ($scope.attribute.required &&  !$scope.attribute.value.value_meta) {
+                    addTimezone = true;
+                }
+
+                // if the post is being created and has a default value.
+                if ($scope.attribute.default &&  !$scope.attribute.value.value_meta) {
+                    addTimezone = true;
+                }
+
+                /* When adding a new value or editing an old. We only want to add/change the timezone if
+                * the value is changed. Converting to timestamp to ensure comparing the same thing */
+                if (newValue && new Date(newValue).valueOf() !== new Date(oldValue).valueOf()) {
+                    addTimezone = true;
+                }
+
+                if (addTimezone) {
                     $scope.attribute.value.value_meta = {
                         from_tz:Intl.DateTimeFormat().resolvedOptions().timeZone
                     };
-                } else if (oldValue && newValue === '') {
-                    // Removing timezone if the value is deleted
+                }
+
+                // Removing timezone if the value is deleted
+                if (oldValue && newValue === '') {
                     $scope.attribute.value.value_meta = null;
                 }
             });


### PR DESCRIPTION
This pull request makes the following changes:
- Adds timezone-information to date and date/time fields with
  - required fields
  - default values
  - fields that are not required and does not have a default value, when a value is added by the user
- Changes timezone-information in edit-view when the user change the value in date/date-time field only

Testing checklist:
- Add a post with date and date/time fields:
 1. required field
 2. with default values
 3. fields that are not required and does not have a default value

Check the values sent to the api. 
- [ ] All times when a value is given in the field, either if it is pre-filled or if it is changed/added by the user, this addition should be added to the value-object: `{value_meta: { from_tz: "timezone info}}`

Change the timezone on your computer
Edit the post
- [ ] the value_meta should update to current timezone



- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
