### PR TITLE
fixed broken link to documentaion page for ushahidi

### DIFF
--- a/legacy/app/mode-bar/support-links.html
+++ b/legacy/app/mode-bar/support-links.html
@@ -4,7 +4,7 @@
 
 <div class="modal-body">
   <dl>
-    <dt class="list-item"><a href="https://www.ushahidi.com/support" target="_blank" translate>app.documentation.title</a></dt>
+    <dt class="list-item"><a href="https://docs.ushahidi.com/ushahidi-platform-user-manual" target="_blank" translate>app.documentation.title</a></dt>
     <dd translate>app.documentation.description</dd>
     <dt class="list-item"><a href="https://github.com/ushahidi/platform/issues/new" target="_blank" translate>app.report_a_bug.title</a></dt>
     <dd translate>app.report_a_bug.description</dd>


### PR DESCRIPTION
This pull request makes the following changes:
- changes link https://www.ushahidi.com/support to https://docs.ushahidi.com/ushahidi-platform-user-manual which solved an issue on the ushahidi platform concerning broken link to documentation #4253

- [x] I certify that I ran my checklist
- [x] changed link to the platform user manual

Fixes ushahidi/platform#4253

Ping @ushahidi/platform
