### PR TITLE
Load more button

### DIFF
--- a/legacy/app/data/post-view-data.html
+++ b/legacy/app/data/post-view-data.html
@@ -89,7 +89,7 @@
             <div class="listing-item" ng-if="posts.length > 0 || isLoading()">
 
                 <div class="listing-item-primary">
-                    <button ng-disabled="isLoading()" ng-hide="( isLoading() || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
+                    <button ng-hide="( isLoading() || posts.length >= totalItems)" class="button-gamma button-flat" ng-click="loadMore()" translate="app.load_more">Load more
                     </button>
                      <loading-dots-button button-class="'button-gamma button-flat'" label="'app.loading'" ng-show="isLoading()"></loading-dots-button>
                 </div>
@@ -98,7 +98,7 @@
     </div>
     <div class="post-col" ng-class="{'active' : activeCol === 'post' }">
         <!-- Verify if we need all these bindings ie. parentForm savingPost -->
-        <div ui-view filters="filters" is-loading="isLoading" saving-post="savingPost"></post-detail-data>
+        <post-detail-data ui-view filters="filters" is-loading="isLoading" saving-post="savingPost"></post-detail-data>
     </div>
 </div>
 <ush-logo></ush-logo>

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -121,7 +121,7 @@
         "single-spa-angularjs": "^4.2.3",
         "sortablejs": "1.10.0",
         "underscore": "^1.7.0",
-        "ushahidi-platform-pattern-library": "5.0.2",
+        "ushahidi-platform-pattern-library": "5.0.3",
         "ushahidi-platform-sdk": "^0.5.0"
     },
     "engines": {


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a new version of pattern library
- Turn off disabling of load-more button when loading. This caused the button to be disabled whenever a network-request was made, even if it was not loading of posts.

Testing checklist:
- Go to data-view
- Click on Load more
- [x] All areas of the Load more button should be clickable
- [x] More mosts should be loaded

Change language to a RTL language
-Repeat the above check-list

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#4400 .

Ping @ushahidi/platform
