### PR TITLE
chore/deps: bump SDK-version to 0.6.2

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -122,7 +122,7 @@
         "sortablejs": "1.10.0",
         "underscore": "^1.7.0",
         "ushahidi-platform-pattern-library": "5.0.3",
-        "ushahidi-platform-sdk": "^0.5.0"
+        "ushahidi-platform-sdk": "^0.6.2"
     },
     "engines": {
         "node": ">=10.0"


### PR DESCRIPTION
This pull request makes the following changes:
- fixes bug that joined only= and hydrate= parameters for survey- and post-requests in the wrong format.

Testing checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
