### PR TITLE
fix: disable form autocompletion in user management

### DIFF
--- a/legacy/app/settings/users/users-edit.html
+++ b/legacy/app/settings/users/users-edit.html
@@ -38,7 +38,7 @@
             </div>
             <!-- end toolbar -->
 
-            <form name="form">
+            <form name="form" autocomplete="off">
                 <div class="form-sheet">
                     <div class="form-field init required" ng-class="{ 'error': form.full_name.$invalid && (form.full_name.$dirty || displayError) }">
                         <label for="user-fullname" translate>user.full_name</label>


### PR DESCRIPTION
This pull request makes the following changes:
- disables browser autocompletion in the user management form

Testing checklist:
- [ ] Log in with credentials saved in browser
- [ ] Edit other user
- [ ] The e-mail address and password of the user shouldn't be supplanted with the log in credentials

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4442 .

Ping @ushahidi/platform
