### PR TITLE
Jumping Map View

### DIFF
--- a/legacy/app/map/post-view-map.directive.js
+++ b/legacy/app/map/post-view-map.directive.js
@@ -77,32 +77,30 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
             }
         }
 
-        function addPostsToMap(posts) {
+        function addPostsToMap(posts, shouldFitMapBoundary = true) {
             var geojson = L.geoJson(posts, {
                 pointToLayer: Maps.pointToLayer,
                 onEachFeature: onEachFeature
             });
 
             if (map.options.clustering) {
-
                 markers = markers ? markers : L.markerClusterGroup({
                     maxClusterRadius: map.options.cluster_radius
                 });
-                // This has to be done individually.
-                // Using clusterLayer.addLayers() breaks the clustering.
-                // Need to investigate as this should have been fixing in v1.0.0
-                angular.forEach(geojson.getLayers(), function (layer) {
-                    markers.addLayer(layer);
-                });
+
+                // Apparently cluster.addLayers doesn't break clustering anymore
+                markers.addLayers(geojson.getLayers());
             } else {
                 markers = geojson;
             }
             markers.addTo(map);
             geoJsonLayers.push(markers);
 
-            if (posts.features.length > 0) {
-                map.fitBounds(geojson.getBounds());
+            // Adjust map boundaries only when post fetching is first or last batch
+            if (posts.features.length > 0 && shouldFitMapBoundary) {
+                map.fitBounds(markers.getBounds());
             }
+
             // Focus map on data points but..
             // Avoid zooming further than 15 (particularly when we just have a single point)
             if (map.getZoom() > 15) {
@@ -202,9 +200,9 @@ function PostViewMap(PostEndpoint, Maps, _, PostFilters, L, $q, $rootScope, $com
                         let request = PostEndpoint.geojson(conditions);
                         currentGeoJsonRequests.push(request);
                         request.$promise.then(result => {
+                            // var isLastPostChunk = i + limit > posts.total;
                             addPostsToMap(result)
                         });
-
                     }
                 }
             });


### PR DESCRIPTION
This pull request makes the following changes:
- Modify the `addPostsToMap` function to accepts a boolean parameter that determines if the status of the received posts
- Avoid looping over geojson layers using the `cluster.addLayers` to set layers to the cluster group

Test this by:
- [ ] The map loads to show all the markers loaded into it, no markers are left outside of the initial view after it finishes loading.
- [ ] When the map has more than 400 points , the view auto-adjusts progressively as points are loaded into it, but it doesn't feel like it's "shaking" or "jumping"

Fixes ushahidi/platform#2265.

Ping @ushahidi/platform
