### PR TITLE
fix: show delete action only to allowed users ushahidi/platform#4453

### DIFF
--- a/legacy/app/map/post-card/post-actions.html
+++ b/legacy/app/map/post-card/post-actions.html
@@ -50,7 +50,7 @@
         </a>
       </li>
 
-      <li ng-show="post.allowed_privileges.indexOf('update') !== -1 && postIsUnlocked()">
+      <li ng-show="post.allowed_privileges.indexOf('delete') !== -1 && postIsUnlocked()">
         <a ng-click="deletePost()">
           <svg class="iconic" role="img">
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#trash"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- Shows "delete" action for posts only to users who have the permissions to carry it

Testing checklist:
- [ ] User without permission to delete - clicking on the three dot menus in the data view on both the post list and the post detail , doesn't show the "Delete" action
- [ ] User with permission to delete - shows the "delete action"
- [ ] 
- [x] I tested this in my local environment

Requires ushahidi/platform#4452 in the backend

Fixes ushahidi/platform#4453 .

Ping @ushahidi/platform
