### PR TITLE
Fix: Users should be able to see the lock status of a post on the post-edit view

### DIFF
--- a/legacy/app/app.js
+++ b/legacy/app/app.js
@@ -216,6 +216,18 @@ angular
     .factory('FocusTrap', function () {
         return require('focus-trap');
     })
+    .factory('UnifiedScopeForShowingLockInMetadata', function() {
+        let data = {};
+
+        return {
+             getPostFromPostCard: function () {
+                return data;
+            },
+            setPostForShowingLockInAnyView: function (post) {
+                data = post;
+            }
+        };
+    })
     .run([
         '$rootScope',
         'LoadingProgress',

--- a/legacy/app/data/post-detail/post-detail-data.directive.js
+++ b/legacy/app/data/post-detail/post-detail-data.directive.js
@@ -23,7 +23,10 @@ PostDetailDataController.$inject = [
     'PostSurveyService',
     '$state',
     'PostsSdk',
-    'SurveysSdk'
+    'SurveysSdk',
+    'UnifiedScopeForShowingLockInMetadata',
+    'PostLockService',
+    '$stateParams'
 ];
 function PostDetailDataController(
     $scope,
@@ -34,7 +37,10 @@ function PostDetailDataController(
     PostSurveyService,
     $state,
     PostsSdk,
-    SurveysSdk
+    SurveysSdk,
+    UnifiedScopeForShowingLockInMetadata,
+    PostLockService,
+    $stateParams
 ) {
     $scope.$watch('post', function (post, oldVal) {
         if (post !== oldVal) {
@@ -42,6 +48,15 @@ function PostDetailDataController(
         }
     });
 
+    // broadcast is from Post Card directive
+    $scope.$on('postWithLock', function ($event, postFromCard) {
+        if (postFromCard.id === Number($stateParams.postId)) {
+            // Set method to the (post detail) transfer service (on load)
+            UnifiedScopeForShowingLockInMetadata.setPostForShowingLockInAnyView(postFromCard);
+        }
+    });
+
+    $scope.isPostLocked = isPostLocked;
     $scope.post = $scope.post.data.result;
     $scope.canCreatePostInSurvey = PostSurveyService.canCreatePostInSurvey;
     $scope.selectedPost = {post: $scope.post};
@@ -156,4 +171,9 @@ function PostDetailDataController(
         }
         $scope.$parent.deselectPost();
     };
+
+    function isPostLocked() {
+        let postFromPostCard = UnifiedScopeForShowingLockInMetadata.getPostFromPostCard();
+        return PostLockService.isPostLockedForCurrentUser(postFromPostCard);
+    }
 }

--- a/legacy/app/map/post-card/post-card.directive.js
+++ b/legacy/app/map/post-card/post-card.directive.js
@@ -1,7 +1,7 @@
 module.exports = PostCardDirective;
 
-PostCardDirective.$inject = ['PostLockService', '$rootScope'];
-function PostCardDirective(PostLockService, $rootScope) {
+PostCardDirective.$inject = ['PostLockService', '$rootScope', 'UnifiedScopeForShowingLockInMetadata'];
+function PostCardDirective(PostLockService, $rootScope, UnifiedScopeForShowingLockInMetadata) {
     return {
         restrict: 'E',
         replace: true,
@@ -15,6 +15,9 @@ function PostCardDirective(PostLockService, $rootScope) {
         },
         template: require('./card.html'),
         link: function ($scope, $element) {
+            // broadcast $scope.post from post card to be used in post detail data
+            $rootScope.$broadcast('postWithLock', $scope.post);
+
             $scope.isPostLocked = isPostLocked;
             $scope.clickAction = clickAction;
             activate();
@@ -42,6 +45,9 @@ function PostCardDirective(PostLockService, $rootScope) {
                 }
 
                 $scope.externalClickAction($scope.post);
+
+                 // Set method to the (post detail) transfer service (on post card click)
+                UnifiedScopeForShowingLockInMetadata.setPostForShowingLockInAnyView($scope.post);
             }
         }
     };

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -125,7 +125,7 @@
         "ushahidi-platform-sdk": "^0.5.0"
     },
     "engines": {
-        "node": ">=10.0"
+        "node": ">=10.0 <13.0.0"
     },
     "greenkeeper": {
         "ignore": [

--- a/legacy/test/unit/main/post/detail/post-detail-data.directive.spec.js
+++ b/legacy/test/unit/main/post/detail/post-detail-data.directive.spec.js
@@ -29,6 +29,11 @@ describe('Post detail directive', function () {
                 }
             };
         });
+        testApp.service('$stateParams', function () {
+            return {
+                'id': '1'
+            };
+        });
 
         angular.mock.module('testApp');
     });

--- a/legacy/test/unit/make-test-app.js
+++ b/legacy/test/unit/make-test-app.js
@@ -39,6 +39,12 @@ module.exports = function () {
                 };
             }
         })
+        .factory('UnifiedScopeForShowingLockInMetadata', function () {
+            return {
+                getPostFromPostCard: function () {},
+                setPostForShowingLockInAnyView: function () {}
+            };
+        })
         .constant('CONST', {
             BACKEND_URL: backendUrl,
             API_URL: backendUrl + '/api/v2',


### PR DESCRIPTION
#### This pull request makes the following changes
- Fixes ushahidi/platform#4459

#### Testing checklist
- [x] Lock icon now shows up on data view's right side
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
