### PR TITLE
Fix: Filtering by date not working as expected

### DIFF
--- a/legacy/app/common/services/post-filters.service.js
+++ b/legacy/app/common/services/post-filters.service.js
@@ -209,6 +209,13 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
     }
 
     function getQueryParams(filters) {
+        if (filters.date_before instanceof Date) {
+            // filters.date_before to end of day time for filter by date to work properly
+            const value_toEndOfDayTime = new Date(filters.date_before).setHours(23, 59, 59, 999);
+            const value_toEndOfDayTime_toString = new Date(value_toEndOfDayTime).toString();
+            filters.date_before = new Date(value_toEndOfDayTime_toString);
+        }
+
         var defaults = getDefaults();
         var query = _.omit(
             filters,


### PR DESCRIPTION
#### This pull request makes the following changes
- Fixes ushahidi/platform#4461
- [Video on how end date input is using start of day](https://ushahidi.slack.com/archives/CFC4WQG4V/p1660648464559589) instead of end of day

#### Testing checklist
- [x] filtering by date now works correctly, it now returns all posts within a time range (i.e. from start date's beginning of day to end date's end of day) 
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
