### PR TITLE
Fix: Filters are reset when the page is reloaded 

### DIFF
--- a/legacy/app/auth/authentication-events.run.js
+++ b/legacy/app/auth/authentication-events.run.js
@@ -91,6 +91,7 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     }
 
     function doLogin(redirect, noReload) {
+        localStorage.removeItem('ush-filterState-2');
         TermsOfService.getTosEntry()
             .then(function () {
                 loadSessionData();
@@ -121,6 +122,8 @@ function AuthenticationEvents($rootScope, $location, Authentication, Session, _,
     function doLogout() {
         $rootScope.currentUser = null;
         $rootScope.loggedin = false;
+        localStorage.removeItem('ush-filterState');
+        localStorage.removeItem('ush-filterState-2');
         // we don't want to reload until after filters are correctly set with
         // the backend default that the user would get when logged out
         PostFilters.resetDefaults().then(function () {

--- a/legacy/app/common/services/post-filters.service.js
+++ b/legacy/app/common/services/post-filters.service.js
@@ -1,7 +1,7 @@
 module.exports = PostFiltersService;
 
-PostFiltersService.$inject = ['_', 'FormEndpoint', 'TagEndpoint', '$q'];
-function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
+PostFiltersService.$inject = ['_', 'FormEndpoint', 'TagEndpoint', '$q', '$rootScope'];
+function PostFiltersService(_, FormEndpoint, TagEndpoint, $q, $rootScope) {
     // Create initial filter state
     var filterState = window.filterState = getDefaults();
     var forms = [];
@@ -138,6 +138,12 @@ function PostFiltersService(_, FormEndpoint, TagEndpoint, $q) {
 
     // Get filterState
     function getFilters() {
+        if (localStorage.getItem('ush-filterState') !== null && $rootScope.currentUser) {
+            return JSON.parse(localStorage.getItem('ush-filterState'));
+        }
+        if (localStorage.getItem('ush-filterState-2') !== null && !$rootScope.currentUser) {
+            return JSON.parse(localStorage.getItem('ush-filterState-2'));
+        }
         return filterState;
     }
 

--- a/legacy/app/map/post-toolbar/filters/filters-dropdown.directive.js
+++ b/legacy/app/map/post-toolbar/filters/filters-dropdown.directive.js
@@ -73,6 +73,15 @@ function FiltersDropdownController($scope, $state, PostFilters, ModalService, $r
         return 'app.apply_filters';
     };
 
+    $scope.setFiltersToLocalStorage = function () {
+        if ($rootScope.currentUser) {
+            localStorage.setItem('ush-filterState', JSON.stringify($scope.filters));
+        }
+        if (!$rootScope.currentUser) {
+            localStorage.setItem('ush-filterState-2', JSON.stringify($scope.filters));
+        }
+    }
+
     $scope.displayStats = function () {
         return $state.$current.includes['posts.map'];
     };

--- a/legacy/app/map/post-toolbar/filters/filters-dropdown.html
+++ b/legacy/app/map/post-toolbar/filters/filters-dropdown.html
@@ -37,6 +37,6 @@
     <!-- end: filter options -->
     <div class="form-field filter-actions">
         <button type="button" class="button-beta" ng-click="clearFilters()" translate>global_filter.restore_defaults</button>
-        <button type="submit" class="button-alpha" translate>{{getButtonText()}}</button>
+        <button type="submit" class="button-alpha" ng-click="setFiltersToLocalStorage()" translate>{{getButtonText()}}</button>
     </div>
 </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#4469

Testing checklist:
- [x] Filter is retained on page reload (but reset on login or logout)
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
