### PR TITLE
Fix: Filters are reset when the page is reloaded (Part 2: Transitions and logout related issues)

### DIFF
--- a/legacy/app/auth/authentication.service.js
+++ b/legacy/app/auth/authentication.service.js
@@ -140,6 +140,8 @@ function (
             if ($rootScope.hasPermission('Manage Posts')) {
                 PostLockEndpoint.unlock().$promise.finally(function () {
                     continueLogout(silent);
+                }).catch(err => {
+                    // Clean up browser console error display
                 });
             } else {
                 continueLogout(silent);

--- a/legacy/app/data/data-routes.js
+++ b/legacy/app/data/data-routes.js
@@ -35,12 +35,16 @@ function (
                     }
                 }]
             },
-            onEnter: ['$state', 'PostFilters', 'post', function ($state, PostFilters, post) {
+            onEnter: ['$state', 'PostFilters', 'post', '$timeout', function ($state, PostFilters, post, $timeout) {
                 if (!post) {
                     if (PostFilters.getMode() === 'savedsearch') {
-                        $state.go('posts.data.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                        $timeout(() => {
+                            $state.go('posts.data.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                        });
                     } else if (PostFilters.getMode() === 'collection') {
-                        $state.go('posts.data.collection', {collectionId: PostFilters.getModeId()});
+                        $timeout(() => {
+                            $state.go('posts.data.collection', {collectionId: PostFilters.getModeId()});
+                        });
                     }
                 }
             }],

--- a/legacy/app/map/map-routes.js
+++ b/legacy/app/map/map-routes.js
@@ -201,11 +201,15 @@ function (
             views: {
                 'mode-context': 'modeContext'
             },
-            onEnter: ['$state', 'PostFilters', function ($state, PostFilters) {
+            onEnter: ['$state', 'PostFilters', '$timeout', function ($state, PostFilters, $timeout) {
                 if (PostFilters.getMode() === 'savedsearch') {
-                    $state.go('posts.map.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                    $timeout(() => {
+                        $state.go('posts.map.savedsearch', {savedSearchId: PostFilters.getModeId()});
+                    });
                 } else if (PostFilters.getMode() === 'collection') {
-                    $state.go('posts.map.collection', {collectionId: PostFilters.getModeId()});
+                    $timeout(() => {
+                        $state.go('posts.map.collection', {collectionId: PostFilters.getModeId()});
+                    });
                 }
             }]
         }


### PR DESCRIPTION
#### This pull request makes the following changes
- Fixes ushahidi/platform#4469
- To be merged into #1820
- Related pr #1821 

#### Hints on how to reproduce issues fixed in this PR
- Click on the commits in this PR, and remove the fixes added from the code. From the post toolbar, play around with the filters whether logged in or not. Keep the browser console open to see errors displayed.
- In the case of admin, also test with saved searches filter that is only to be accessible to admins (Use this idea to test for collections and other permissions). Still on admin-related saved searches filter, try to navigate to map and data views when logged in and after logging out.

#### Fixes the following errors (after filter reset fix)

Done:
- (Clean up) logout console error when the user is no more logged in
- Saved search transition errors that occur for saved searches (affects saved searches filter that is only to be accessible to users with certain permissions e.g. admin, when accessing saved searches on map and data routes, and on logout) and collection

In progress:
- Saved search transition error part 2 (affects saved searches filter that is only to be accessible to users with certain permissions e.g. admin, and on logout only): Transition rejection - User is not allowed to read resource saved searches
- Collection post returns fix (not confirmed yet)

#### Testing checklist
- [x] Add later
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
