### PR TITLE
Fix: By-the-keystroke geocoding search is too taxing on geocoding services

### DIFF
--- a/legacy/app/data/common/post-edit-create/location.directive.js
+++ b/legacy/app/data/common/post-edit-create/location.directive.js
@@ -188,19 +188,13 @@ function PostLocationDirective($document, $http, L, Geocoding, Maps, _, Notify, 
         }
 
         function handleActiveSearch(event) {
-            var del = event.keyCode === 8 || event.keyCode === 46;
-            var letter = event.keyCode > 47 && event.keyCode < 58;
-            var number = event.keyCode > 64 && event.keyCode < 91;
-            if (del || letter || number) {
+            if (event.keyCode === 13) {
+                event.preventDefault();
                 $scope.processing = true;
                 if ($scope.searchTimeout) {
                     clearTimeout($scope.searchTimeout);
                 }
                 $scope.searchTimeout = setTimeout($scope.searchLocation, 250);
-            }
-            if (event.keyCode === 13) {
-                event.preventDefault();
-                return false;
             }
         }
 


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#4474

Testing checklist:
- [x] Location geocoding search works only on enter key press
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
