### PR TITLE
Fix: Account Settings Icon not visible

### DIFF
--- a/legacy/app/mode-bar/mode-bar.html
+++ b/legacy/app/mode-bar/mode-bar.html
@@ -74,7 +74,7 @@
             </li>
 
             <li ng-show="currentUser">
-                <button ng-click="viewAccountSettings()" data-cy="mb-account-settings-button"
+                <button ng-click="viewAccountSettings()" data-cy="mb-account-settings-button">
                     <img class="avatar" ng-src="https://www.gravatar.com/avatar/{{ currentUser.gravatar || '00000000000000000000000000000000' }}?d=retro" alt="account_settings"/>
                     <span class="label" translate="nav.account_settings">Account Settings</span>
                 </button>


### PR DESCRIPTION
#### This pull request makes the following changes
- Fixes ushahidi/platform#4439

Testing checklist:
- [x] Account settings icon now visible
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
