### PR TITLE
Fix: Text color is not visible for links added to the deployment description (in activity & settings mode-context)

### DIFF
--- a/legacy/app/activity/activity.html
+++ b/legacy/app/activity/activity.html
@@ -27,6 +27,7 @@
             <p
                 ng-if="nav.site.description"
                 markdown-to-html="nav.site.description"
+                class="tool"
             ></p>
         </div>
     </div>

--- a/legacy/app/settings/settings-list.html
+++ b/legacy/app/settings/settings-list.html
@@ -27,6 +27,7 @@
             <p
                 ng-if="nav.site.description"
                 markdown-to-html="nav.site.description"
+                class="tool"
             ></p>
         </div>
     </div>


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes ushahidi/platform#

Testing checklist:
- [x] Site description link color fixed in activiity and settings mode context)
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
